### PR TITLE
Chat fixes, Event broadcasts, Handling quest update packets, new texts, more minor fixes

### DIFF
--- a/playerbot/BotTests.cpp
+++ b/playerbot/BotTests.cpp
@@ -118,7 +118,7 @@ void LogAnalysis::AnalyseEvents()
     eventMin["EquipAction"] = 1;
     eventMin["LeaveGroupAction"] = 1;
     eventMin["QueryItemUsageAction"] = 1;
-    eventMin["QuestObjectiveCompletedAction"] = 1;
+    eventMin["QuestUpdateAddKillAction"] = 1;
     eventMin["ReviveFromCorpseAction"] = 1;
     eventMin["StoreLootAction"] = 1;
     eventMin["SellAction"] = 1;
@@ -184,17 +184,17 @@ void LogAnalysis::AnalyseQuests()
 
         Tokens tokens = StrSplit(line, ",");
 
-        if (tokens.size() == 10) //Some quest names have a "," so add an extra element. 
+        if (tokens.size() == 10) //Some quest names have a "," so add an extra element.
         {
             tokens[7] = tokens[7] + tokens[8];
             tokens[8] = tokens[9];
-        } 
+        }
         else if (tokens.size() == 11)
         {
             tokens[7] = tokens[7] + tokens[8] + tokens[9];
             tokens[8] = tokens[10];
         }
-        
+
 
         for(auto& token : tokens)
             token.erase(std::remove(token.begin(), token.end(), '\"'), token.end());
@@ -204,7 +204,7 @@ void LogAnalysis::AnalyseQuests()
             questId[tokens[7]] = stoi(tokens[8]);
             questStartCount[tokens[7]]++;
         }
-        else if (tokens[2] == "QueryItemUsageAction" || tokens[3] == "QuestObjectiveCompletedAction")
+        else if (tokens[2] == "QueryItemUsageAction" || tokens[3] == "QuestUpdateAddKillAction")
         {
             questId[tokens[7]] = questId[tokens[7]];
             questObjective[tokens[7]]++;

--- a/playerbot/BroadcastHelper.cpp
+++ b/playerbot/BroadcastHelper.cpp
@@ -1,0 +1,894 @@
+
+#include "playerbot/playerbot.h"
+#include "BroadcastHelper.h"
+#include "playerbot/ServerFacade.h"
+#include "playerbot/AiFactory.h"
+#include "Chat/Channel.h"
+
+using namespace ai;
+
+BroadcastHelper::BroadcastHelper() {}
+
+uint8 BroadcastHelper::GetLocale()
+{
+    uint8 locale = sConfig.GetIntDefault("DBC.Locale", 0 /*LocaleConstant::LOCALE_enUS*/);
+    // -- In case we're using auto detect on config file^M
+    if (locale >= MAX_LOCALE)
+        locale = LocaleConstant::LOCALE_enUS;
+    return locale;
+}
+
+bool BroadcastHelper::BroadcastTest(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    //return something to ignore the logic
+    return false;
+
+    //don't think bots rejoin channnels when changing areas?
+    //bot->GetPlayerbotMgr()->JoinChatChannels(bot);
+
+    std::map<std::string, std::string> placeholders;
+    placeholders["%rand1"] = std::to_string(urand(0, 1));
+    placeholders["%rand2"] = std::to_string(urand(0, 1));
+    placeholders["%rand3"] = std::to_string(urand(0, 1));
+
+    int32 rand = urand(0, 1);
+
+    if (rand == 1 && ai->SayToTrade(BOT_TEXT2("Posted to trade, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (ai->SayToGuildRecruitment(BOT_TEXT2("Posted to GuildRecruitment, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+
+    return ai->SayToTrade(BOT_TEXT2("Posted to trade, %rand1, %rand2, %rand3", placeholders));
+
+    //int32 rand = urand(1, 8);
+    if (rand == 1 && ai->SayToGuild(BOT_TEXT2("Posted to guild, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 2 && ai->SayToWorld(BOT_TEXT2("Posted to world, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 3 && ai->SayToGeneral(BOT_TEXT2("Posted to general, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 4 && ai->SayToTrade(BOT_TEXT2("Posted to trade, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 5 && ai->SayToLFG(BOT_TEXT2("Posted to LFG, %rand1, %rand2, %rand3", placeholders)))//
+        return true;
+    else if (rand == 6 && ai->SayToLocalDefense(BOT_TEXT2("Posted to LocalDefense, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 7 && ai->SayToWorldDefense(BOT_TEXT2("Posted to WorldDefense, %rand1, %rand2, %rand3", placeholders)))//+
+        return true;
+    else if (rand == 8 && ai->SayToGuildRecruitment(BOT_TEXT2("Posted to GuildRecruitment, %rand1, %rand2, %rand3", placeholders)))//
+        return true;
+
+    return false;
+}
+
+/**
+@param toChannels - map of (ToChannel, chance), where chance is in range 0-100 as uint32 (unless global chance is not 100%)
+
+@return true if said to the channel, false otherwise
+*/
+bool BroadcastHelper::BroadcastToChannelWithGlobalChance(PlayerbotAI* ai, std::string message, std::list<std::pair<ToChannel, uint32>> toChannels)
+{
+    if (message.empty())
+    {
+        return false;
+    }
+
+    for (const auto& pair : toChannels) {
+        uint32 roll = urand(1, 100);
+        uint32 chance = pair.second;
+        uint32 broadcastRoll = urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue);
+
+        switch (pair.first)
+        {
+            case TO_GUILD:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToGuildGlobalChance
+                    && ai->SayToGuild(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_WORLD:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToWorldGlobalChance
+                    && ai->SayToWorld(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_GENERAL:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToGeneralGlobalChance
+                    && ai->SayToGeneral(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_TRADE:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToTradeGlobalChance
+                    && ai->SayToTrade(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_LOOKING_FOR_GROUP:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToLFGGlobalChance
+                    && ai->SayToLFG(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_LOCAL_DEFENSE:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToLocalDefenseGlobalChance
+                    && ai->SayToLocalDefense(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_WORLD_DEFENSE:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToWorldDefenseGlobalChance
+                    && ai->SayToWorldDefense(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            case TO_GUILD_RECRUITMENT:
+            {
+                if (roll <= chance
+                    && broadcastRoll <= sPlayerbotAIConfig.broadcastToGuildRecruitmentGlobalChance
+                    && ai->SayToGuildRecruitment(message))
+                {
+                    return true;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastLootingItem(
+    PlayerbotAI* ai,
+    Player* bot,
+    const ItemPrototype *proto,
+    ItemQualifier& itemQualifier
+    )
+{
+    std::map<std::string, std::string> placeholders;
+    placeholders["%item_link"] = ai->GetChatHelper()->formatItem(itemQualifier);
+    AreaTableEntry const* current_area = ai->GetCurrentArea();
+    AreaTableEntry const* current_zone = ai->GetCurrentZone();
+    placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+    placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+    placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+    placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+    placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+    switch (proto->Quality)
+    {
+        case ITEM_QUALITY_POOR:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemPoor)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_poor", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_NORMAL:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemNormal)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_normal", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_UNCOMMON:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemUncommon)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_uncommon", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_RARE:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemRare)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_rare", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_EPIC:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemEpic)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_epic", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_LEGENDARY:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemLegendary)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_legendary", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case ITEM_QUALITY_ARTIFACT:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLootingItemArtifact)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_looting_item_artifact", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        default:
+            break;
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastQuestAccepted(
+    PlayerbotAI* ai,
+    Player* bot,
+    const Quest* quest
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceQuestAcceptedGeneric)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(quest);
+        AreaTableEntry const* current_area = ai->GetCurrentArea();
+        AreaTableEntry const* current_zone = ai->GetCurrentZone();
+        placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+        placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_quest_accepted_generic", placeholders),
+            { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastQuestObjectiveProgress(
+    PlayerbotAI* ai,
+    Player* bot,
+    Quest const* quest,
+    uint32 available,
+    uint32 required,
+    std::string obectiveName
+)
+{
+    std::map<std::string, std::string> placeholders;
+    AreaTableEntry const* current_area = ai->GetCurrentArea();
+    AreaTableEntry const* current_zone = ai->GetCurrentZone();
+    placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+    placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+    placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(quest);
+    placeholders["%quest_obj_name"] = obectiveName;
+    placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+    placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+    placeholders["%my_level"] = std::to_string(bot->GetLevel());
+    placeholders["%quest_obj_available"] = std::to_string(available);
+    placeholders["%quest_obj_required"] = std::to_string(required);
+    placeholders["%quest_obj_missing"] = std::to_string(required - available);
+    placeholders["%quest_obj_full_formatted"] = ai->GetChatHelper()->formatQuestObjective(obectiveName, available, required);
+
+    if (available < required
+        && urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceQuestObjectiveProgressGeneric)
+    {
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_quest_objective_progress_generic", placeholders),
+            { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+    else if (available >= required
+        && urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceQuestObjectiveCompletedGeneric)
+    {
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_quest_objective_completed_generic", placeholders),
+            { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastQuestCompleted(
+    PlayerbotAI* ai,
+    Player* bot,
+    Quest const* quest
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceQuestCompletedGeneric)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(quest);
+        AreaTableEntry const* current_area = ai->GetCurrentArea();
+        AreaTableEntry const* current_zone = ai->GetCurrentZone();
+        placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+        placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_quest_completed_generic", placeholders),
+            { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastKill(
+    PlayerbotAI* ai,
+    Player* bot,
+    Creature *creature
+)
+{
+    std::map<std::string, std::string> placeholders;
+    placeholders["%victim_name"] = creature->GetName();
+    AreaTableEntry const* current_area = ai->GetCurrentArea();
+    AreaTableEntry const* current_zone = ai->GetCurrentZone();
+    placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+    placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+    placeholders["%victim_level"] = creature->GetLevel();
+    placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+    placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+    placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+    //if ((creature->IsElite() && !creature->GetMap()->IsDungeon())
+    //if creature->IsWorldBoss()
+    //if creature->GetLevel() > DEFAULT_MAX_LEVEL + 1
+    //if creature->GetLevel() > bot->GetLevel() + 4
+
+    if (creature->IsPet())
+    {
+        if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillPet)
+        {
+            return BroadcastToChannelWithGlobalChance(
+                ai,
+                BOT_TEXT2("broadcast_killed_pet", placeholders),
+                { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+            );
+        }
+    }
+    else if (creature->IsPlayer())
+    {
+        if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillPlayer)
+        {
+            placeholders["%victim_class"] = ai->GetChatHelper()->formatClass(creature->getClass());
+
+            return BroadcastToChannelWithGlobalChance(
+                ai,
+                BOT_TEXT2("broadcast_killed_player", placeholders),
+                { {TO_WORLD_DEFENSE, 50}, {TO_LOCAL_DEFENSE, 50}, {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+            );
+        }
+    }
+    else
+    {
+        switch (creature->GetCreatureInfo()->Rank)
+        {
+        case CREATURE_ELITE_NORMAL:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillNormal)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_normal", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case CREATURE_ELITE_ELITE:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillElite)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_elite", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case CREATURE_ELITE_RAREELITE:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillRareelite)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_rareelite", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case CREATURE_ELITE_WORLDBOSS:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillWorldboss)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_worldboss", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case CREATURE_ELITE_RARE:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillRare)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_rare", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        case CREATURE_UNKNOWN:
+            if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceKillUnknown)
+            {
+                return BroadcastToChannelWithGlobalChance(
+                    ai,
+                    BOT_TEXT2("broadcast_killed_unknown", placeholders),
+                    { {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+                );
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastLevelup(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    uint32 level = bot->GetLevel();
+
+    std::map<std::string, std::string> placeholders;
+    AreaTableEntry const* current_area = ai->GetCurrentArea();
+    AreaTableEntry const* current_zone = ai->GetCurrentZone();
+    placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+    placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+    placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+    placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+    placeholders["%my_level"] = std::to_string(level);
+
+    if (level == sPlayerbotAIConfig.randomBotMaxLevel
+        && urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLevelupMaxLevel)
+    {
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_levelup_max_level", placeholders),
+            { {TO_GUILD, 30}, {TO_WORLD, 90}, {TO_GENERAL, 100} }
+        );
+    }
+    // It's divisible by 10
+    else if (level % 10 == 0
+        && urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLevelupTenX)
+    {
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_levelup_10x", placeholders),
+            { {TO_GUILD, 50}, {TO_WORLD, 90}, {TO_GENERAL, 100} }
+        );
+    }
+    else if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceLevelupGeneric)
+    {
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("broadcast_levelup_generic", placeholders),
+            { {TO_GUILD, 90}, {TO_WORLD, 90}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastGuildMemberPromotion(
+    PlayerbotAI* ai,
+    Player* bot,
+    Player* player
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceGuildManagement)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%other_name"] = player->GetName();
+        placeholders["%other_class"] = ai->GetChatHelper()->formatClass(player->getClass());
+        placeholders["%other_race"] = ai->GetChatHelper()->formatRace(player->getRace());
+        placeholders["%other_level"] = std::to_string(player->GetLevel());
+
+        return ai->SayToGuild(BOT_TEXT2("broadcast_guild_promotion", placeholders));
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastGuildMemberDemotion(
+    PlayerbotAI* ai,
+    Player* bot,
+    Player* player
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceGuildManagement)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%other_name"] = player->GetName();
+        placeholders["%other_class"] = ai->GetChatHelper()->formatClass(player->getClass());
+        placeholders["%other_race"] = ai->GetChatHelper()->formatRace(player->getRace());
+        placeholders["%other_level"] = std::to_string(player->GetLevel());
+
+        return ai->SayToGuild(BOT_TEXT2("broadcast_guild_demotion", placeholders));
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastGuildGroupOrRaidInvite(
+    PlayerbotAI* ai,
+    Player* bot,
+    Player* player,
+    Group* group,
+    Guild* guild
+)
+{
+    std::map<std::string, std::string> placeholders;
+    placeholders["%name"] = player->GetName();
+    AreaTableEntry const* current_area = ai->GetCurrentArea();
+    AreaTableEntry const* current_zone = ai->GetCurrentZone();
+    placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+    placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+
+    //TODO move texts to sql!
+    if (group && group->IsRaidGroup())
+    {
+        if (urand(0, 3))
+        {
+            return ai->SayToGuild(BOT_TEXT2("Hey anyone want to raid in %zone_name", placeholders));
+        }
+        else
+        {
+            return ai->SayToGuild(BOT_TEXT2("Hey %name I'm raiding in %zone_name do you wan to join me?", placeholders));
+        }
+    }
+    else
+    {
+        //(bot->GetTeam() == ALLIANCE ? LANG_COMMON : LANG_ORCISH)
+        if (urand(0, 3))
+        {
+            return ai->SayToGuild(BOT_TEXT2("Hey anyone wanna group up in %zone_name?", placeholders));
+        }
+        else
+        {
+            return ai->SayToGuild(BOT_TEXT2("Hey %name do you want join my group? I'm heading for %zone_name", placeholders));
+        }
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestInstance(
+    PlayerbotAI* ai,
+    std::vector<std::string>& allowedInstances,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestInstance)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+
+        std::ostringstream itemout;
+        //itemout << "|c00b000b0" << allowedInstances[urand(0, allowedInstances.size() - 1)] << "|r";
+        itemout << allowedInstances[urand(0, allowedInstances.size() - 1)];
+        placeholders["%instance_name"] = itemout.str();
+
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_instance", placeholders),
+            { {TO_LOOKING_FOR_GROUP, 50}, {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestQuest(
+    PlayerbotAI* ai,
+    std::vector<uint32>& quests,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestQuest)
+    {
+
+        int index = rand() % quests.size();
+
+        Quest const* quest = sObjectMgr.GetQuestTemplate(quests[index]);
+
+        std::map<std::string, std::string> placeholders;
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+        placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(quest);
+        placeholders["%quest_level"] = std::to_string(quest->GetQuestLevel());
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_quest", placeholders),
+            { {TO_LOOKING_FOR_GROUP, 50}, {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestGrindMaterials(
+    PlayerbotAI* ai,
+    std::string item,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestGrindMaterials)
+    {
+
+        std::map<std::string, std::string> placeholders;
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+        placeholders["%category"] = item;
+
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_trade", placeholders),
+            { {TO_TRADE, 50}, {TO_LOOKING_FOR_GROUP, 50}, {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestGrindReputation(
+    PlayerbotAI* ai,
+    std::vector<std::string> levels,
+    std::vector<std::string> allowedFactions,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestGrindReputation)
+    {
+
+        std::map<std::string, std::string> placeholders;
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+        placeholders["%rep_level"] = levels[urand(0, 2)];
+        std::ostringstream rnd; rnd << urand(1, 5) << "K";
+        placeholders["%rndK"] = rnd.str();
+
+        std::ostringstream itemout;
+        //itemout << "|c004040b0" << allowedFactions[urand(0, allowedFactions.size() - 1)] << "|r";
+        itemout << allowedFactions[urand(0, allowedFactions.size() - 1)];
+        placeholders["%faction"] = itemout.str();
+
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_faction", placeholders),
+            { {TO_LOOKING_FOR_GROUP, 50}, {TO_GUILD, 50}, {TO_WORLD, 50}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestSell(
+    PlayerbotAI* ai,
+    const ItemPrototype* proto,
+    uint32 count,
+    uint32 price,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestSell)
+    {
+
+        std::map<std::string, std::string> placeholders;
+        placeholders["%item_link"] = ai->GetChatHelper()->formatItem(proto, 0);
+        placeholders["%item_formatted_link"] = ai->GetChatHelper()->formatItem(proto, count);
+        placeholders["%item_count"] = std::to_string(count);
+        placeholders["%cost_gold"] = ai->GetChatHelper()->formatMoney(price);
+
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_sell", placeholders),
+            { {TO_TRADE, 90}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestSomething(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestSomething)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+
+        AreaTableEntry const* current_area = ai->GetCurrentArea();
+        AreaTableEntry const* current_zone = ai->GetCurrentZone();
+        placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+        placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_something", placeholders),
+            { {TO_GUILD, 10}, {TO_WORLD, 70}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestSomethingToxic(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestSomethingToxic)
+    {
+        //items
+        std::vector<Item*> botItems;
+        ai->GetInventoryAndEquippedItems(botItems);
+
+        std::map<std::string, std::string> placeholders;
+
+        placeholders["%random_inventory_item_link"] = botItems.size() > 0 ? ai->GetChatHelper()->formatItem(botItems[rand() % botItems.size()]) : BOT_TEXT("string_empty_link");
+
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+        AreaTableEntry const* current_area = ai->GetCurrentArea();
+        AreaTableEntry const* current_zone = ai->GetCurrentZone();
+        placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+        placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_something_toxic", placeholders),
+            { {TO_GUILD, 10}, {TO_WORLD, 70}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestToxicLinks(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestToxicLinks)
+    {
+        //quests
+        std::vector<uint32> incompleteQuests;
+        for (uint16 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
+        {
+            uint32 questId = bot->GetQuestSlotQuestId(slot);
+            if (!questId)
+                continue;
+
+            QuestStatus status = bot->GetQuestStatus(questId);
+            if (status == QUEST_STATUS_INCOMPLETE || status == QUEST_STATUS_NONE)
+                incompleteQuests.push_back(questId);
+        }
+
+        //items
+        std::vector<Item*> botItems;
+        ai->GetInventoryAndEquippedItems(botItems);
+
+        //spells
+        //?
+
+        std::map<std::string, std::string> placeholders;
+
+        placeholders["%random_inventory_item_link"] = botItems.size() > 0 ? ai->GetChatHelper()->formatItem(botItems[rand() % botItems.size()]) : BOT_TEXT("string_empty_link");
+
+        if (incompleteQuests.size() > 0)
+        {
+            Quest const* quest = sObjectMgr.GetQuestTemplate(incompleteQuests[rand() % incompleteQuests.size()]);
+            placeholders["%random_taken_quest_or_item_link"] = ai->GetChatHelper()->formatQuest(quest);
+        }
+        else
+        {
+            placeholders["%random_taken_quest_or_item_link"] = placeholders["%random_inventory_item_link"];
+        }
+
+        placeholders["%my_role"] = ai->GetChatHelper()->formatClass(bot, AiFactory::GetPlayerSpecTab(bot));
+        AreaTableEntry const* current_area = ai->GetCurrentArea();
+        AreaTableEntry const* current_zone = ai->GetCurrentZone();
+        placeholders["%area_name"] = current_area ? ai->GetLocalizedAreaName(current_area) : BOT_TEXT("string_unknown_area");
+        placeholders["%zone_name"] = current_zone ? ai->GetLocalizedAreaName(current_zone) : BOT_TEXT("string_unknown_area");
+        placeholders["%my_class"] = ai->GetChatHelper()->formatClass(bot->getClass());
+        placeholders["%my_race"] = ai->GetChatHelper()->formatRace(bot->getRace());
+        placeholders["%my_level"] = std::to_string(bot->GetLevel());
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("suggest_toxic_links", placeholders),
+            { {TO_GUILD, 10}, {TO_WORLD, 70}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}

--- a/playerbot/BroadcastHelper.cpp
+++ b/playerbot/BroadcastHelper.cpp
@@ -965,6 +965,7 @@ bool BroadcastHelper::BroadcastSuggestToxicLinks(
         std::map<std::string, std::string> placeholders;
 
         placeholders["%random_inventory_item_link"] = botItems.size() > 0 ? ai->GetChatHelper()->formatItem(botItems[rand() % botItems.size()]) : BOT_TEXT("string_empty_link");
+        placeholders["%prefix"] = sPlayerbotAIConfig.toxicLinksPrefix;
 
         if (incompleteQuests.size() > 0)
         {
@@ -989,6 +990,28 @@ bool BroadcastHelper::BroadcastSuggestToxicLinks(
             ai,
             BOT_TEXT2("suggest_toxic_links", placeholders),
             { {TO_GUILD, 10}, {TO_WORLD, 70}, {TO_GENERAL, 100} }
+        );
+    }
+
+    return false;
+}
+
+bool BroadcastHelper::BroadcastSuggestThunderfury(
+    PlayerbotAI* ai,
+    Player* bot
+)
+{
+    if (urand(1, sPlayerbotAIConfig.broadcastChanceMaxValue) <= sPlayerbotAIConfig.broadcastChanceSuggestThunderfury)
+    {
+
+        std::map<std::string, std::string> placeholders;
+        ItemPrototype const* thunderfuryProto = sObjectMgr.GetItemPrototype(19019);
+        placeholders["%thunderfury_link"] = bot->GetPlayerbotAI()->GetChatHelper()->formatItem(thunderfuryProto);
+
+        return BroadcastToChannelWithGlobalChance(
+            ai,
+            BOT_TEXT2("thunderfury_spam", placeholders),
+            { {TO_WORLD, 70}, {TO_GENERAL, 100} }
         );
     }
 

--- a/playerbot/BroadcastHelper.h
+++ b/playerbot/BroadcastHelper.h
@@ -42,15 +42,33 @@ namespace ai
             Player* bot,
             const Quest* quest
         );
-        static bool BroadcastQuestObjectiveProgress(
+        static bool BroadcastQuestUpdateAddKill(
             PlayerbotAI* ai,
             Player* bot,
             Quest const* quest,
-            uint32 available,
-            uint32 required,
+            uint32 availableCount,
+            uint32 requiredCount,
             std::string obectiveName
         );
-        static bool BroadcastQuestCompleted(
+        static bool BroadcastQuestUpdateAddItem(
+            PlayerbotAI* ai,
+            Player* bot,
+            Quest const* quest,
+            uint32 availableCount,
+            uint32 requiredCount,
+            const ItemPrototype* proto
+        );
+        static bool BroadcastQuestUpdateFailedTimer(
+            PlayerbotAI* ai,
+            Player* bot,
+            Quest const* quest
+        );
+        static bool BroadcastQuestUpdateComplete(
+            PlayerbotAI* ai,
+            Player* bot,
+            Quest const* quest
+        );
+        static bool BroadcastQuestTurnedIn(
             PlayerbotAI* ai,
             Player* bot,
             Quest const* quest

--- a/playerbot/BroadcastHelper.h
+++ b/playerbot/BroadcastHelper.h
@@ -139,6 +139,10 @@ namespace ai
             PlayerbotAI* ai,
             Player* bot
         );
+        static bool BroadcastSuggestThunderfury(
+            PlayerbotAI* ai,
+            Player* bot
+        );
     };
 
 

--- a/playerbot/BroadcastHelper.h
+++ b/playerbot/BroadcastHelper.h
@@ -1,0 +1,127 @@
+#pragma once
+
+namespace ai
+{
+
+    class BroadcastHelper
+    {
+    public:
+        BroadcastHelper();
+
+    public:
+        enum ToChannel
+        {
+            TO_GUILD = 1,
+            TO_WORLD = 2,
+            TO_GENERAL = 3,
+            TO_TRADE = 4,
+            TO_LOOKING_FOR_GROUP = 5,
+            TO_LOCAL_DEFENSE = 6,
+            TO_WORLD_DEFENSE = 7,
+            TO_GUILD_RECRUITMENT = 8
+        };
+
+        static uint8 GetLocale();
+        static bool BroadcastTest(
+            PlayerbotAI* ai,
+            Player* bot
+        );
+        static bool BroadcastToChannelWithGlobalChance(
+            PlayerbotAI* ai,
+            std::string message,
+            std::list<std::pair<ToChannel, uint32>> toChannels
+        );
+        static bool BroadcastLootingItem(
+            PlayerbotAI* ai,
+            Player* bot,
+            const ItemPrototype* proto,
+            ItemQualifier& itemQualifier
+        );
+        static bool BroadcastQuestAccepted(
+            PlayerbotAI* ai,
+            Player* bot,
+            const Quest* quest
+        );
+        static bool BroadcastQuestObjectiveProgress(
+            PlayerbotAI* ai,
+            Player* bot,
+            Quest const* quest,
+            uint32 available,
+            uint32 required,
+            std::string obectiveName
+        );
+        static bool BroadcastQuestCompleted(
+            PlayerbotAI* ai,
+            Player* bot,
+            Quest const* quest
+        );
+        static bool BroadcastKill(
+            PlayerbotAI* ai,
+            Player* bot,
+            Creature* creature
+        );
+        static bool BroadcastLevelup(
+            PlayerbotAI* ai,
+            Player* bot
+        );
+        static bool BroadcastGuildMemberPromotion(
+            PlayerbotAI* ai,
+            Player* bot,
+            Player* player
+        );
+        static bool BroadcastGuildMemberDemotion(
+            PlayerbotAI* ai,
+            Player* bot,
+            Player* player
+        );
+        static bool BroadcastGuildGroupOrRaidInvite(
+            PlayerbotAI* ai,
+            Player* bot,
+            Player* player,
+            Group* group,
+            Guild* guild
+        );
+        static bool BroadcastSuggestInstance(
+            PlayerbotAI* ai,
+            std::vector<std::string>& allowedInstances,
+            Player* bot
+        );
+        static bool BroadcastSuggestQuest(
+            PlayerbotAI* ai,
+            std::vector<uint32>& quests,
+            Player* bot
+        );
+        static bool BroadcastSuggestGrindMaterials(
+            PlayerbotAI* ai,
+            std::string item,
+            Player* bot
+        );
+        static bool BroadcastSuggestGrindReputation(
+            PlayerbotAI* ai,
+            std::vector<std::string> levels,
+            std::vector<std::string> allowedFactions,
+            Player* bot
+        );
+        static bool BroadcastSuggestSell(
+            PlayerbotAI* ai,
+            const ItemPrototype* proto,
+            uint32 count,
+            uint32 price,
+            Player* bot
+        );
+        static bool BroadcastSuggestSomething(
+            PlayerbotAI* ai,
+            Player* bot
+        );
+        static bool BroadcastSuggestSomethingToxic(
+            PlayerbotAI* ai,
+            Player* bot
+        );
+        static bool BroadcastSuggestToxicLinks(
+            PlayerbotAI* ai,
+            Player* bot
+        );
+    };
+
+
+};

--- a/playerbot/ChatHelper.cpp
+++ b/playerbot/ChatHelper.cpp
@@ -5,6 +5,7 @@
 #include "strategy/values/ItemUsageValue.h"
 #include <numeric>
 #include <iomanip>
+#include <regex>
 
 using namespace ai;
 
@@ -280,6 +281,38 @@ uint32 ChatHelper::parseMoney(const std::string& text)
         }
     }
     return copper;
+}
+
+std::set<uint32> ChatHelper::ExtractAllQuestIds(const std::string& text)
+{
+    std::set<uint32> ids;
+
+    std::regex rgx("Hquest:[0-9]+");
+    auto begin = std::sregex_iterator(text.begin(), text.end(), rgx);
+    auto end = std::sregex_iterator();
+    for (std::sregex_iterator i = begin; i != end; ++i)
+    {
+        std::smatch match = *i;
+        ids.insert(std::stoi(match.str().erase(0, 7)));
+    }
+
+    return ids;
+}
+
+std::set<uint32> ChatHelper::ExtractAllItemIds(const std::string& text)
+{
+    std::set<uint32> ids;
+
+    std::regex rgx("Hitem:[0-9]+");
+    auto begin = std::sregex_iterator(text.begin(), text.end(), rgx);
+    auto end = std::sregex_iterator();
+    for (std::sregex_iterator i = begin; i != end; ++i)
+    {
+        std::smatch match = *i;
+        ids.insert(std::stoi(match.str().erase(0, 6)));
+    }
+
+    return ids;
 }
 
 ItemIds ChatHelper::parseItems(const std::string& text, bool validate)

--- a/playerbot/ChatHelper.h
+++ b/playerbot/ChatHelper.h
@@ -24,6 +24,9 @@ namespace ai
         static std::string formatMoney(uint32 copper);
         static uint32 parseMoney(const std::string& text);
 
+        static std::set<uint32> ExtractAllQuestIds(const std::string& text);
+        static std::set<uint32> ExtractAllItemIds(const std::string& text);
+
         static std::string formatQuest(Quest const* quest);
 
         static std::string formatItem(ItemQualifier& itemQualifier, int count = 0, int total = 0);

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -2857,6 +2857,92 @@ bool PlayerbotAI::SayToGuildRecruitment(std::string msg)
 #endif
 }
 
+bool PlayerbotAI::SayToParty(std::string msg)
+{
+    if (!bot->GetGroup())
+    {
+        return false;
+    }
+
+    WorldPacket data;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_PARTY, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetObjectGuid(), bot->GetName());
+
+    for (auto reciever : GetPlayersInGroup())
+    {
+        sServerFacade.SendPacket(reciever, data);
+    }
+
+    return true;
+}
+
+bool PlayerbotAI::SayToRaid(std::string msg)
+{
+    if (!bot->GetGroup() || bot->GetGroup()->IsRaidGroup())
+    {
+        return false;
+    }
+
+    WorldPacket data;
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetObjectGuid(), bot->GetName());
+
+    for (auto reciever : GetPlayersInGroup())
+    {
+        sServerFacade.SendPacket(reciever, data);
+    }
+
+    return true;
+}
+
+bool PlayerbotAI::Yell(std::string msg)
+{
+    if (bot->GetTeam() == ALLIANCE)
+    {
+        bot->Yell(msg, LANG_COMMON);
+    }
+    else
+    {
+        bot->Yell(msg, LANG_ORCISH);
+    }
+
+    return true;
+}
+
+bool PlayerbotAI::Say(std::string msg)
+{
+    if (bot->GetTeam() == ALLIANCE)
+    {
+        bot->Say(msg, LANG_COMMON);
+    }
+    else
+    {
+        bot->Say(msg, LANG_ORCISH);
+    }
+
+    return true;
+}
+
+bool PlayerbotAI::Whisper(std::string msg, std::string receiverName)
+{
+    ObjectGuid receiver = sObjectMgr.GetPlayerGuidByName(receiverName);
+    Player* rPlayer = sObjectMgr.GetPlayer(receiver);
+
+    if (!rPlayer)
+    {
+        return false;
+    }
+
+    if (bot->GetTeam() == ALLIANCE)
+    {
+        bot->Whisper(msg, LANG_COMMON, receiver);
+    }
+    else
+    {
+        bot->Whisper(msg, LANG_ORCISH, receiver);
+    }
+
+    return true;
+}
+
 bool PlayerbotAI::TellPlayerNoFacing(Player* player, std::string text, PlayerbotSecurityLevel securityLevel, bool isPrivate, bool noRepeat, bool ignoreSilent)
 {
     if(!player)

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -1602,13 +1602,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
                 if (lang == LANG_ADDON)
                     return;
 
-                if ((boost::algorithm::istarts_with(message, "LFG") || boost::algorithm::istarts_with(message, "LFM"))
-                    && GetChatHelper()->ExtractAllQuestIds(message).size() > 0)
-                {
-                    if (isFromFreeBot && urand(0, 20))
-                        return;
-                }
-                else if (boost::algorithm::istarts_with(message, sPlayerbotAIConfig.toxicLinksPrefix)
+                if (boost::algorithm::istarts_with(message, sPlayerbotAIConfig.toxicLinksPrefix)
                     && (GetChatHelper()->ExtractAllItemIds(message).size() > 0 || GetChatHelper()->ExtractAllQuestIds(message).size() > 0)
                     && sPlayerbotAIConfig.toxicLinksRepliesChance)
                 {

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -82,6 +82,29 @@ enum ChatChannelId
     GUILD_RECRUITMENT = 25,
 };
 
+enum ChatChannelSource
+{
+    SRC_GUILD,
+    SRC_WORLD,
+    SRC_GENERAL,
+    SRC_TRADE,
+    SRC_LOOKING_FOR_GROUP,
+    SRC_LOCAL_DEFENSE,
+    SRC_WORLD_DEFENSE,
+    SRC_GUILD_RECRUITMENT,
+
+    SRC_SAY,
+    SRC_WHISPER,
+    SRC_EMOTE,
+    SRC_TEXT_EMOTE,
+    SRC_YELL,
+
+    SRC_PARTY,
+    SRC_RAID,
+
+    SRC_UNDEFINED
+};
+
 enum HealingItemDisplayId
 {
    HEALTHSTONE_DISPLAYID = 8026,
@@ -323,7 +346,7 @@ public:
     static std::string BotStateToString(BotState state);
 	std::string HandleRemoteCommand(std::string command);
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
-    void QueueChatResponse(uint8 msgtype, ObjectGuid guid1, ObjectGuid guid2, std::string message, std::string chanName, std::string name);
+    void QueueChatResponse(uint32 msgType, ObjectGuid guid1, ObjectGuid guid2, std::string message, std::string chanName, std::string name);
 	void HandleBotOutgoingPacket(const WorldPacket& packet);
     void HandleMasterIncomingPacket(const WorldPacket& packet);
     void HandleMasterOutgoingPacket(const WorldPacket& packet);
@@ -357,11 +380,16 @@ public:
     void DropQuest(uint32 questId);
     std::vector<const Quest*> GetAllCurrentQuests();
     std::vector<const Quest*> GetCurrentIncompleteQuests();
+    std::set<uint32> GetAllCurrentQuestIds();
+    std::set<uint32> GetCurrentIncompleteQuestIds();
+    const Quest* GetCurrentIncompleteQuestWithId(uint32 questId);
+    bool HasCurrentIncompleteQuestWithId(uint32 questId);
     std::vector<std::pair<const Quest*, uint32>> GetCurrentQuestsRequiringItemId(uint32 itemId);
     const AreaTableEntry* GetCurrentArea();
     const AreaTableEntry* GetCurrentZone();
     std::string GetLocalizedAreaName(const AreaTableEntry* entry);
     bool IsInCapitalCity();
+    ChatChannelSource GetChatChannelSource(Player* bot, uint32 type, std::string channelName);
     bool SayToGuild(std::string msg);
     bool SayToWorld(std::string msg);
     bool SayToGeneral(std::string msg);
@@ -483,6 +511,7 @@ public:
     std::vector<Item*> GetInventoryAndEquippedItems();
     std::vector<Item*> GetInventoryItems();
     uint32 GetInventoryItemsCountWithId(uint32 itemId);
+    bool HasItemInInventory(uint32 itemId);
 
 private:
     void InventoryIterateItemsInBags(IterateItemsVisitor* visitor);

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -354,6 +354,10 @@ public:
     static GameObject* GetGameObject(GameObjectDataPair const* gameObjectDataPair);
     WorldObject* GetWorldObject(ObjectGuid guid);
     std::vector<Player*> GetPlayersInGroup();
+    void DropQuest(uint32 questId);
+    std::vector<const Quest*> GetAllCurrentQuests();
+    std::vector<const Quest*> GetCurrentIncompleteQuests();
+    std::vector<std::pair<const Quest*, uint32>> GetCurrentQuestsRequiringItemId(uint32 itemId);
     const AreaTableEntry* GetCurrentArea();
     const AreaTableEntry* GetCurrentZone();
     std::string GetLocalizedAreaName(const AreaTableEntry* entry);
@@ -471,7 +475,9 @@ public:
     void AccelerateRespawn(ObjectGuid guid, float accelMod = 0) { Creature* creature = GetCreature(guid); if (creature) AccelerateRespawn(creature,accelMod); }
 
 public:
-    void GetInventoryAndEquippedItems(std::vector<Item*>& items);
+    std::vector<Item*> GetInventoryAndEquippedItems();
+    std::vector<Item*> GetInventoryItems();
+    uint32 GetInventoryItemsCountWithId(uint32 itemId);
 
 private:
     void InventoryIterateItemsInBags(IterateItemsVisitor* visitor);

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -370,6 +370,11 @@ public:
     bool SayToLocalDefense(std::string msg);
     bool SayToWorldDefense(std::string msg);
     bool SayToGuildRecruitment(std::string msg);
+    bool SayToParty(std::string msg);
+    bool SayToRaid(std::string msg);
+    bool Yell(std::string msg);
+    bool Say(std::string msg);
+    bool Whisper(std::string msg, std::string receiverName);
     bool TellPlayer(Player* player, std::ostringstream &stream, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool ignoreSilent = false) { return TellPlayer(player, stream.str(), securityLevel, isPrivate, ignoreSilent); }
     bool TellPlayer(Player* player, std::string text, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool ignoreSilent = false);
     bool TellPlayerNoFacing(Player* player, std::ostringstream& stream, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool noRepeat = true, bool ignoreSilent = false) { return TellPlayerNoFacing(player, stream.str(), securityLevel, isPrivate, noRepeat, ignoreSilent); }

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -62,6 +62,26 @@ namespace ai
 	};
 };
 
+enum ImportantAreaId
+{
+    CITY = 3459
+};
+
+enum ChatChannelId
+{
+    GENERAL = 1,
+    TRADE = 2,
+    LOCAL_DEFENSE = 22,
+    WORLD_DEFENSE = 23,
+#ifdef MANGOSBOT_ZERO
+    //Yes, for 1.12 it is 24
+    LOOKING_FOR_GROUP = 24,
+#else
+    LOOKING_FOR_GROUP = 26,
+#endif
+    GUILD_RECRUITMENT = 25,
+};
+
 enum HealingItemDisplayId
 {
    HEALTHSTONE_DISPLAYID = 8026,
@@ -169,7 +189,7 @@ enum ShieldWardDisplayId
 };
 
 enum class BotTypeNumber : uint8
-{    
+{
     ACTIVITY_TYPE_NUMBER = 1,
     GROUPER_TYPE_NUMBER = 2,
     GUILDER_TYPE_NUMBER = 3,
@@ -236,7 +256,7 @@ enum ActivityType
     PARTY_ACTIVITY = 7,
     REACT_ACTIVITY = 8,
     ALL_ACTIVITY = 9,
-    MAX_ACTIVITY_TYPE 
+    MAX_ACTIVITY_TYPE
 };
 
 enum BotRoles
@@ -299,7 +319,7 @@ public:
 private:
     void UpdateAIInternal(uint32 elapsed, bool minimal = false) override;
 
-public:	
+public:
     static std::string BotStateToString(BotState state);
 	std::string HandleRemoteCommand(std::string command);
     void HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang = LANG_UNIVERSAL);
@@ -334,6 +354,18 @@ public:
     static GameObject* GetGameObject(GameObjectDataPair const* gameObjectDataPair);
     WorldObject* GetWorldObject(ObjectGuid guid);
     std::vector<Player*> GetPlayersInGroup();
+    const AreaTableEntry* GetCurrentArea();
+    const AreaTableEntry* GetCurrentZone();
+    std::string GetLocalizedAreaName(const AreaTableEntry* entry);
+    bool IsInCapitalCity();
+    bool SayToGuild(std::string msg);
+    bool SayToWorld(std::string msg);
+    bool SayToGeneral(std::string msg);
+    bool SayToTrade(std::string msg);
+    bool SayToLFG(std::string msg);
+    bool SayToLocalDefense(std::string msg);
+    bool SayToWorldDefense(std::string msg);
+    bool SayToGuildRecruitment(std::string msg);
     bool TellPlayer(Player* player, std::ostringstream &stream, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool ignoreSilent = false) { return TellPlayer(player, stream.str(), securityLevel, isPrivate, ignoreSilent); }
     bool TellPlayer(Player* player, std::string text, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool ignoreSilent = false);
     bool TellPlayerNoFacing(Player* player, std::ostringstream& stream, PlayerbotSecurityLevel securityLevel = PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, bool isPrivate = true, bool noRepeat = true, bool ignoreSilent = false) { return TellPlayerNoFacing(player, stream.str(), securityLevel, isPrivate, noRepeat, ignoreSilent); }
@@ -437,6 +469,9 @@ public:
 
     void AccelerateRespawn(Creature* creature, float accelMod = 0);
     void AccelerateRespawn(ObjectGuid guid, float accelMod = 0) { Creature* creature = GetCreature(guid); if (creature) AccelerateRespawn(creature,accelMod); }
+
+public:
+    void GetInventoryAndEquippedItems(std::vector<Item*>& items);
 
 private:
     void InventoryIterateItemsInBags(IterateItemsVisitor* visitor);

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -469,10 +469,12 @@ bool PlayerbotAIConfig::Initialize()
     broadcastChanceLootingItemLegendary = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemLegendary", 30000);
     broadcastChanceLootingItemArtifact = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemArtifact", 30000);
 
-    broadcastChanceQuestAcceptedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestAcceptedGeneric", 6000);
-    broadcastChanceQuestObjectiveCompletedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric", 300);
-    broadcastChanceQuestObjectiveProgressGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric", 300);
-    broadcastChanceQuestCompletedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestCompletedGeneric", 10000);
+    broadcastChanceQuestAccepted = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestAccepted", 6000);
+    broadcastChanceQuestUpdateObjectiveCompleted = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestUpdateObjectiveCompleted", 300);
+    broadcastChanceQuestUpdateObjectiveProgress = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestUpdateObjectiveProgress", 300);
+    broadcastChanceQuestUpdateFailedTimer = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestUpdateFailedTimer", 300);
+    broadcastChanceQuestUpdateComplete = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestUpdateComplete", 1000);
+    broadcastChanceQuestTurnedIn = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestTurnedIn", 10000);
 
     broadcastChanceKillNormal = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillNormal", 30);
     broadcastChanceKillElite = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillElite", 300);
@@ -491,7 +493,7 @@ bool PlayerbotAIConfig::Initialize()
     broadcastChanceSuggestQuest = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestQuest", 10000);
     broadcastChanceSuggestGrindMaterials = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestGrindMaterials", 5000);
     broadcastChanceSuggestGrindReputation = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestGrindReputation", 5000);
-    broadcastChanceSuggestSell = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSell", 5000);
+    broadcastChanceSuggestSell = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSell", 300);
     broadcastChanceSuggestSomething = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomething", 30000);
 
     broadcastChanceSuggestSomethingToxic = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomethingToxic", 0);

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -440,9 +440,67 @@ bool PlayerbotAIConfig::Initialize()
     randomBotRaidNearby = config.GetBoolDefault("AiPlayerbot.RandomBotRaidNearby", true);
     randomBotGuildNearby = config.GetBoolDefault("AiPlayerbot.RandomBotGuildNearby", true);
     inviteChat = config.GetBoolDefault("AiPlayerbot.InviteChat", true);
-    guildFeedbackRate = config.GetFloatDefault("AiPlayerbot.GuildFeedbackRate", 100.0f);
-    guildSuggestRate = config.GetFloatDefault("AiPlayerbot.GuildSuggestRate", 100.0f);
-    guildRepliesRate= config.GetFloatDefault("AiPlayerbot.GuildRepliesRate", 100.0f);
+
+    guildMaxBotLimit = config.GetIntDefault("AiPlayerbot.GuildMaxBotLimit", 1000);
+
+    enableBroadcasts = config.GetBoolDefault("AiPlayerbot.EnableBroadcasts", true);
+
+    //broadcastChanceMaxValue is used in urand(1, broadcastChanceMaxValue) for broadcasts,
+    //lowering it will increase the chance, setting it to 0 will disable broadcasts
+    //for internal use, not intended to be change by the user
+    broadcastChanceMaxValue = enableBroadcasts ? 30000 : 0;
+
+    //all broadcast chances should be in range 1-broadcastChanceMaxValue, value of 0 will disable this particular broadcast
+    //setting value to max does not guarantee the broadcast, as there are some internal randoms as well
+    broadcastToGuildGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToGuildGlobalChance", 30000);
+    broadcastToWorldGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToWorldGlobalChance", 30000);
+    broadcastToGeneralGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToGeneralGlobalChance", 30000);
+    broadcastToTradeGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToTradeGlobalChance", 30000);
+    broadcastToLFGGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToLFGGlobalChance", 30000);
+    broadcastToLocalDefenseGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToLocalDefenseGlobalChance", 30000);
+    broadcastToWorldDefenseGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToWorldDefenseGlobalChance", 30000);
+    broadcastToGuildRecruitmentGlobalChance = config.GetIntDefault("AiPlayerbot.BroadcastToGuildRecruitmentGlobalChance", 30000);
+
+    broadcastChanceLootingItemPoor = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemPoor", 30);
+    broadcastChanceLootingItemNormal = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemNormal", 300);
+    broadcastChanceLootingItemUncommon = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemUncommon", 10000);
+    broadcastChanceLootingItemRare = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemRare", 20000);
+    broadcastChanceLootingItemEpic = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemEpic", 30000);
+    broadcastChanceLootingItemLegendary = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemLegendary", 30000);
+    broadcastChanceLootingItemArtifact = config.GetIntDefault("AiPlayerbot.BroadcastChanceLootingItemArtifact", 30000);
+
+    broadcastChanceQuestAcceptedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestAcceptedGeneric", 6000);
+    broadcastChanceQuestObjectiveCompletedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric", 300);
+    broadcastChanceQuestObjectiveProgressGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric", 300);
+    broadcastChanceQuestCompletedGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceQuestCompletedGeneric", 10000);
+
+    broadcastChanceKillNormal = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillNormal", 30);
+    broadcastChanceKillElite = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillElite", 300);
+    broadcastChanceKillRareelite = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillRareelite", 3000);
+    broadcastChanceKillWorldboss = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillWorldboss", 20000);
+    broadcastChanceKillRare = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillRare", 10000);
+    broadcastChanceKillUnknown = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillUnknown", 100);
+    broadcastChanceKillPet = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillPet", 10);
+    broadcastChanceKillPlayer = config.GetIntDefault("AiPlayerbot.BroadcastChanceKillPlayer", 30);
+
+    broadcastChanceLevelupGeneric = config.GetIntDefault("AiPlayerbot.BroadcastChanceLevelupGeneric", 20000);
+    broadcastChanceLevelupTenX = config.GetIntDefault("AiPlayerbot.BroadcastChanceLevelupTenX", 30000);
+    broadcastChanceLevelupMaxLevel = config.GetIntDefault("AiPlayerbot.BroadcastChanceLevelupMaxLevel", 30000);
+
+    broadcastChanceSuggestInstance = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestInstance", 5000);
+    broadcastChanceSuggestQuest = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestQuest", 10000);
+    broadcastChanceSuggestGrindMaterials = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestGrindMaterials", 5000);
+    broadcastChanceSuggestGrindReputation = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestGrindReputation", 5000);
+    broadcastChanceSuggestSell = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSell", 5000);
+    broadcastChanceSuggestSomething = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomething", 30000);
+
+    broadcastChanceSuggestSomethingToxic = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomethingToxic", 0);
+    broadcastChanceSuggestToxicLinks = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestToxicLinks", 0);
+
+    //does not depend on global chance
+    broadcastChanceGuildManagement = config.GetIntDefault("AiPlayerbot.BroadcastChanceGuildManagement", 30000);
+
+    guildRepliesRate = config.GetIntDefault("AiPlayerbot.GuildRepliesRate", 100); //0-100
     
     randomBotFormGuild = config.GetBoolDefault("AiPlayerbot.RandomBotFormGuild", true);
     

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -162,7 +162,7 @@ bool PlayerbotAIConfig::Initialize()
     LoadList<std::list<uint32> >(config.GetStringDefault("AiPlayerbot.RandomBotQuestItems", "6948,5175,5176,5177,5178,16309,12382,13704,11000,22754"), randomBotQuestItems);
     LoadList<std::list<uint32> >(config.GetStringDefault("AiPlayerbot.RandomBotSpellIds", "54197"), randomBotSpellIds);
 	LoadList<std::list<uint32> >(config.GetStringDefault("AiPlayerbot.PvpProhibitedZoneIds", "2255,656,2361,2362,2363,976,35,2268,3425,392,541,1446,3828,3712,3738,3565,3539,3623,4152,3988,4658,4284,4418,4436,4275,4323"), pvpProhibitedZoneIds);
-    
+
 #ifndef MANGOSBOT_ZERO
     // disable pvp near dark portal if event is active
     if (sWorldState.GetExpansion() == EXPANSION_NONE)
@@ -373,7 +373,7 @@ bool PlayerbotAIConfig::Initialize()
 
     //Get all config values starting with AiPlayerbot.WorldBuff
     std::vector<std::string> values = configA->GetValues("AiPlayerbot.WorldBuff");
-   
+
     if (values.size())
     {
         sLog.outString("Loading WorldBuffs");
@@ -443,6 +443,7 @@ bool PlayerbotAIConfig::Initialize()
 
     guildMaxBotLimit = config.GetIntDefault("AiPlayerbot.GuildMaxBotLimit", 1000);
 
+    ////////////////////////////
     enableBroadcasts = config.GetBoolDefault("AiPlayerbot.EnableBroadcasts", true);
 
     //broadcastChanceMaxValue is used in urand(1, broadcastChanceMaxValue) for broadcasts,
@@ -497,20 +498,27 @@ bool PlayerbotAIConfig::Initialize()
     broadcastChanceSuggestSomething = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomething", 30000);
 
     broadcastChanceSuggestSomethingToxic = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestSomethingToxic", 0);
+
     broadcastChanceSuggestToxicLinks = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestToxicLinks", 0);
+    toxicLinksPrefix = config.GetStringDefault("AiPlayerbot.ToxicLinksPrefix", "gnomes");
+
+    broadcastChanceSuggestThunderfury = config.GetIntDefault("AiPlayerbot.BroadcastChanceSuggestThunderfury", 1);
 
     //does not depend on global chance
     broadcastChanceGuildManagement = config.GetIntDefault("AiPlayerbot.BroadcastChanceGuildManagement", 30000);
+    ////////////////////////////
 
+    toxicLinksRepliesChance = config.GetIntDefault("AiPlayerbot.ToxicLinksRepliesChance", 100); //0-100
+    thunderfuryRepliesChance = config.GetIntDefault("AiPlayerbot.ThunderfuryRepliesChance", 100); //0-100
     guildRepliesRate = config.GetIntDefault("AiPlayerbot.GuildRepliesRate", 100); //0-100
-    
+
     randomBotFormGuild = config.GetBoolDefault("AiPlayerbot.RandomBotFormGuild", true);
-    
+
     boostFollow = config.GetBoolDefault("AiPlayerbot.BoostFollow", false);
     turnInRpg = config.GetBoolDefault("AiPlayerbot.TurnInRpg", false);
     globalSoundEffects = config.GetBoolDefault("AiPlayerbot.GlobalSoundEffects", false);
     nonGmFreeSummon = config.GetBoolDefault("AiPlayerbot.NonGmFreeSummon", false);
-    
+
     //SPP automation
     autoPickReward = config.GetStringDefault("AiPlayerbot.AutoPickReward", "no");
     autoEquipUpgradeLoot = config.GetBoolDefault("AiPlayerbot.AutoEquipUpgradeLoot", false);
@@ -727,7 +735,7 @@ void PlayerbotAIConfig::loadFreeAltBotAccounts()
             uint32 accountId = fields[1].GetUInt32();
 
             if (std::find(toggleAlwaysOnlineAccounts.begin(), toggleAlwaysOnlineAccounts.end(), accountName) != toggleAlwaysOnlineAccounts.end())
-                accountAlwaysOnline = !accountAlwaysOnline;                       
+                accountAlwaysOnline = !accountAlwaysOnline;
 
             auto result = CharacterDatabase.PQuery("SELECT name, guid FROM characters WHERE account = '%u'", accountId);
             if (!result)
@@ -753,7 +761,7 @@ void PlayerbotAIConfig::loadFreeAltBotAccounts()
                     freeAltBots.push_back(std::make_pair(accountId, guid));
 
             } while (result->NextRow());
-        
+
 
         } while (results->NextRow());
     }
@@ -778,7 +786,7 @@ bool PlayerbotAIConfig::openLog(std::string fileName, char const* mode, bool has
 {
     if (!haslog && !hasLog(fileName))
         return false;
-     
+
     auto logFileIt = logFiles.find(fileName);
     if (logFileIt == logFiles.end())
     {
@@ -805,7 +813,7 @@ bool PlayerbotAIConfig::openLog(std::string fileName, char const* mode, bool has
 
     logFileIt->second.first = file;
     logFileIt->second.second = fileOpen;
-    
+
     return true;
 }
 
@@ -891,5 +899,5 @@ bool PlayerbotAIConfig::CanLogAction(PlayerbotAI* ai, std::string actionName, bo
         }
     }
 
-    return std::find(debugFilter.begin(), debugFilter.end(), actionName) == debugFilter.end(); 
+    return std::find(debugFilter.begin(), debugFilter.end(), actionName) == debugFilter.end();
 }

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -217,7 +217,13 @@ public:
     uint32 broadcastChanceSuggestSomething;
 
     uint32 broadcastChanceSuggestSomethingToxic;
+
     uint32 broadcastChanceSuggestToxicLinks;
+    std::string toxicLinksPrefix;
+    uint32 toxicLinksRepliesChance;
+
+    uint32 broadcastChanceSuggestThunderfury;
+    uint32 thunderfuryRepliesChance;
 
     uint32 broadcastChanceGuildManagement;
 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -166,9 +166,61 @@ public:
     bool randomBotFormGuild;
     bool randomBotRandomPassword;
     bool inviteChat;
-    float guildFeedbackRate;
-    float guildSuggestRate;
-    float guildRepliesRate;
+
+    uint32 guildMaxBotLimit;
+
+    bool enableBroadcasts;
+    uint32 broadcastChanceMaxValue;
+
+    uint32 broadcastToGuildGlobalChance;
+    uint32 broadcastToWorldGlobalChance;
+    uint32 broadcastToGeneralGlobalChance;
+    uint32 broadcastToTradeGlobalChance;
+    uint32 broadcastToLFGGlobalChance;
+    uint32 broadcastToLocalDefenseGlobalChance;
+    uint32 broadcastToWorldDefenseGlobalChance;
+    uint32 broadcastToGuildRecruitmentGlobalChance;
+
+    uint32 broadcastChanceLootingItemPoor;
+    uint32 broadcastChanceLootingItemNormal;
+    uint32 broadcastChanceLootingItemUncommon;
+    uint32 broadcastChanceLootingItemRare;
+    uint32 broadcastChanceLootingItemEpic;
+    uint32 broadcastChanceLootingItemLegendary;
+    uint32 broadcastChanceLootingItemArtifact;
+
+    uint32 broadcastChanceQuestAcceptedGeneric;
+    uint32 broadcastChanceQuestObjectiveCompletedGeneric;
+    uint32 broadcastChanceQuestObjectiveProgressGeneric;
+    uint32 broadcastChanceQuestCompletedGeneric;
+
+    uint32 broadcastChanceKillNormal;
+    uint32 broadcastChanceKillElite;
+    uint32 broadcastChanceKillRareelite;
+    uint32 broadcastChanceKillWorldboss;
+    uint32 broadcastChanceKillRare;
+    uint32 broadcastChanceKillUnknown;
+    uint32 broadcastChanceKillPet;
+    uint32 broadcastChanceKillPlayer;
+
+    uint32 broadcastChanceLevelupGeneric;
+    uint32 broadcastChanceLevelupTenX;
+    uint32 broadcastChanceLevelupMaxLevel;
+
+    uint32 broadcastChanceSuggestInstance;
+    uint32 broadcastChanceSuggestQuest;
+    uint32 broadcastChanceSuggestGrindMaterials;
+    uint32 broadcastChanceSuggestGrindReputation;
+    uint32 broadcastChanceSuggestSell;
+    uint32 broadcastChanceSuggestSomething;
+
+    uint32 broadcastChanceSuggestSomethingToxic;
+    uint32 broadcastChanceSuggestToxicLinks;
+
+    uint32 broadcastChanceGuildManagement;
+
+    uint32 guildRepliesRate;
+
     bool talentsInPublicNote;
     bool nonGmFreeSummon;
 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -189,10 +189,12 @@ public:
     uint32 broadcastChanceLootingItemLegendary;
     uint32 broadcastChanceLootingItemArtifact;
 
-    uint32 broadcastChanceQuestAcceptedGeneric;
-    uint32 broadcastChanceQuestObjectiveCompletedGeneric;
-    uint32 broadcastChanceQuestObjectiveProgressGeneric;
-    uint32 broadcastChanceQuestCompletedGeneric;
+    uint32 broadcastChanceQuestAccepted;
+    uint32 broadcastChanceQuestUpdateObjectiveCompleted;
+    uint32 broadcastChanceQuestUpdateObjectiveProgress;
+    uint32 broadcastChanceQuestUpdateFailedTimer;
+    uint32 broadcastChanceQuestUpdateComplete;
+    uint32 broadcastChanceQuestTurnedIn;
 
     uint32 broadcastChanceKillNormal;
     uint32 broadcastChanceKillElite;

--- a/playerbot/PlayerbotMgr.cpp
+++ b/playerbot/PlayerbotMgr.cpp
@@ -267,6 +267,91 @@ Player* PlayerbotHolder::GetPlayerBot(uint32 playerGuid) const
     return (it == playerBots.end()) ? nullptr : it->second ? it->second : nullptr;
 }
 
+void PlayerbotHolder::JoinChatChannels(Player* bot)
+{
+    // bots join World chat if not solo oriented
+    if (bot->GetLevel() >= 10 && sRandomPlayerbotMgr.IsFreeBot(bot) && bot->GetPlayerbotAI() && bot->GetPlayerbotAI()->GetGrouperType() != GrouperType::SOLO)
+    {
+        // TODO make action/config
+        // Make the bot join the world channel for chat
+        WorldPacket pkt(CMSG_JOIN_CHANNEL);
+#ifndef MANGOSBOT_ZERO
+        pkt << uint32(0) << uint8(0) << uint8(0);
+#endif
+        pkt << std::string("World");
+        pkt << ""; // Pass
+        bot->GetSession()->HandleJoinChannelOpcode(pkt);
+    }
+    // join standard channels
+    uint8 locale = BroadcastHelper::GetLocale();
+
+    AreaTableEntry const* current_zone = bot->GetPlayerbotAI()->GetCurrentZone();
+    ChannelMgr* cMgr = channelMgr(bot->GetTeam());
+    std::string current_zone_name = current_zone ? bot->GetPlayerbotAI()->GetLocalizedAreaName(current_zone) : "";
+
+    if (current_zone && cMgr)
+    {
+        for (uint32 i = 0; i < sChatChannelsStore.GetNumRows(); ++i)
+        {
+            ChatChannelsEntry const* channel = sChatChannelsStore.LookupEntry(i);
+            if (!channel) continue;
+
+            Channel* new_channel = nullptr;
+            switch (channel->ChannelID)
+            {
+                case ChatChannelId::GENERAL:
+                case ChatChannelId::LOCAL_DEFENSE:
+                {
+                    char new_channel_name_buf[100];
+                    snprintf(new_channel_name_buf, 100, channel->pattern[locale], current_zone_name.c_str());
+#ifdef MANGOSBOT_ZERO
+                    new_channel = cMgr->GetJoinChannel(new_channel_name_buf);
+#else
+                    new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
+#endif
+                    break;
+                }
+                case ChatChannelId::TRADE:
+                case ChatChannelId::GUILD_RECRUITMENT:
+                {
+                    char new_channel_name_buf[100];
+                    //3459 is ID for a zone named "City" (only exists for the sake of using its name)
+                    //Currently in magons TBC, if you switch zones, then you join "Trade - <zone>" and "GuildRecruitment - <zone>"
+                    //which is a core bug, should be "Trade - City" and "GuildRecruitment - City" in both 1.12 and TBC
+                    //but if you (actual player) logout in a city and log back in - you join "City" versions
+                    snprintf(
+                        new_channel_name_buf,
+                        100,
+                        channel->pattern[locale],
+                        bot->GetPlayerbotAI()->GetLocalizedAreaName(GetAreaEntryByAreaID(ImportantAreaId::CITY))
+                    );
+
+#ifdef MANGOSBOT_ZERO
+                    new_channel = cMgr->GetJoinChannel(new_channel_name_buf);
+#else
+                    new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
+#endif
+                    break;
+                }
+                case ChatChannelId::LOOKING_FOR_GROUP:
+                case ChatChannelId::WORLD_DEFENSE:
+                {
+#ifdef MANGOSBOT_ZERO
+                    new_channel = cMgr->GetJoinChannel(channel->pattern[locale]);
+#else
+                    new_channel = cMgr->GetJoinChannel(channel->pattern[locale], channel->ChannelID);
+#endif
+                    break;
+                }
+                default:
+                    break;
+            }
+            if (new_channel)
+                new_channel->Join(bot, "");
+        }
+    }
+}
+
 void PlayerbotHolder::OnBotLogin(Player * const bot)
 {
     PlayerbotAI* ai = bot->GetPlayerbotAI();
@@ -311,7 +396,7 @@ void PlayerbotHolder::OnBotLogin(Player * const bot)
                 }
             }
 
-            // Don't disband alt groups when master goes away 
+            // Don't disband alt groups when master goes away
             // (will need to manually disband with leave command)
             uint32 account = sObjectMgr.GetPlayerAccountIdByGUID(member);
             if (!sPlayerbotAIConfig.IsInRandomAccountList(account))
@@ -344,81 +429,7 @@ void PlayerbotHolder::OnBotLogin(Player * const bot)
 
     ai->TellPlayer(ai->GetMaster(), BOT_TEXT("hello"));
 
-    // bots join World chat if not solo oriented
-    if (bot->GetLevel() >= 10 && sRandomPlayerbotMgr.IsFreeBot(bot) && bot->GetPlayerbotAI() && bot->GetPlayerbotAI()->GetGrouperType() != GrouperType::SOLO)
-    {
-        // TODO make action/config
-        // Make the bot join the world channel for chat
-        WorldPacket pkt(CMSG_JOIN_CHANNEL);
-#ifndef MANGOSBOT_ZERO
-        pkt << uint32(0) << uint8(0) << uint8(0);
-#endif
-        pkt << std::string("World");
-        pkt << ""; // Pass
-        bot->GetSession()->HandleJoinChannelOpcode(pkt);
-
-#ifdef MANGOSBOT_ZERO
-        // bots join World Defense
-        WorldPacket pkt2(CMSG_JOIN_CHANNEL);
-#ifndef MANGOSBOT_ZERO
-        pkt2 << uint32(0) << uint8(0) << uint8(0);
-#endif
-        pkt2 << std::string("WorldDefense");
-        pkt2 << ""; // Pass
-        bot->GetSession()->HandleJoinChannelOpcode(pkt2);
-#endif
-    }
-    // join standard channels
-    int32 locale = sConfig.GetIntDefault("DBC.Locale", 0 /*LocaleConstant::LOCALE_enUS*/); // bot->GetSession()->GetSessionDbcLocale();
-    // -- In case we're using auto detect on config file
-    if (locale == 255)
-        locale = static_cast<int32>(LocaleConstant::LOCALE_enUS);
-    
-    AreaTableEntry const* current_zone = GetAreaEntryByAreaID(sTerrainMgr.GetAreaId(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ()));
-    ChannelMgr* cMgr = channelMgr(bot->GetTeam());
-    std::string current_zone_name = current_zone ? current_zone->area_name[locale] : "";
-
-    if (current_zone && cMgr)
-    {
-        for (uint32 i = 0; i < sChatChannelsStore.GetNumRows(); ++i)
-        {
-            ChatChannelsEntry const* channel = sChatChannelsStore.LookupEntry(i);
-            if (!channel) continue;
-
-#ifndef MANGOSBOT_ZERO
-            bool isLfg = (channel->flags & Channel::CHANNEL_DBC_FLAG_LFG) != 0;
-#else
-            bool isLfg = channel->ChannelID == 24;
-#endif
-
-            // skip non built-in channels or global channel without zone name in pattern
-            if (!isLfg && (!channel || (channel->flags & 4) == 4))
-                continue;
-
-            //  new channel
-            Channel* new_channel = nullptr;
-            if (isLfg)
-            {
-#ifndef MANGOSBOT_ZERO
-                new_channel = cMgr->GetJoinChannel(channel->pattern[locale], channel->ChannelID);
-#else
-                new_channel = cMgr->GetJoinChannel("LookingForGroup");
-#endif
-            }
-            else
-            {
-                char new_channel_name_buf[100];
-                snprintf(new_channel_name_buf, 100, channel->pattern[locale], current_zone_name.c_str());
-#ifndef MANGOSBOT_ZERO
-                new_channel = cMgr->GetJoinChannel(new_channel_name_buf, channel->ChannelID);
-#else
-                new_channel = cMgr->GetJoinChannel(new_channel_name_buf);
-#endif
-            }
-            if (new_channel)
-                new_channel->Join(bot, "");
-        }
-    }
+    JoinChatChannels(bot);
 
     if (sRandomPlayerbotMgr.IsRandomBot(bot))
     {

--- a/playerbot/PlayerbotMgr.h
+++ b/playerbot/PlayerbotMgr.h
@@ -33,6 +33,7 @@ public:
     void ForEachPlayerbot(std::function<void(Player*)> fct) const;
 
     void LogoutAllBots();
+    void JoinChatChannels(Player* bot);
     void OnBotLogin(Player* bot);
     void MovePlayerBot(uint32 guid, PlayerbotHolder* newHolder);
 

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -228,10 +228,12 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 # AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
 # AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
 #
-# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
-# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+# AiPlayerbot.BroadcastChanceQuestAccepted = 6000
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveCompleted = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveProgress = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateFailedTimer = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateComplete = 1000
+# AiPlayerbot.BroadcastChanceQuestTurnedIn = 10000
 #
 # AiPlayerbot.BroadcastChanceKillNormal = 30
 # AiPlayerbot.BroadcastChanceKillElite = 300
@@ -246,11 +248,11 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
-# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -192,10 +192,80 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 # Bots will put their talentspec in guild notes when they change/tell their talents if they have the rights.
 # AiPlayerbot.TalentsInPublicNote = 0
 
-# Bots will chat in guild about certain events
-# AIPlayerbot.GuildFeedbackRate = 100.0        # Actual events like levelup, hard kills or nice loot.
-# AiPlayerbot.GuildSuggestRate = 100.0         # Random suggestions.
-# AiPlayerbot.GuildRepliesRate = 100.0         # Reply someone saying something.
+#max limit of members in a guild (bots will leave guild if there are more members than this number)
+# AiPlayerbot.guildMaxBotLimit = 1000
+
+##################################################################################
+#
+# Broadcast rates
+#
+# 1 - to enable broadcasts globally, 0 - to disable (default 1)
+# AiPlayerbot.EnableBroadcasts = 1
+#
+# all broadcast chances should be in range 0-30000
+#
+# value of 0 will disable this particular broadcast
+# setting value to 30000 does not guarantee the broadcast, as there are some internal randoms as well
+#
+# setting channel broadcast chance to 0, will re-route most broadcasts to other available channels
+# setting all channel broadcasts to 0 will disable most broadcasts
+# AiPlayerbot.BroadcastToGuildGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldGlobalChance = 30000
+# AiPlayerbot.BroadcastToGeneralGlobalChance = 30000
+# AiPlayerbot.BroadcastToTradeGlobalChance = 30000
+# AiPlayerbot.BroadcastToLFGGlobalChance = 30000
+# AiPlayerbot.BroadcastToLocalDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToGuildRecruitmentGlobalChance = 30000
+#
+# individual settings
+# setting one of these to 0 will disable the particular broadcast
+# AiPlayerbot.BroadcastChanceLootingItemPoor = 30
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
+# AiPlayerbot.BroadcastChanceLootingItemRare = 20000
+# AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
+# AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
+# AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
+#
+# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
+# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+#
+# AiPlayerbot.BroadcastChanceKillNormal = 30
+# AiPlayerbot.BroadcastChanceKillElite = 300
+# AiPlayerbot.BroadcastChanceKillRareelite = 3000
+# AiPlayerbot.BroadcastChanceKillWorldboss = 20000
+# AiPlayerbot.BroadcastChanceKillRare = 10000
+# AiPlayerbot.BroadcastChanceKillUnknown = 100
+# AiPlayerbot.BroadcastChanceKillPet = 10
+# AiPlayerbot.BroadcastChanceKillPlayer = 30
+#
+# AiPlayerbot.BroadcastChanceLevelupGeneric = 20000
+# AiPlayerbot.BroadcastChanceLevelupTenX = 30000
+# AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
+#
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestQuest = 10000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
+# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestSomething = 30000
+#
+# Very rude speeches
+# AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
+#
+# Specifically for "<censored> [item link]"
+# AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# does not depend on global chance
+# AiPlayerbot.BroadcastChanceGuildManagement = 30000
+#
+##################################################################################
+
+# Bots will chat in guild about certain events (int)
+# AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.
 # AiPlayerbot.RandomBotSayWithoutMaster = 0

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -221,7 +221,7 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 # individual settings
 # setting one of these to 0 will disable the particular broadcast
 # AiPlayerbot.BroadcastChanceLootingItemPoor = 30
-# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 150
 # AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
 # AiPlayerbot.BroadcastChanceLootingItemRare = 20000
 # AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
@@ -248,25 +248,35 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
 # AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches
 # AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
 #
-# Specifically for "<censored> [item link]"
+# Specifically for "<word> [item link]"
 # AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# prefix is used as a word in "<word> [item link]"
+# AiPlayerbot.ToxicLinksPrefix = gnomes
+#
+# chance to suggest thunderfury
+# AiPlayerbot.BroadcastChanceSuggestThunderfury = 1
 #
 # does not depend on global chance
 # AiPlayerbot.BroadcastChanceGuildManagement = 30000
 #
 ##################################################################################
 
-# Bots will chat in guild about certain events (int)
+# Chance to reply to toxic links with toxic links (0-100)
+# AiPlayerbot.ToxicLinksRepliesChance = 100
+# Chance to reply to thunderfury with thunderfury (0-100)
+# AiPlayerbot.ThunderfuryRepliesChance = 100
+# Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -203,7 +203,7 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # individual settings
 # setting one of these to 0 will disable the particular broadcast
 # AiPlayerbot.BroadcastChanceLootingItemPoor = 30
-# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 150
 # AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
 # AiPlayerbot.BroadcastChanceLootingItemRare = 20000
 # AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
@@ -230,25 +230,35 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
 # AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches
 # AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
 #
-# Specifically for "<censored> [item link]"
+# Specifically for "<word> [item link]"
 # AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# prefix is used as a word in "<word> [item link]"
+# AiPlayerbot.ToxicLinksPrefix = gnomes
+#
+# chance to suggest thunderfury
+# AiPlayerbot.BroadcastChanceSuggestThunderfury = 1
 #
 # does not depend on global chance
 # AiPlayerbot.BroadcastChanceGuildManagement = 30000
 #
 ##################################################################################
 
-# Bots will chat in guild about certain events (int)
+# Chance to reply to toxic links with toxic links (0-100)
+# AiPlayerbot.ToxicLinksRepliesChance = 100
+# Chance to reply to thunderfury with thunderfury (0-100)
+# AiPlayerbot.ThunderfuryRepliesChance = 100
+# Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -210,10 +210,12 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
 # AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
 #
-# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
-# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+# AiPlayerbot.BroadcastChanceQuestAccepted = 6000
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveCompleted = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveProgress = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateFailedTimer = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateComplete = 1000
+# AiPlayerbot.BroadcastChanceQuestTurnedIn = 10000
 #
 # AiPlayerbot.BroadcastChanceKillNormal = 30
 # AiPlayerbot.BroadcastChanceKillElite = 300
@@ -228,11 +230,11 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
-# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -174,10 +174,80 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # Bots will chat in say/guild when they invite other bots to groups/raids/guilds
 # AiPlayerbot.InviteChat = 1
 
-# Bots will chat in guild about certain events
-# AIPlayerbot.GuildFeedbackRate = 100.0        # Actual events like levelup, hard kills or nice loot.
-# AiPlayerbot.GuildSuggestRate  = 100.0        # Random suggestions.
-# AiPlayerbot.GuildRepliesRate  = 100.0        # Reply someone saying something.
+#max limit of members in a guild (bots will leave guild if there are more members than this number)
+# AiPlayerbot.guildMaxBotLimit = 1000
+
+##################################################################################
+#
+# Broadcast rates
+#
+# 1 - to enable broadcasts globally, 0 - to disable (default 1)
+# AiPlayerbot.EnableBroadcasts = 1
+#
+# all broadcast chances should be in range 0-30000
+#
+# value of 0 will disable this particular broadcast
+# setting value to 30000 does not guarantee the broadcast, as there are some internal randoms as well
+#
+# setting channel broadcast chance to 0, will re-route most broadcasts to other available channels
+# setting all channel broadcasts to 0 will disable most broadcasts
+# AiPlayerbot.BroadcastToGuildGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldGlobalChance = 30000
+# AiPlayerbot.BroadcastToGeneralGlobalChance = 30000
+# AiPlayerbot.BroadcastToTradeGlobalChance = 30000
+# AiPlayerbot.BroadcastToLFGGlobalChance = 30000
+# AiPlayerbot.BroadcastToLocalDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToGuildRecruitmentGlobalChance = 30000
+#
+# individual settings
+# setting one of these to 0 will disable the particular broadcast
+# AiPlayerbot.BroadcastChanceLootingItemPoor = 30
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
+# AiPlayerbot.BroadcastChanceLootingItemRare = 20000
+# AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
+# AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
+# AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
+#
+# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
+# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+#
+# AiPlayerbot.BroadcastChanceKillNormal = 30
+# AiPlayerbot.BroadcastChanceKillElite = 300
+# AiPlayerbot.BroadcastChanceKillRareelite = 3000
+# AiPlayerbot.BroadcastChanceKillWorldboss = 20000
+# AiPlayerbot.BroadcastChanceKillRare = 10000
+# AiPlayerbot.BroadcastChanceKillUnknown = 100
+# AiPlayerbot.BroadcastChanceKillPet = 10
+# AiPlayerbot.BroadcastChanceKillPlayer = 30
+#
+# AiPlayerbot.BroadcastChanceLevelupGeneric = 20000
+# AiPlayerbot.BroadcastChanceLevelupTenX = 30000
+# AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
+#
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestQuest = 10000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
+# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestSomething = 30000
+#
+# Very rude speeches
+# AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
+#
+# Specifically for "<censored> [item link]"
+# AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# does not depend on global chance
+# AiPlayerbot.BroadcastChanceGuildManagement = 30000
+#
+##################################################################################
+
+# Bots will chat in guild about certain events (int)
+# AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.
 # AiPlayerbot.RandomBotSayWithoutMaster = 0

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -177,10 +177,80 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # Bots will chat in say/guild when they invite other bots to groups/raids/guilds
 # AiPlayerbot.InviteChat = 1
 
-# Bots will chat in guild about certain events
-# AIPlayerbot.GuildFeedbackRate = 100.0        # Actual events like levelup, hard kills or nice loot.
-# AiPlayerbot.GuildSuggestRate  = 100.0        # Random suggestions.
-# AiPlayerbot.GuildRepliesRate  = 100.0        # Reply someone saying something.
+#max limit of members in a guild (bots will leave guild if there are more members than this number)
+# AiPlayerbot.guildMaxBotLimit = 1000
+
+##################################################################################
+#
+# Broadcast rates
+#
+# 1 - to enable broadcasts globally, 0 - to disable (default 1)
+# AiPlayerbot.EnableBroadcasts = 1
+#
+# all broadcast chances should be in range 0-30000
+#
+# value of 0 will disable this particular broadcast
+# setting value to 30000 does not guarantee the broadcast, as there are some internal randoms as well
+#
+# setting channel broadcast chance to 0, will re-route most broadcasts to other available channels
+# setting all channel broadcasts to 0 will disable most broadcasts
+# AiPlayerbot.BroadcastToGuildGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldGlobalChance = 30000
+# AiPlayerbot.BroadcastToGeneralGlobalChance = 30000
+# AiPlayerbot.BroadcastToTradeGlobalChance = 30000
+# AiPlayerbot.BroadcastToLFGGlobalChance = 30000
+# AiPlayerbot.BroadcastToLocalDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToWorldDefenseGlobalChance = 30000
+# AiPlayerbot.BroadcastToGuildRecruitmentGlobalChance = 30000
+#
+# individual settings
+# setting one of these to 0 will disable the particular broadcast
+# AiPlayerbot.BroadcastChanceLootingItemPoor = 30
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
+# AiPlayerbot.BroadcastChanceLootingItemRare = 20000
+# AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
+# AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
+# AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
+#
+# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
+# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
+# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+#
+# AiPlayerbot.BroadcastChanceKillNormal = 30
+# AiPlayerbot.BroadcastChanceKillElite = 300
+# AiPlayerbot.BroadcastChanceKillRareelite = 3000
+# AiPlayerbot.BroadcastChanceKillWorldboss = 20000
+# AiPlayerbot.BroadcastChanceKillRare = 10000
+# AiPlayerbot.BroadcastChanceKillUnknown = 100
+# AiPlayerbot.BroadcastChanceKillPet = 10
+# AiPlayerbot.BroadcastChanceKillPlayer = 30
+#
+# AiPlayerbot.BroadcastChanceLevelupGeneric = 20000
+# AiPlayerbot.BroadcastChanceLevelupTenX = 30000
+# AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
+#
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestQuest = 10000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
+# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestSomething = 30000
+#
+# Very rude speeches
+# AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
+#
+# Specifically for "<censored> [item link]"
+# AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# does not depend on global chance
+# AiPlayerbot.BroadcastChanceGuildManagement = 30000
+#
+##################################################################################
+
+# Bots will chat in guild about certain events (int)
+# AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots will chat in guild about certain events
 # AIPlayerbot.GuildFeedback = 1

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -206,7 +206,7 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # individual settings
 # setting one of these to 0 will disable the particular broadcast
 # AiPlayerbot.BroadcastChanceLootingItemPoor = 30
-# AiPlayerbot.BroadcastChanceLootingItemNormal = 300
+# AiPlayerbot.BroadcastChanceLootingItemNormal = 150
 # AiPlayerbot.BroadcastChanceLootingItemUncommon = 10000
 # AiPlayerbot.BroadcastChanceLootingItemRare = 20000
 # AiPlayerbot.BroadcastChanceLootingItemEpic = 30000
@@ -233,25 +233,35 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
 # AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches
 # AiPlayerbot.BroadcastChanceSuggestSomethingToxic = 0
 #
-# Specifically for "<censored> [item link]"
+# Specifically for "<word> [item link]"
 # AiPlayerbot.BroadcastChanceSuggestToxicLinks = 0
+#
+# prefix is used as a word in "<word> [item link]"
+# AiPlayerbot.ToxicLinksPrefix = gnomes
+#
+# chance to suggest thunderfury
+# AiPlayerbot.BroadcastChanceSuggestThunderfury = 1
 #
 # does not depend on global chance
 # AiPlayerbot.BroadcastChanceGuildManagement = 30000
 #
 ##################################################################################
 
-# Bots will chat in guild about certain events (int)
+# Chance to reply to toxic links with toxic links (0-100)
+# AiPlayerbot.ToxicLinksRepliesChance = 100
+# Chance to reply to thunderfury with thunderfury (0-100)
+# AiPlayerbot.ThunderfuryRepliesChance = 100
+# Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots will chat in guild about certain events

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -213,10 +213,12 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLootingItemLegendary = 30000
 # AiPlayerbot.BroadcastChanceLootingItemArtifact = 30000
 #
-# AiPlayerbot.BroadcastChanceQuestAcceptedGeneric = 6000
-# AiPlayerbot.BroadcastChanceQuestObjectiveCompletedGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestObjectiveProgressGeneric = 300
-# AiPlayerbot.BroadcastChanceQuestCompletedGeneric = 10000
+# AiPlayerbot.BroadcastChanceQuestAccepted = 6000
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveCompleted = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateObjectiveProgress = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateFailedTimer = 300
+# AiPlayerbot.BroadcastChanceQuestUpdateComplete = 1000
+# AiPlayerbot.BroadcastChanceQuestTurnedIn = 10000
 #
 # AiPlayerbot.BroadcastChanceKillNormal = 30
 # AiPlayerbot.BroadcastChanceKillElite = 300
@@ -231,11 +233,11 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 # AiPlayerbot.BroadcastChanceLevelupTenX = 30000
 # AiPlayerbot.BroadcastChanceLevelupMaxLevel = 30000
 #
-# AiPlayerbot.BroadcastChanceSuggestInstance = 5000
+# AiPlayerbot.BroadcastChanceSuggestInstance = 1000
 # AiPlayerbot.BroadcastChanceSuggestQuest = 10000
-# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 5000
-# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 5000
-# AiPlayerbot.BroadcastChanceSuggestSell = 5000
+# AiPlayerbot.BroadcastChanceSuggestGrindMaterials = 1000
+# AiPlayerbot.BroadcastChanceSuggestGrindReputation = 1000
+# AiPlayerbot.BroadcastChanceSuggestSell = 300
 # AiPlayerbot.BroadcastChanceSuggestSomething = 30000
 #
 # Very rude speeches

--- a/playerbot/playerbot.h
+++ b/playerbot/playerbot.h
@@ -20,6 +20,7 @@
 #include "PlayerbotMgr.h"
 #include "playerbot/RandomPlayerbotMgr.h"
 #include "ChatHelper.h"
+#include "BroadcastHelper.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotDbStore.h"
 

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -32,21 +32,7 @@ bool AutoLearnSpellAction::Execute(Event& event)
 
 void AutoLearnSpellAction::LearnSpells(std::ostringstream* out)
 {
-    if (sPlayerbotAIConfig.guildFeedbackRate && frand(0, 100) <= sPlayerbotAIConfig.guildFeedbackRate && bot->GetGuildId() && (sRandomPlayerbotMgr.IsFreeBot(bot) || !ai->HasActivePlayerMaster()))
-    {
-        Guild* guild = sGuildMgr.GetGuildById(bot->GetGuildId());
-
-        if (guild)
-        {
-            std::map<std::string, std::string> placeholders;
-            placeholders["%level"] = std::to_string(bot->GetLevel());
-
-            if (urand(0, 3))
-                guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Ding!", placeholders), LANG_UNIVERSAL);
-            else
-                guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Yay level %level!", placeholders), LANG_UNIVERSAL);
-        }
-    }
+    BroadcastHelper::BroadcastLevelup(ai, bot);
 
     if (sPlayerbotAIConfig.autoLearnTrainerSpells)
         LearnTrainerSpells(out);

--- a/playerbot/strategy/actions/DropQuestAction.cpp
+++ b/playerbot/strategy/actions/DropQuestAction.cpp
@@ -142,13 +142,7 @@ void CleanQuestLogAction::DropQuestType(Player* requester, uint8 &numQuest, uint
             continue;
 
         //Drop quest.
-        bot->SetQuestSlot(slot, 0);
-
-        //We ignore unequippable quest items in this case, its' still be equipped
-        bot->TakeQuestSourceItem(questId, false);
-
-        bot->SetQuestStatus(questId, QUEST_STATUS_NONE);
-        bot->getQuestStatusMap()[questId].m_rewarded = false;
+        bot->GetPlayerbotAI()->DropQuest(questId);
 
         numQuest--;
 

--- a/playerbot/strategy/actions/GuildManagementActions.cpp
+++ b/playerbot/strategy/actions/GuildManagementActions.cpp
@@ -90,13 +90,7 @@ bool GuildManageNearbyAction::Execute(Event& event)
 
             if (!urand(0, 30) && dCount < 2 && guild->HasRankRight(botMember->RankId, GR_RIGHT_PROMOTE))
             {
-                if (sPlayerbotAIConfig.guildFeedbackRate && frand(0, 100) <= sPlayerbotAIConfig.guildFeedbackRate && bot->GetGuildId() && !urand(0, 10))
-                {
-                    std::map<std::string, std::string> placeholders;
-                    placeholders["%name"] = player->GetName();
-
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Good job %name. You deserver this.", placeholders), LANG_UNIVERSAL);
-                }
+                BroadcastHelper::BroadcastGuildMemberPromotion(ai, bot, player);
 
                 ai->DoSpecificAction("guild promote", Event("guild management", guid), true);
                 continue;
@@ -104,13 +98,7 @@ bool GuildManageNearbyAction::Execute(Event& event)
 
             if (!urand(0, 30) && dCount > 2 && guild->HasRankRight(botMember->RankId, GR_RIGHT_DEMOTE))
             {
-                if (sPlayerbotAIConfig.guildFeedbackRate && frand(0, 100) <= sPlayerbotAIConfig.guildFeedbackRate && bot->GetGuildId() && !urand(0, 10) && (sRandomPlayerbotMgr.IsFreeBot(bot) || !ai->HasActivePlayerMaster()))
-                {
-                    std::map<std::string, std::string> placeholders;
-                    placeholders["%name"] = player->GetName();
-
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("That was awefull %name. I hate to do this but...", placeholders), LANG_UNIVERSAL);
-                }
+                BroadcastHelper::BroadcastGuildMemberDemotion(ai, bot, player);
 
                 ai->DoSpecificAction("guild demote", Event("guild management", guid), true);
                 continue;
@@ -156,10 +144,14 @@ bool GuildManageNearbyAction::Execute(Event& event)
             placeholders["%name"] = player->GetName();
             placeholders["%members"] = std::to_string(guild->GetMemberSize());
             placeholders["%guildname"] = guild->GetName();
-            placeholders["%place"] = WorldPosition(player).getAreaName(false, false);
+            AreaTableEntry const* current_area = GetAreaEntryByAreaID(sServerFacade.GetAreaId(bot));
+            AreaTableEntry const* current_zone = GetAreaEntryByAreaID(sTerrainMgr.GetZoneId(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ()));
+            placeholders["%area_name"] = current_area ? current_area->area_name[BroadcastHelper::GetLocale()] : BOT_TEXT("string_unknown_area");
+            placeholders["%zone_name"] = current_zone ? current_zone->area_name[BroadcastHelper::GetLocale()] : BOT_TEXT("string_unknown_area");
 
             std::vector<std::string> lines;
 
+            //TODO - Move these hardcoded texts to sql!
             switch ((urand(0, 10)* urand(0, 10))/10)
             {
             case 0:
@@ -181,7 +173,7 @@ bool GuildManageNearbyAction::Execute(Event& event)
                 lines.push_back(BOT_TEXT2("I'm not really good at smalltalk. Do you wanna join my guild %name/r?", placeholders));
                 break;
             case 6:
-                lines.push_back(BOT_TEXT2("Welcome to %place.... do you want to join my guild %name?", placeholders));
+                lines.push_back(BOT_TEXT2("Welcome to %zone_name.... do you want to join my guild %name?", placeholders));
                 break;
             case 7:
                 lines.push_back(BOT_TEXT2("%name, you should join my guild!", placeholders));
@@ -250,9 +242,15 @@ bool GuildLeaveAction::Execute(Event& event)
 
     Guild* guild = sGuildMgr.GetGuildById(bot->GetGuildId()); 
     
-    if (guild->GetMemberSize() >= 1000)
+    if (guild->GetMemberSize() >= sPlayerbotAIConfig.guildMaxBotLimit)
     {
-        guild->BroadcastToGuild(bot->GetSession(), "I am leaving this guild to prevent it from reaching the 1064 member limit.", LANG_UNIVERSAL);
+        std::map<std::string, std::string> placeholders;
+        placeholders["%guild_bot_limit"] = std::to_string(sPlayerbotAIConfig.guildMaxBotLimit);
+        guild->BroadcastToGuild(
+            bot->GetSession(),
+            BOT_TEXT2("I am leaving this guild to prevent it from reaching the %guild_bot_limit member limit.", placeholders),
+            LANG_UNIVERSAL
+        );
     }
 
     sPlayerbotAIConfig.logEvent(ai, "GuildLeaveAction", guild->GetName(), std::to_string(guild->GetMemberSize()));

--- a/playerbot/strategy/actions/InviteToGroupAction.cpp
+++ b/playerbot/strategy/actions/InviteToGroupAction.cpp
@@ -299,24 +299,13 @@ namespace ai
             {
                 if (guild && bot->IsInGuild(player))
                 {
-                    std::map<std::string, std::string> placeholders;
-                    placeholders["%name"] = player->GetName();
-                    placeholders["%place"] = WorldPosition(player).getAreaName(false, false);
-
-                    if (group && group->IsRaidGroup())
-                    {
-                        if (urand(0, 3))
-                            guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey anyone want to raid in %place", placeholders), LANG_UNIVERSAL);
-                        else
-                            guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey %name I'm raiding in %place do you wan to join me?", placeholders), LANG_UNIVERSAL);
-                    }
-                    else
-                    {
-                        if (urand(0, 3))
-                            guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey anyone wanna group up in %place?", placeholders), (bot->GetTeam() == ALLIANCE ? LANG_COMMON : LANG_ORCISH));
-                        else
-                            guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey %name do you want join my group? I'm heading for %place", placeholders), (bot->GetTeam() == ALLIANCE ? LANG_COMMON : LANG_ORCISH));
-                    }
+                    BroadcastHelper::BroadcastGuildGroupOrRaidInvite(
+                        ai,
+                        bot,
+                        player,
+                        group,
+                        guild
+                    );
                 }
                 else
                 {
@@ -344,7 +333,7 @@ namespace ai
 
         if (bot->InBattleGround())
             return false;
-        
+
         if (bot->InBattleGroundQueue())
             return false;
 
@@ -369,7 +358,7 @@ namespace ai
                 return false;
         }
 
-        if (ai->HasActivePlayerMaster()) //Alts do not invite randomly          
+        if (ai->HasActivePlayerMaster()) //Alts do not invite randomly
            return false;
 
         return true;
@@ -421,10 +410,10 @@ namespace ai
 
             if (playerAi)
             {
-                if (playerAi->GetGrouperType() == GrouperType::SOLO && !playerAi->HasRealPlayerMaster()) //Do not invite solo players. 
+                if (playerAi->GetGrouperType() == GrouperType::SOLO && !playerAi->HasRealPlayerMaster()) //Do not invite solo players.
                     continue;
 
-                if (playerAi->HasActivePlayerMaster()) //Do not invite alts of active players. 
+                if (playerAi->HasActivePlayerMaster()) //Do not invite alts of active players.
                     continue;
 
                 if (player->GetLevel() > bot->GetLevel() + 5) //Invite higher levels that need money so they can grind money and help out.
@@ -449,24 +438,13 @@ namespace ai
 
             if (sPlayerbotAIConfig.inviteChat && (sRandomPlayerbotMgr.IsFreeBot(bot) || !ai->HasActivePlayerMaster()))
             {
-                std::map<std::string, std::string> placeholders;
-                placeholders["%name"] = player->GetName();
-                placeholders["%place"] = WorldPosition(player).getAreaName(false, false);
-
-                if (group && group->IsRaidGroup())
-                {
-                    if (urand(0, 3))
-                        guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey anyone want to raid in %place", placeholders), LANG_UNIVERSAL);
-                    else
-                        guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey %name I'm raiding in %place do you wan to join me?", placeholders), LANG_UNIVERSAL);
-                }
-                else
-                {
-                    if (urand(0, 3))
-                        guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey anyone wanna group up in %place?", placeholders), (bot->GetTeam() == ALLIANCE ? LANG_COMMON : LANG_ORCISH));
-                    else
-                        guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Hey %name do you want join my group? I'm heading for %place", placeholders), (bot->GetTeam() == ALLIANCE ? LANG_COMMON : LANG_ORCISH));
-                }
+                BroadcastHelper::BroadcastGuildGroupOrRaidInvite(
+                    ai,
+                    bot,
+                    player,
+                    group,
+                    guild
+                );
             }
 
             return Invite(bot, player);

--- a/playerbot/strategy/actions/LootAction.cpp
+++ b/playerbot/strategy/actions/LootAction.cpp
@@ -347,23 +347,9 @@ bool StoreLootAction::Execute(Event& event)
             ai->TellPlayerNoFacing(requester, BOT_TEXT2("loot_command", args), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
         }
 
-        if (sPlayerbotAIConfig.guildFeedbackRate && frand(0, 100) <= sPlayerbotAIConfig.guildFeedbackRate && bot->GetGuildId() && !urand(0, 10) && proto->Quality >= ITEM_QUALITY_RARE && (sRandomPlayerbotMgr.IsFreeBot(bot) || !ai->HasActivePlayerMaster()))
-        {
-            Guild* guild = sGuildMgr.GetGuildById(bot->GetGuildId());
-
-            if (guild)
-            {
-                std::map<std::string, std::string> placeholders;
-                placeholders["%name"] = chat->formatItem(itemQualifier);
-
-                if (urand(0, 3))
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Yay I looted %name!", placeholders), LANG_UNIVERSAL);
-                else
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Guess who got a %name? Me!", placeholders), LANG_UNIVERSAL);
-            }
-        }
-
         sPlayerbotAIConfig.logEvent(ai, "StoreLootAction", proto->Name1, std::to_string(proto->ItemId));
+
+        BroadcastHelper::BroadcastLootingItem(ai, bot, proto, itemQualifier);
     }
 
     AI_VALUE(LootObjectStack*, "available loot")->Remove(guid);

--- a/playerbot/strategy/actions/QuestAction.cpp
+++ b/playerbot/strategy/actions/QuestAction.cpp
@@ -256,9 +256,11 @@ bool QuestAction::AcceptQuest(Player* requester, Quest const* quest, uint64 ques
     return success;
 }
 
-bool QuestObjectiveCompletedAction::Execute(Event& event)
+/*
+* For creature or gameobject
+*/
+bool QuestUpdateAddKillAction::Execute(Event& event)
 {
-    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
     WorldPacket p(event.getPacket());
     p.rpos(0);
 
@@ -266,9 +268,11 @@ bool QuestObjectiveCompletedAction::Execute(Event& event)
     ObjectGuid guid;
     p >> questId >> entry >> available >> required >> guid;
 
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
     Quest const* qInfo = sObjectMgr.GetQuestTemplate(questId);
 
-    if (entry & 0x80000000)
+    if (qInfo && (entry & 0x80000000))
     {
         entry &= 0x7FFFFFFF;
         GameObjectInfo const* info = sObjectMgr.GetGameObjectInfo(entry);
@@ -276,20 +280,160 @@ bool QuestObjectiveCompletedAction::Execute(Event& event)
         {
             ai->TellPlayer(requester, chat->formatQuestObjective(info->name, available, required), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
 
-            BroadcastHelper::BroadcastQuestObjectiveProgress(ai, bot, qInfo, available, required, info->name);
+            BroadcastHelper::BroadcastQuestUpdateAddKill(ai, bot, qInfo, available, required, info->name);
         }
     }
-    else
+    else if (qInfo)
     {
         CreatureInfo const* info = sObjectMgr.GetCreatureTemplate(entry);
         if (info)
         {
             ai->TellPlayer(requester, chat->formatQuestObjective(info->Name, available, required), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
 
-            BroadcastHelper::BroadcastQuestObjectiveProgress(ai, bot, qInfo, available, required, info->Name);
+            BroadcastHelper::BroadcastQuestUpdateAddKill(ai, bot, qInfo, available, required, info->Name);
         }
     }
+    else
+    {
 
-    sPlayerbotAIConfig.logEvent(ai, "QuestObjectiveCompletedAction", qInfo->GetTitle(), std::to_string((float)available / (float)required));
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_id"] = questId;
+        placeholders["%available"] = available;
+        placeholders["%required"] = required;
+
+        ai->TellPlayer(
+            requester,
+            BOT_TEXT2("%available/%required for questId: %quest_id", placeholders),
+            PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL,
+            false
+        );
+    }
+
+    sPlayerbotAIConfig.logEvent(ai, "QuestUpdateAddKillAction", std::to_string(questId), std::to_string((float)available / (float)required));
+    return false;
+}
+
+bool QuestUpdateAddItemAction::Execute(Event& event)
+{
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+
+    uint32 itemId, count;
+    p >> itemId >> count;
+
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
+    ItemPrototype const* itemPrototype = sObjectMgr.GetItemPrototype(itemId);
+
+    if (itemPrototype)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%item_link"] = ai->GetChatHelper()->formatItem(itemPrototype);
+        uint32 availableItemsCount = ai->GetInventoryItemsCountWithId(itemId);
+        placeholders["%quest_obj_available"] = availableItemsCount;
+
+        for (const auto& pair : ai->GetCurrentQuestsRequiringItemId(itemId))
+        {
+            placeholders["%quest_link"] = chat->formatQuest(pair.first);
+            uint32 requiredItemsCount = pair.second;
+            placeholders["%quest_obj_required"] = std::to_string(requiredItemsCount);
+            ai->TellPlayer(
+                requester,
+                BOT_TEXT2("%quest_link - %item_link %quest_obj_available/%quest_obj_required", placeholders),
+                PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL,
+                false
+            );
+
+            BroadcastHelper::BroadcastQuestUpdateAddItem(ai, bot, pair.first, availableItemsCount, requiredItemsCount, itemPrototype);
+        }
+    }
+    else {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%item_id"] = itemId;
+        placeholders["%count"] = count;
+
+        ai->TellPlayer(
+            requester,
+            BOT_TEXT2("Got %count of itemId: %item_id for quest", placeholders),
+            PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL,
+            false
+        );
+    }
+
+    sPlayerbotAIConfig.logEvent(ai, "QuestUpdateAddItemAction", std::to_string(itemId), "count: " + std::to_string(count));
+    return false;
+}
+
+bool QuestUpdateFailedAction::Execute(Event& event)
+{
+    //opcode SMSG_QUESTUPDATE_FAILED is never sent...(yet?)
+    return false;
+}
+
+bool QuestUpdateFailedTimerAction::Execute(Event& event)
+{
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+
+    uint32 questId;
+    p >> questId;
+
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
+    Quest const* qInfo = sObjectMgr.GetQuestTemplate(questId);
+
+    if (qInfo)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(qInfo);
+
+        ai->TellPlayer(requester, BOT_TEXT2("Failed timer for %quest_link, abandoning", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+        BroadcastHelper::BroadcastQuestUpdateFailedTimer(ai, bot, qInfo);
+    }
+    else
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_id"] = questId;
+
+        ai->TellPlayer(requester, BOT_TEXT2("Failed timer for %quest_id", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+    }
+
+    //drop quest
+    bot->GetPlayerbotAI()->DropQuest(questId);
+
+    sPlayerbotAIConfig.logEvent(ai, "QuestUpdateFailedTimerAction", std::to_string(questId), "FailedTimer");
+    return false;
+}
+
+bool QuestUpdateCompleteAction::Execute(Event& event)
+{
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+
+    uint32 questId;
+    p >> questId;
+
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
+    Quest const* qInfo = sObjectMgr.GetQuestTemplate(questId);
+
+    if (qInfo)
+    {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_link"] = ai->GetChatHelper()->formatQuest(qInfo);
+
+        ai->TellPlayer(requester, BOT_TEXT2("Completed %quest_link", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+        BroadcastHelper::BroadcastQuestUpdateComplete(ai, bot, qInfo);
+    }
+    else {
+        std::map<std::string, std::string> placeholders;
+        placeholders["%quest_id"] = questId;
+
+        ai->TellPlayer(requester, BOT_TEXT2("Completed %quest_id", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+    }
+
+    sPlayerbotAIConfig.logEvent(ai, "QuestUpdateCompleteAction", std::to_string(questId), "Complete");
     return false;
 }

--- a/playerbot/strategy/actions/QuestAction.cpp
+++ b/playerbot/strategy/actions/QuestAction.cpp
@@ -330,7 +330,7 @@ bool QuestUpdateAddItemAction::Execute(Event& event)
         std::map<std::string, std::string> placeholders;
         placeholders["%item_link"] = ai->GetChatHelper()->formatItem(itemPrototype);
         uint32 availableItemsCount = ai->GetInventoryItemsCountWithId(itemId);
-        placeholders["%quest_obj_available"] = availableItemsCount;
+        placeholders["%quest_obj_available"] = std::to_string(availableItemsCount);
 
         for (const auto& pair : ai->GetCurrentQuestsRequiringItemId(itemId))
         {
@@ -394,7 +394,7 @@ bool QuestUpdateFailedTimerAction::Execute(Event& event)
     else
     {
         std::map<std::string, std::string> placeholders;
-        placeholders["%quest_id"] = questId;
+        placeholders["%quest_id"] = std::to_string(questId);
 
         ai->TellPlayer(requester, BOT_TEXT2("Failed timer for %quest_id", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
     }
@@ -429,7 +429,7 @@ bool QuestUpdateCompleteAction::Execute(Event& event)
     }
     else {
         std::map<std::string, std::string> placeholders;
-        placeholders["%quest_id"] = questId;
+        placeholders["%quest_id"] = std::to_string(questId);
 
         ai->TellPlayer(requester, BOT_TEXT2("Completed %quest_id", placeholders), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
     }

--- a/playerbot/strategy/actions/QuestAction.cpp
+++ b/playerbot/strategy/actions/QuestAction.cpp
@@ -242,6 +242,8 @@ bool QuestAction::AcceptQuest(Player* requester, Quest const* quest, uint64 ques
 
         if (bot->GetQuestStatus(questId) != QUEST_STATUS_NONE && bot->GetQuestStatus(questId) != QUEST_STATUS_AVAILABLE)
         {
+            BroadcastHelper::BroadcastQuestAccepted(ai, bot, quest);
+
             sPlayerbotAIConfig.logEvent(ai, "AcceptQuestAction", quest->GetTitle(), std::to_string(quest->GetQuestId()));
             outputMessage = BOT_TEXT2("quest_accepted", args);
             success = true;
@@ -264,6 +266,8 @@ bool QuestObjectiveCompletedAction::Execute(Event& event)
     ObjectGuid guid;
     p >> questId >> entry >> available >> required >> guid;
 
+    Quest const* qInfo = sObjectMgr.GetQuestTemplate(questId);
+
     if (entry & 0x80000000)
     {
         entry &= 0x7FFFFFFF;
@@ -271,6 +275,8 @@ bool QuestObjectiveCompletedAction::Execute(Event& event)
         if (info)
         {
             ai->TellPlayer(requester, chat->formatQuestObjective(info->name, available, required), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+            BroadcastHelper::BroadcastQuestObjectiveProgress(ai, bot, qInfo, available, required, info->name);
         }
     }
     else
@@ -279,10 +285,11 @@ bool QuestObjectiveCompletedAction::Execute(Event& event)
         if (info)
         {
             ai->TellPlayer(requester, chat->formatQuestObjective(info->Name, available, required), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+            BroadcastHelper::BroadcastQuestObjectiveProgress(ai, bot, qInfo, available, required, info->Name);
         }
     }
 
-    Quest const* qInfo = sObjectMgr.GetQuestTemplate(questId);
     sPlayerbotAIConfig.logEvent(ai, "QuestObjectiveCompletedAction", qInfo->GetTitle(), std::to_string((float)available / (float)required));
     return false;
 }

--- a/playerbot/strategy/actions/QuestAction.h
+++ b/playerbot/strategy/actions/QuestAction.h
@@ -21,10 +21,46 @@ namespace ai
         bool ProcessQuests(WorldObject* questGiver);
     };
     
-    class QuestObjectiveCompletedAction : public Action 
+    class QuestUpdateAddKillAction : public Action
     {
     public:
-        QuestObjectiveCompletedAction(PlayerbotAI* ai) : Action(ai, "quest objective completed") {}
+        QuestUpdateAddKillAction(PlayerbotAI* ai) : Action(ai, "quest update add kill") {}
+
+    public:
+        virtual bool Execute(Event& event);
+    };
+
+    class QuestUpdateAddItemAction : public Action
+    {
+    public:
+        QuestUpdateAddItemAction(PlayerbotAI* ai) : Action(ai, "quest update add item") {}
+
+    public:
+        virtual bool Execute(Event& event);
+    };
+
+    class QuestUpdateFailedAction : public Action
+    {
+    public:
+        QuestUpdateFailedAction(PlayerbotAI* ai) : Action(ai, "quest update failed") {}
+
+    public:
+        virtual bool Execute(Event& event);
+    };
+
+    class QuestUpdateFailedTimerAction : public Action
+    {
+    public:
+        QuestUpdateFailedTimerAction(PlayerbotAI* ai) : Action(ai, "quest update failed timer") {}
+
+    public:
+        virtual bool Execute(Event& event);
+    };
+
+    class QuestUpdateCompleteAction : public Action
+    {
+    public:
+        QuestUpdateCompleteAction(PlayerbotAI* ai) : Action(ai, "quest update complete") {}
 
     public:
         virtual bool Execute(Event& event);

--- a/playerbot/strategy/actions/SayAction.h
+++ b/playerbot/strategy/actions/SayAction.h
@@ -22,6 +22,7 @@ namespace ai
         ChatReplyAction(PlayerbotAI* ai) : Action(ai, "chat message") {}
         virtual bool Execute(Event& event) { return true; }
         bool isUseful();
+        static std::string CreateReplyMessage(Player* bot, std::string incomingMessage, uint32 guid1, std::string name);
         static void ChatReplyDo(Player* bot, uint32 type, uint32 guid1, uint32 guid2, std::string msg, std::string chanName, std::string name);
     };
 }

--- a/playerbot/strategy/actions/SayAction.h
+++ b/playerbot/strategy/actions/SayAction.h
@@ -22,7 +22,12 @@ namespace ai
         ChatReplyAction(PlayerbotAI* ai) : Action(ai, "chat message") {}
         virtual bool Execute(Event& event) { return true; }
         bool isUseful();
-        static std::string CreateReplyMessage(Player* bot, std::string incomingMessage, uint32 guid1, std::string name);
         static void ChatReplyDo(Player* bot, uint32 type, uint32 guid1, uint32 guid2, std::string msg, std::string chanName, std::string name);
+        static bool HandleThunderfuryReply(Player* bot, ChatChannelSource chatChannelSource, std::string msg, std::string name);
+        static bool HandleToxicLinksReply(Player* bot, ChatChannelSource chatChannelSource, std::string msg, std::string name);
+        static bool HandleWTBItemsReply(Player* bot, ChatChannelSource chatChannelSource, std::string msg, std::string name);
+        static bool HandleLFGQuestsReply(Player* bot, ChatChannelSource chatChannelSource, std::string msg, std::string name);
+        static bool SendGeneralResponse(Player* bot, ChatChannelSource chatChannelSource, std::string responseMessage, std::string name);
+        static std::string GenerateReplyMessage(Player* bot, std::string incomingMessage, uint32 guid1, std::string name);
     };
 }

--- a/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
+++ b/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
@@ -32,6 +32,7 @@ SuggestWhatToDoAction::SuggestWhatToDoAction(PlayerbotAI* ai, std::string name)
     suggestions.push_back(&SuggestWhatToDoAction::something);
     suggestions.push_back(&SuggestWhatToDoAction::somethingToxic);
     suggestions.push_back(&SuggestWhatToDoAction::toxicLinks);
+    suggestions.push_back(&SuggestWhatToDoAction::thunderfury);
 }
 
 bool SuggestWhatToDoAction::isUseful()
@@ -256,6 +257,11 @@ void SuggestWhatToDoAction::somethingToxic()
 void SuggestWhatToDoAction::toxicLinks()
 {
     BroadcastHelper::BroadcastSuggestToxicLinks(ai, bot);
+}
+
+void SuggestWhatToDoAction::thunderfury()
+{
+    BroadcastHelper::BroadcastSuggestThunderfury(ai, bot);
 }
 
 class FindTradeItemsVisitor : public IterateItemsVisitor

--- a/playerbot/strategy/actions/SuggestWhatToDoAction.h
+++ b/playerbot/strategy/actions/SuggestWhatToDoAction.h
@@ -18,8 +18,8 @@ namespace ai
         void grindMaterials();
         void grindReputation();
         void something();
-        void trade();
-        void spam(std::string msg, uint8 flags = 0, bool worldChat = false, bool guild = false);
+        void somethingToxic();
+        void toxicLinks();
 
         std::vector<uint32> GetIncompletedQuests();
 

--- a/playerbot/strategy/actions/SuggestWhatToDoAction.h
+++ b/playerbot/strategy/actions/SuggestWhatToDoAction.h
@@ -20,6 +20,7 @@ namespace ai
         void something();
         void somethingToxic();
         void toxicLinks();
+        void thunderfury();
 
         std::vector<uint32> GetIncompletedQuests();
 

--- a/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
+++ b/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
@@ -108,7 +108,7 @@ void TalkToQuestGiverAction::RewardNoItem(Quest const* quest, WorldObject* quest
         bot->RewardQuest(quest, 0, questGiver, false);
         out = BOT_TEXT2("quest_status_completed", args);
 
-        BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
+        BroadcastHelper::BroadcastQuestTurnedIn(ai, bot, quest);
     }
     else
     {
@@ -130,7 +130,7 @@ void TalkToQuestGiverAction::RewardSingleItem(Quest const* quest, WorldObject* q
         bot->RewardQuest(quest, index, questGiver, true);
         out = BOT_TEXT2("quest_status_complete_single_reward", args);
 
-        BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
+        BroadcastHelper::BroadcastQuestTurnedIn(ai, bot, quest);
     }
     else
     {
@@ -200,7 +200,7 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
             args["%item"] = chat->formatItem(proto);
             out = BOT_TEXT2("quest_status_complete_single_reward", args);
 
-            BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
+            BroadcastHelper::BroadcastQuestTurnedIn(ai, bot, quest);
         }
 
         bot->RewardQuest(quest, *bestIds.begin(), questGiver, true);
@@ -228,7 +228,7 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
                 args["%item"] = chat->formatItem(proto);
                 out = BOT_TEXT2("quest_status_complete_single_reward", args);
 
-                BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
+                BroadcastHelper::BroadcastQuestTurnedIn(ai, bot, quest);
             }
 
             bot->RewardQuest(quest, *bestIds.begin(), questGiver, true);

--- a/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
+++ b/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
@@ -107,6 +107,8 @@ void TalkToQuestGiverAction::RewardNoItem(Quest const* quest, WorldObject* quest
     {
         bot->RewardQuest(quest, 0, questGiver, false);
         out = BOT_TEXT2("quest_status_completed", args);
+
+        BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
     }
     else
     {
@@ -114,7 +116,7 @@ void TalkToQuestGiverAction::RewardNoItem(Quest const* quest, WorldObject* quest
     }
 }
 
-void TalkToQuestGiverAction::RewardSingleItem(Quest const* quest, WorldObject* questGiver, std::string& out) 
+void TalkToQuestGiverAction::RewardSingleItem(Quest const* quest, WorldObject* questGiver, std::string& out)
 {
     int index = 0;
     ItemPrototype const *item = sObjectMgr.GetItemPrototype(quest->RewChoiceItemId[index]);
@@ -127,6 +129,8 @@ void TalkToQuestGiverAction::RewardSingleItem(Quest const* quest, WorldObject* q
     {
         bot->RewardQuest(quest, index, questGiver, true);
         out = BOT_TEXT2("quest_status_complete_single_reward", args);
+
+        BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
     }
     else
     {
@@ -142,7 +146,7 @@ ItemIds TalkToQuestGiverAction::BestRewards(Quest const* quest)
     {
         return returnIds;
     }
-    else if (quest->GetRewChoiceItemsCount() == 1)    
+    else if (quest->GetRewChoiceItemsCount() == 1)
     {
         return { 0 };
     }
@@ -195,6 +199,8 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
         {
             args["%item"] = chat->formatItem(proto);
             out = BOT_TEXT2("quest_status_complete_single_reward", args);
+
+            BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
         }
 
         bot->RewardQuest(quest, *bestIds.begin(), questGiver, true);
@@ -221,6 +227,8 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
             {
                 args["%item"] = chat->formatItem(proto);
                 out = BOT_TEXT2("quest_status_complete_single_reward", args);
+
+                BroadcastHelper::BroadcastQuestCompleted(ai, bot, quest);
             }
 
             bot->RewardQuest(quest, *bestIds.begin(), questGiver, true);

--- a/playerbot/strategy/actions/TalkToQuestGiverAction.h
+++ b/playerbot/strategy/actions/TalkToQuestGiverAction.h
@@ -13,7 +13,7 @@ namespace ai
     protected:
         virtual bool ProcessQuest(Player* requester, Quest const* quest, WorldObject* questGiver) override;
 
-    private:        
+    private:
         bool TurnInQuest(Player* requester, Quest const* quest, WorldObject* questGiver, std::string& out);
         void RewardNoItem(Quest const* quest, WorldObject* questGiver, std::string& out);
         void RewardSingleItem(Quest const* quest, WorldObject* questGiver, std::string& out);

--- a/playerbot/strategy/actions/WorldPacketActionContext.h
+++ b/playerbot/strategy/actions/WorldPacketActionContext.h
@@ -71,7 +71,11 @@ namespace ai
             creators["remember taxi"] = &WorldPacketActionContext::remember_taxi;
             creators["accept trade"] = &WorldPacketActionContext::accept_trade;
             creators["store loot"] = &WorldPacketActionContext::store_loot;
-            creators["quest objective completed"] = &WorldPacketActionContext::quest_objective_completed;
+            creators["quest update add kill"] = &WorldPacketActionContext::quest_update_add_kill;
+            creators["quest update add item"] = &WorldPacketActionContext::quest_update_add_item;
+            creators["quest update failed"] = &WorldPacketActionContext::quest_update_failed;
+            creators["quest update failed timer"] = &WorldPacketActionContext::quest_update_failed_timer;
+            creators["quest update complete"] = &WorldPacketActionContext::quest_update_complete;
             creators["party command"] = &WorldPacketActionContext::party_command;
             creators["tell cast failed"] = &WorldPacketActionContext::tell_cast_failed;
             creators["accept duel"] = &WorldPacketActionContext::accept_duel;
@@ -107,7 +111,11 @@ namespace ai
         static Action* accept_duel(PlayerbotAI* ai) { return new AcceptDuelAction(ai); }
         static Action* tell_cast_failed(PlayerbotAI* ai) { return new TellCastFailedAction(ai); }
         static Action* party_command(PlayerbotAI* ai) { return new PartyCommandAction(ai); }
-        static Action* quest_objective_completed(PlayerbotAI* ai) { return new QuestObjectiveCompletedAction(ai); }
+        static Action* quest_update_add_kill(PlayerbotAI* ai) { return new QuestUpdateAddKillAction(ai); }
+        static Action* quest_update_add_item(PlayerbotAI* ai) { return new QuestUpdateAddItemAction(ai); }
+        static Action* quest_update_failed(PlayerbotAI* ai) { return new QuestUpdateFailedAction(ai); }
+        static Action* quest_update_failed_timer(PlayerbotAI* ai) { return new QuestUpdateFailedTimerAction(ai); }
+        static Action* quest_update_complete(PlayerbotAI* ai) { return new QuestUpdateCompleteAction(ai); }
         static Action* store_loot(PlayerbotAI* ai) { return new StoreLootAction(ai); }
         static Action* accept_trade(PlayerbotAI* ai) { return new TradeStatusAction(ai); }
         static Action* remember_taxi(PlayerbotAI* ai) { return new RememberTaxiAction(ai); }

--- a/playerbot/strategy/actions/XpGainAction.cpp
+++ b/playerbot/strategy/actions/XpGainAction.cpp
@@ -34,25 +34,12 @@ bool XpGainAction::Execute(Event& event)
     AI_VALUE(LootObjectStack*, "available loot")->Add(guid);
     ai->AccelerateRespawn(guid);
 
-    if (sPlayerbotAIConfig.guildFeedbackRate && frand(0, 100) <= sPlayerbotAIConfig.guildFeedbackRate && !urand(0,10) && sRandomPlayerbotMgr.IsFreeBot(bot) && (!ai->HasRealPlayerMaster() || !urand(0,10)))
+    Creature* creature = ai->GetCreature(guid);
+
+    //if (creature && ((creature->IsElite() && !creature->GetMap()->IsDungeon()) || creature->IsWorldBoss() || creature->GetLevel() > DEFAULT_MAX_LEVEL + 1 || creature->GetLevel() > bot->GetLevel() + 4))
+    if (creature && !creature->GetMap()->IsDungeon())
     {
-        Creature* creature = ai->GetCreature(guid); 
-
-        if (creature && ((creature->IsElite() && !creature->GetMap()->IsDungeon()) || creature->IsWorldBoss() || creature->GetLevel() > DEFAULT_MAX_LEVEL + 1 || creature->GetLevel() > bot->GetLevel() + 4))
-        {
-            Guild* guild = sGuildMgr.GetGuildById(bot->GetGuildId());
-
-            if (guild)
-            {
-                std::map<std::string, std::string> placeholders;
-                placeholders["%name"] = creature->GetName();
-
-                if(urand(0,3))
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Wow I just killed %name!", placeholders), LANG_UNIVERSAL);
-                else
-                    guild->BroadcastToGuild(bot->GetSession(), BOT_TEXT2("Awesome that %name went down quickly!", placeholders), LANG_UNIVERSAL);
-            }
-        }
+        BroadcastHelper::BroadcastKill(ai, bot, creature);
     }
 
     if (!sRandomPlayerbotMgr.IsFreeBot(bot) || sPlayerbotAIConfig.playerbotsXPrate == 1)

--- a/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -7,7 +7,11 @@ using namespace ai;
 WorldPacketHandlerStrategy::WorldPacketHandlerStrategy(PlayerbotAI* ai) : PassTroughStrategy(ai)
 {
     supported.push_back("loot start roll");
-    supported.push_back("quest objective completed");
+    supported.push_back("quest update add kill");
+    supported.push_back("quest update add item");
+    supported.push_back("quest update failed");
+    supported.push_back("quest update failed timer");
+    supported.push_back("quest update complete");
     supported.push_back("party command");
     supported.push_back("ready check");
     supported.push_back("uninvite");

--- a/playerbot/strategy/triggers/WorldPacketTriggerContext.h
+++ b/playerbot/strategy/triggers/WorldPacketTriggerContext.h
@@ -30,7 +30,11 @@ namespace ai
             creators["activate taxi"] = &WorldPacketTriggerContext::taxi;
             creators["trade status"] = &WorldPacketTriggerContext::trade_status;
             creators["loot response"] = &WorldPacketTriggerContext::loot_response;
-            creators["quest objective completed"] = &WorldPacketTriggerContext::quest_objective_completed;
+            creators["quest update add kill"] = &WorldPacketTriggerContext::quest_update_add_kill;
+            creators["quest update add item"] = &WorldPacketTriggerContext::quest_update_add_item;
+            creators["quest update failed"] = &WorldPacketTriggerContext::quest_update_failed;
+            creators["quest update failed timer"] = &WorldPacketTriggerContext::quest_update_failed_timer;
+            creators["quest update complete"] = &WorldPacketTriggerContext::quest_update_complete;
             creators["item push result"] = &WorldPacketTriggerContext::item_push_result;
             creators["party command"] = &WorldPacketTriggerContext::party_command;
             creators["taxi done"] = &WorldPacketTriggerContext::taxi_done;
@@ -79,7 +83,11 @@ namespace ai
         static Trigger* taxi_done(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "taxi done"); }
         static Trigger* party_command(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "party command"); }
         static Trigger* item_push_result(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "item push result"); }
-        static Trigger* quest_objective_completed(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest objective completed"); }
+        static Trigger* quest_update_add_kill(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest update add kill"); }
+        static Trigger* quest_update_add_item(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest update add item"); }
+        static Trigger* quest_update_failed(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest update failed"); }
+        static Trigger* quest_update_failed_timer(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest update failed timer"); }
+        static Trigger* quest_update_complete(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "quest update complete"); }
         static Trigger* loot_response(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "loot response"); }
         static Trigger* trade_status(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "trade status"); }
         static Trigger* cannot_equip(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "cannot equip"); }

--- a/sql/world/ai_playerbot_texts.sql
+++ b/sql/world/ai_playerbot_texts.sql
@@ -2556,16 +2556,39 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 -- %my_race
 -- %my_class
 -- %my_level
-('broadcast_quest_objective_completed_generic', 'Finally done with the %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_objective_completed_generic', 'finally got %quest_obj_available/%quest_obj_required of %quest_obj_name for the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_objective_completed_generic', '%quest_obj_full_formatted for the %quest_link, at last', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_completed', 'Finally done with the %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_completed', 'finally got %quest_obj_available/%quest_obj_required of %quest_obj_name for the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_completed', '%quest_obj_full_formatted for the %quest_link, at last', 0, 0, '', '', '', '', '', '', '', ''),
 
 
 
-('broadcast_quest_objective_progress_generic', 'Oof, got %quest_obj_available/%quest_obj_required %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_objective_progress_generic', 'still need %quest_obj_missing more of %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_objective_progress_generic', '%quest_obj_full_formatted, still working on %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_progress', 'Oof, got %quest_obj_available/%quest_obj_required %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_progress', 'still need %quest_obj_missing more of %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_kill_objective_progress', '%quest_obj_full_formatted, still working on %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
 
+
+
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %quest_obj_available
+-- %quest_obj_required
+-- %quest_obj_missing
+-- %item_link
+-- %quest_obj_full_formatted
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_update_add_item_objective_completed', 'Finally done with the %item_link for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_item_objective_completed', 'finally got %quest_obj_available/%quest_obj_required of %item_link for the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_item_objective_completed', '%quest_obj_full_formatted for the %quest_link, at last', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_quest_update_add_item_objective_progress', 'Oof, got %quest_obj_available/%quest_obj_required %item_link for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_item_objective_progress', 'still need %quest_obj_missing more of %item_link for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_add_item_objective_progress', '%quest_obj_full_formatted, still working on %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
 
 
 -- usable placeholders:
@@ -2575,11 +2598,34 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 -- %my_race
 -- %my_class
 -- %my_level
-('broadcast_quest_completed_generic', 'Yess, I have finally completed the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_completed_generic', 'completed the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_completed_generic', 'managed to finish %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_completed_generic', 'just finished %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
-('broadcast_quest_completed_generic', 'just finished %quest_link in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_failed_timer', 'Failed to finish %quest_link in time...', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_failed_timer', 'Ran out of time for %quest_link :(', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_update_complete', 'I have completed all objectives for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_complete', 'Completed all objectives for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_update_complete', 'Gonna turn in the %quest_link soon, just finished all objectives', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_turned_in', 'Yess, I have finally turned in the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_turned_in', 'turned in the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_turned_in', 'managed to finish %quest_link, just turned in', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_turned_in', 'just turned in %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_turned_in', 'just turned in %quest_link in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
 
 
 

--- a/sql/world/ai_playerbot_texts.sql
+++ b/sql/world/ai_playerbot_texts.sql
@@ -2459,591 +2459,1308 @@ CREATE TABLE IF NOT EXISTS `ai_playerbot_texts` (
   `text_loc7` varchar(1024) NOT NULL DEFAULT '',
   `text_loc8` varchar(1024) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=501 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
 
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (1, 'suggest_instance', 'Anyone wants %instance?', 0, 0, '', 'Quelqu\'un fait %instance ?', '', '', '', '¿Alguien quiere ir a %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (2, 'suggest_instance', 'Any groups for %instance?', 0, 0, '', 'Des groupes pour %instance ?', '', '', '', '¿Algún grupo para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (3, 'suggest_instance', 'Need help for %instance?', 0, 0, '', 'Besoin d\'aide pour %instance ?', '', '', '', '¿Alguien necesita ayuda con %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (4, 'suggest_instance', 'LFD: %instance.', 0, 0, '', 'Cherche à faire : %instance', '', '', '', 'Busco grupo para %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (5, 'suggest_instance', 'Anyone needs %role for %instance?', 0, 0, '', 'Quelqu\'un a besoin de %role pour %instance ?', '', '', '', '¿Alguien necesita un %role para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (6, 'suggest_instance', 'Missing %role for %instance?', 0, 0, '', '%role manquant pour %instance ?', '', '', '', '¿Buscando un %role para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (7, 'suggest_instance', 'Can be a %role for %instance.', 0, 0, '', 'Peut être un %role pour %instance', '', '', '', 'Puedo ser un %role para %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (8, 'suggest_instance', 'Need help with %instance?', 0, 0, '', 'Besoin d\'aide avec %instance ?', '', '', '', '¿Alguien necesita ayuda con %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (9, 'suggest_instance', 'Need %role help with %instance?', 0, 0, '', 'Besoin d\'aide %role avec %instance ?', '', '', '', '¿Necesitas ayuda de %role con %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (10, 'suggest_instance', 'Anyone needs gear from %instance?', 0, 0, '', 'Quelqu\'un a besoin d\'équipement de %instance ?', '', '', '', '¿Alguien necesita equipo de %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (11, 'suggest_instance', 'A little grind in %instance?', 0, 0, '', 'Un peu de grind dans %instance ?', '', '', '', '¿Un poco de farmeo en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (12, 'suggest_instance', 'WTR %instance', 0, 0, '', 'Cherche à rejoindre %instance', '', '', '', 'WTR %instance', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (13, 'suggest_instance', 'Need help for %instance.', 0, 0, '', 'Besoin d\'aide pour %instance', '', '', '', 'Necesito ayuda para %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (14, 'suggest_instance', 'Wanna run %instance.', 0, 0, '', 'Je veux faire %instance', '', '', '', 'Quiero hacer %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (15, 'suggest_instance', '%role looks for %instance.', 0, 0, '', '%role recherche %instance', '', '', '', '%role busca %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (16, 'suggest_instance', 'What about %instance?', 0, 0, '', 'Et %instance ?', '', '', '', '¿Qué pasa con %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (17, 'suggest_instance', 'Who wants to farm %instance?', 0, 0, '', 'Qui veut exploiter %instance ?', '', '', '', '¿Quién quiere farmear %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (18, 'suggest_instance', 'Go in %instance?', 0, 0, '', 'Aller à %instance ?', '', '', '', '¿Vamos a %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (19, 'suggest_instance', 'Looking for %instance.', 0, 0, '', 'À la recherche de %instance', '', '', '', 'Buscando gente para %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (20, 'suggest_instance', 'Need help with %instance quests?', 0, 0, '', 'Besoin d\'aide pour les quêtes %instance ?', '', '', '', '¿Necesitas ayuda con las misiones en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (21, 'suggest_instance', 'Wanna quest in %instance.', 0, 0, '', 'Je veux une quête dans %instance', '', '', '', 'Quiero hacer una vuelta rapida en %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (22, 'suggest_instance', 'Anyone with quests in %instance?', 0, 0, '', 'Quelqu\'un a des quêtes dans %instance ?', '', '', '', '¿Alguien con misiones en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (23, 'suggest_instance', 'Could help with quests in %instance.', 0, 0, '', 'Peux aider pour les quêtes dans %instance', '', '', '', 'Podría ayudar con las misiones en %instance.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (24, 'suggest_instance', '%role: any place in group for %instance?', 0, 0, '', '%role : n\'importe quel rôle dans le groupe pour %instance ?', '', '', '', '%role: ¿algún lugar en el grupo para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (25, 'suggest_instance', 'Does anybody still run %instance this days?', 0, 0, '', 'Est-ce que quelqu\'un fait encore %instance ces jours-ci ?', '', '', '', '¿Alguien todavía hace %instance estos días?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (26, 'suggest_instance', '%instance: anyone wants to take a %role?', 0, 0, '', '%instance : quelqu\'un veut prendre un %role ?', '', '', '', '¿Alguien quiere un %role para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (27, 'suggest_instance', 'Is there any point being %role in %instance?', 0, 0, '', 'Y a-t-il un intérêt à être %role dans %instance ?', '', '', '', '¿Tiene algún sentido ser %role en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (28, 'suggest_instance', 'It is really worth to go to %instance?', 0, 0, '', 'Cela vaut-il vraiment la peine d\'aller dans %instance ?', '', '', '', '¿Realmente vale la pena ir a %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (29, 'suggest_instance', 'Anybody needs more people for %instance?', 0, 0, '', 'Quelqu\'un a besoin de plus de personnes pour %instance ?', '', '', '', '¿Alguien necesita más personas para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (30, 'suggest_instance', '%instance bosses drop good gear. Wanna run?', 0, 0, '', 'Les boss %instance drop du bon équipement. Tu veux courir ?', '', '', '', 'Los jefes en %instance sueltan buen equipo. ¿Quieres ir?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (31, 'suggest_instance', 'What about %instance?', 0, 0, '', 'Et %instance ?', '', '', '', '¿Qué pasa con %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (32, 'suggest_instance', 'Anybody needs %role?', 0, 0, '', 'Quelqu\'un a besoin de %role ?', '', '', '', '¿Alguien necesita un %role?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (33, 'suggest_instance', 'Anyone needs %role?', 0, 0, '', 'Quelqu\'un a besoin de %role ?', '', '', '', '¿Alguien hacer un grupo con un %role?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (34, 'suggest_instance', 'Who wants %instance?', 0, 0, '', 'Qui veut %instance ?', '', '', '', '¿Quién quiere %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (35, 'suggest_instance', 'Can anybody summon me at %instance?', 0, 0, '', 'Quelqu\'un peut-il me TP à %instance ?', '', '', '', '¿Alguien puede invocarme en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (36, 'suggest_instance', 'Meet me in %instance', 0, 0, '', 'Rencontrez-moi dans %instance', '', '', '', 'Encuéntrame en %instance', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (37, 'suggest_instance', 'Wanna quick %instance run', 0, 0, '', 'Je veux faire rapidement %instance', '', '', '', 'Quiero ir a %instance rápido', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (38, 'suggest_instance', 'Wanna full %instance run', 0, 0, '', 'Je veux faire %instance complètement', '', '', '', 'Quiero hacer %instance completa', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (39, 'suggest_instance', 'How many times were you in %instance?', 0, 0, '', 'Combien de fois avez-vous été dans %instance ?', '', '', '', '¿Cuántas veces estuviste en %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (40, 'suggest_instance', 'Another %instance run?', 0, 0, '', 'Une autre exécution de %instance ?', '', '', '', '¿Otra vuelta en %instance ?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (41, 'suggest_instance', 'Wiped in %instance? Take me instead!', 0, 0, '', 'Effacé dans %instance ? Prends-moi plutôt !', '', '', '', '¿Borrado en %instance? ¡Tómame a mí en su lugar!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (42, 'suggest_instance', 'Take me in %instance please.', 0, 0, '', 'Prenez-moi dans %instance s\'il vous plaît.', '', '', '', 'Tómame en %instance por favor.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (43, 'suggest_instance', 'Quick %instance run?', 0, 0, '', 'Faire rapidement %instance ?', '', '', '', '¿Partida rápida de %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (44, 'suggest_instance', 'Full %instance run?', 0, 0, '', 'Clean complet dans %instance ?', '', '', '', '¿Partida completa de %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (45, 'suggest_instance', 'Who can take %role to %instance?', 0, 0, '', 'Qui peut prendre %role à %instance ?', '', '', '', '¿Quién puede ir de %role para %instance?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (46, 'suggest_quest', 'Need help with %quest?', 0, 0, '', 'Besoin d\'aide avec %quest ?', '', '', '', '¿Alguien necesita ayuda con %quest?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (47, 'suggest_quest', 'Anyone wants to share %quest?', 0, 0, '', 'Quelqu\'un veut partager %quest ?', '', '', '', '¿Alguien quiere hacer %quest?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (48, 'suggest_quest', 'Anyone doing %quest?', 0, 0, '', 'Quelqu\'un fait %quest ?', '', '', '', '¿Alguien está haciendo %quest?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (49, 'suggest_quest', 'Wanna do %quest.', 0, 0, '', 'Je veux faire %quest', '', '', '', '¿Una ayudita con %quest?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (50, 'suggest_trade', 'Anyone to farm %category?', 0, 0, '', 'Quelqu\'un pour farm %category ?', '', '', '', '¿Alguien para farmear %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (51, 'suggest_trade', 'Looking for help farming %category.', 0, 0, '', 'Vous cherchez de l\'aide pour farmer %category', '', '', '', 'Buscando ayuda para farmear %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (52, 'suggest_trade', 'Damn %category are so expensive!', 0, 0, '', 'Putain %category sont si chers!', '', '', '', '¡Malditas %category son tan caras!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (53, 'suggest_trade', 'Wanna %category.', 0, 0, '', 'Je veux %category', '', '', '', 'Quiero %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (54, 'suggest_trade', 'Need help with %category.', 0, 0, '', 'Besoin d\'aide avec %category', '', '', '', 'Necesito ayuda con %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (55, 'suggest_trade', 'WTB %category.', 0, 0, '', 'Cherche à acheter %category', '', '', '', 'Quiero comprar %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (56, 'suggest_trade', 'Anyone interested in %category?', 0, 0, '', 'Quiconque est intéressé par %category?', '', '', '', '¿Alguien interesado en %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (57, 'suggest_trade', 'WTS %category.', 0, 0, '', 'Cherche à vendre %category', '', '', '', 'Quiero vender %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (58, 'suggest_trade', 'I am selling %category cheaper than AH.', 0, 0, '', 'Je vends %category moins cher que l\'hôtel des ventes.', '', '', '', 'Estoy vendiendo %category más barato que en las subastas.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (59, 'suggest_trade', 'Who wants to farm %category?', 0, 0, '', 'Qui veut farmer %category ?', '', '', '', '¿Quién quiere farmear %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (60, 'suggest_trade', 'Wanna farm %category.', 0, 0, '', 'Je veux farmer %category', '', '', '', 'Quiero farmear %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (61, 'suggest_trade', 'Looking for party after %category.', 0, 0, '', 'Recherche de partie après %category', '', '', '', 'Buscando grupo después de %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (62, 'suggest_trade', 'Any %category are appreciated.', 0, 0, '', 'Toute %category est appréciée.', '', '', '', 'Cualquier %category es apreciada.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (63, 'suggest_trade', 'Buying anything of %category.', 0, 0, '', 'Acheter quoi que ce soit de %category', '', '', '', 'Comprando algo de %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (64, 'suggest_trade', 'Wow, anybody is farming %category!', 0, 0, '', 'Wow, quelqu\'un farm %category !', '', '', '', '¡Guau, alguien está farmeando %category!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (65, 'suggest_trade', '%category are selling mad in the AH.', 0, 0, '', '%category se vendent follement dans l\'hôtel des ventes.', '', '', '', '%category están vendiendo locos en las subastas.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (66, 'suggest_trade', 'AH is hot for %category.', 0, 0, '', 'Hôtel des ventes est chaud pour %category', '', '', '', 'Las subastas estan caliente para %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (67, 'suggest_trade', '%category are on the market.', 0, 0, '', '%category sont sur le marché.', '', '', '', '%category están en el mercado.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (68, 'suggest_trade', 'Wanna trade some %category.', 0, 0, '', 'Je veux échanger une %category', '', '', '', 'Quiero intercambiar alguna %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (69, 'suggest_trade', 'Need more %category.', 0, 0, '', 'Besoin de plus de %category', '', '', '', 'Necesito más %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (70, 'suggest_trade', 'Anybody can spare some %category?', 0, 0, '', 'Quelqu\'un peut-il épargner une %category ?', '', '', '', '¿Alguien puede ahorrar algo de %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (71, 'suggest_trade', 'Who wants %category?', 0, 0, '', 'Qui veut %category ?', '', '', '', '¿Quién quiere %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (72, 'suggest_trade', 'Some %category please?', 0, 0, '', 'Une %category s\'il vous plaît ?', '', '', '', '¿Alguna %category, por favor?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (73, 'suggest_trade', 'I should have got skill for %category.', 0, 0, '', 'J\'aurais dû avoir une compétence pour %category', '', '', '', 'Debería haber adquirido habilidad para %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (74, 'suggest_trade', 'I am dying for %category.', 0, 0, '', 'Je meurs d\'envie pour %category', '', '', '', 'Me muero por %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (75, 'suggest_trade', 'People are killing for %category.', 0, 0, '', 'Les gens tuent pour %category', '', '', '', 'La gente está matando por %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (76, 'suggest_trade', '%category is a great bargain!', 0, 0, '', '%category est une bonne affaire!', '', '', '', '%category es una gran ganga!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (77, 'suggest_trade', 'Everybody is mad for %category!', 0, 0, '', 'Tout le monde est fou de %category !', '', '', '', '¡Todo el mundo está loco por %category!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (78, 'suggest_trade', 'Where is the best place to farm for %category?', 0, 0, '', 'Quel est le meilleur endroit pour farmer pour %category ?', '', '', '', '¿Dónde está el mejor lugar para farmear para %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (79, 'suggest_trade', 'I am all set for %category.', 0, 0, '', 'Je suis prêt pour %category', '', '', '', 'Estoy listo para %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (80, 'suggest_trade', 'Is it good to sell %category?', 0, 0, '', 'Est-il bon de vendre %category ?', '', '', '', '¿Es bueno vender %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (81, 'suggest_trade', 'I\'d probably keep all my %category with me.', 0, 0, '', 'Je garderais probablement toute ma %category avec moi.', '', '', '', 'Probablemente mantendría toda mi %category conmigo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (82, 'suggest_trade', 'Need group? Maybe to farm some %category?', 0, 0, '', 'Besoin de groupe ? Peut-être pour farmer une certaine %category ?', '', '', '', '¿Necesitas un grupo? ¿Tal vez para farmear alguna %category?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (83, 'suggest_trade', 'I am still thinking about %category.', 0, 0, '', 'Je pense toujours à %category', '', '', '', 'Todavía estoy pensando en %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (84, 'suggest_trade', 'I heard about %category already, but my pockets are empty.', 0, 0, '', 'J\'ai déjà entendu parler de %category , mais mes poches sont vides.', '', '', '', 'Ya escuché sobre %category, pero mis bolsillos están vacíos.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (85, 'suggest_trade', 'LFG for %category', 0, 0, '', 'Cherche un groupe pour %category', '', '', '', 'Busco grupo para %category', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (86, 'suggest_trade', 'Would selling %category make me rich?', 0, 0, '', 'Vendre %category me rendrait-il riche?', '', '', '', '¿Vender %category me haría rico?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (87, 'suggest_trade', 'OK. I an farming %category tomorrow.', 0, 0, '', 'D\'ACCORD. Je farm %category demain.', '', '', '', 'OK. Tengo una sesion de farmeo de %category mañana.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (88, 'suggest_trade', 'Everyone is talking about %category.', 0, 0, '', 'Tout le monde parle de %category', '', '', '', 'Todos hablan de %category', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (89, 'suggest_trade', 'I saw at least ten people farming for %category.', 0, 0, '', 'J\'ai vu au moins dix personnes farmer pour %category', '', '', '', 'Vi al menos diez personas farmeando para %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (90, 'suggest_trade', 'I sold all my %category yesterday. I am completely broke!', 0, 0, '', 'J\'ai vendu tout mon %category hier. Je suis complètement fauché!', '', '', '', 'Ayer vendí todo mi %category. ¡Estoy completamente arruinado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (91, 'suggest_trade', 'Wanna join a guild farming for %category.', 0, 0, '', 'Je veux rejoindre une guilde farmant pour %category', '', '', '', 'Quiero unirme a una hermandad de farmeo para %category.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (92, 'suggest_faction', 'Anyone farming %faction rep?', 0, 0, '', 'Quelqu\'un farm la réput de %faction ?', '', '', '', '¿Alguien farmea reputación con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (93, 'suggest_faction', 'Anyone help with %faction?', 0, 0, '', 'Quelqu\'un aide-t-il %faction ?', '', '', '', '¿Alguien me ayuda con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (94, 'suggest_faction', 'Wanna quest for %faction.', 0, 0, '', 'Je veux quêter %faction', '', '', '', 'Quiero buscar a %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (95, 'suggest_faction', '%faction is the best.', 0, 0, '', '%faction est la meilleure.', '', '', '', '%faction es el mejor.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (96, 'suggest_faction', 'Need just a bit to be %level with %faction.', 0, 0, '', 'J\'ai besoin d\'un peu pour être au %level avec %faction', '', '', '', 'Solo necesito un poco para estar %level con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (97, 'suggest_faction', 'Anyone got %level with %faction?', 0, 0, '', 'Quelqu\'un a-t-il %level avec %faction ?', '', '', '', '¿Alguien tiene %level con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (98, 'suggest_faction', 'Who wants to be %level with %faction?', 0, 0, '', 'Qui veut être au %level avec %faction ?', '', '', '', '¿Quién quiere estar en %level con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (99, 'suggest_faction', 'I\'ll never be %level with %faction.', 0, 0, '', 'Je ne serai jamais au %level avec %faction', '', '', '', 'Nunca estaré %level con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (100, 'suggest_faction', 'Someone missing %faction rep?', 0, 0, '', 'Quelqu\'un manque de reput de %faction ?', '', '', '', '¿Alguien falta reputación con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (101, 'suggest_faction', 'Could help farming %faction rep.', 0, 0, '', 'Pourrait aider à farmer réput de %faction', '', '', '', 'Podría ayudar a farmear %faction rep.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (102, 'suggest_faction', 'The more rep the better. Especially with %faction.', 0, 0, '', 'Plus il y a de réput, mieux c\'est. Surtout avec %faction', '', '', '', 'Cuantas más repeticiones, mejor. Especialmente con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (103, 'suggest_faction', '%faction: need %rndK for %level.', 0, 0, '', '%faction: besoin %rndK pour %level.', '', '', '', '%faction: necesita %rndK para %level.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (104, 'suggest_faction', 'Who can share %faction quests?', 0, 0, '', 'Qui peut partager les quêtes de %faction ?', '', '', '', '¿Quién puede compartir misiones de %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (105, 'suggest_faction', 'Any dungeons for %faction?', 0, 0, '', 'Des donjons pour %faction ?', '', '', '', '¿Alguna mazmorra para %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (106, 'suggest_faction', 'Wanna do %faction rep grind.', 0, 0, '', 'Je veux faire monter ma réput %faction', '', '', '', 'Quiero hacer %faction rep grind.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (107, 'suggest_faction', 'Let\'s farm %faction rep!', 0, 0, '', 'Farmons la réput %faction !', '', '', '', '¡Vamos a farmear reputación con %faction!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (108, 'suggest_faction', 'Farming for %faction rep.', 0, 0, '', 'Farmons pour la réput %faction', '', '', '', 'Farming for %faction rep.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (109, 'suggest_faction', 'Wanna farm for %faction.', 0, 0, '', 'Je veux farmer pour %faction', '', '', '', 'Quiero farmear para %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (110, 'suggest_faction', 'Need help with %faction.', 0, 0, '', 'Besoin d\'aide avec %faction', '', '', '', 'Necesito ayuda con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (111, 'suggest_faction', 'Is %faction sells something useful?', 0, 0, '', 'Est-ce que %faction vend quelque chose d\'utile ?', '', '', '', '¿%faction vende algo útil?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (112, 'suggest_faction', 'Are there %faction vendors?', 0, 0, '', 'Y a-t-il des vendeurs %faction ?', '', '', '', '¿Hay %proveedores de facciones?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (113, 'suggest_faction', 'Who farms %faction?', 0, 0, '', 'Qui farm %faction ?', '', '', '', '¿Quién farmea %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (114, 'suggest_faction', 'Which is the best way to farm %faction?', 0, 0, '', 'Quelle est la meilleure façon de farmer %faction ?', '', '', '', '¿Cuál es la mejor manera de farmear %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (115, 'suggest_faction', 'I hate %faction rep grind.', 0, 0, '', 'Je déteste le travail de %faction rep.', '', '', '', 'Odio %repetir de facción', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (116, 'suggest_faction', 'I am so tired of %faction.', 0, 0, '', 'Je suis tellement fatigué de %faction', '', '', '', 'Estoy tan cansado de %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (117, 'suggest_faction', 'Go for %faction?', 0, 0, '', 'Vous optez pour %faction ?', '', '', '', '¿Quereis ir a por %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (118, 'suggest_faction', 'Seems everyone is %level with %faction. Only me is late as usually.', 0, 0, '', 'On dirait que tout le monde est %level avec %faction Il n\'y a que moi qui suis en retard comme d\'habitude.', '', '', '', 'Parece que todo el mundo está %level con %faction. Solo yo llego tarde como siempre.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (119, 'suggest_faction', 'LFG for %faction rep grind?', 0, 0, '', 'Cherche un groupe pour monter la réput des représentants de %faction ?', '', '', '', 'Busco grupo para subir reputación con %faction', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (120, 'suggest_faction', 'Can anobody suggest a good spot for %faction rep grind?', 0, 0, '', 'Quelqu\'un peut-il suggérer un bon endroit pour monter les réput de %faction ?', '', '', '', '¿Alguien puede sugerir un buen lugar farmear reputacion con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (121, 'suggest_faction', 'Would %faction rep benefit me?', 0, 0, '', 'Est-ce que la réput %faction me serait bénéfique ?', '', '', '', '¿Me beneficiaría subir reputación con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (122, 'suggest_faction', 'Who would\'ve thought that %faction rep will be useful after all...', 0, 0, '', 'Qui aurait pensé que le représentant de %faction serait utile après tout...', '', '', '', 'Quién hubiera pensado que subir reputacion con %faction sería útil después de todo...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (123, 'suggest_faction', 'I wanna be exalted with all factions, starting with %faction.', 0, 0, '', 'Je veux être exalté avec toutes les factions, à commencer par %faction', '', '', '', 'Quiero ser exaltado con todas las facciones, comenzando con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (124, 'suggest_faction', 'Is there any point to improve my rep with %faction?', 0, 0, '', 'Y a-t-il un intérêt à améliorer ma réputation avec %faction ?', '', '', '', '¿Hay algún punto para mejorar mi reputación con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (125, 'suggest_faction', 'What is better for %faction? Quests or mob grinding?', 0, 0, '', 'Quoi de mieux pour %faction ? Quêtes ou mob pour XP?', '', '', '', '¿Qué es mejor para %faction? ¿Misiones o mafiosos?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (126, 'suggest_faction', 'Will grind %faction rep for you. Just give me some gold.', 0, 0, '', 'Monte la reput de %faction pour vous. Donnez-moi juste de l\'or.', '', '', '', 'Ganare reputacion con %faction por ti. Sólo dame un poco de oro.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (127, 'suggest_faction', 'I think grinding rep with %faction would take forever.', 0, 0, '', 'Je pense que monter la réput avec %faction prendrait une éternité.', '', '', '', 'Creo que subir la reputación con %faction tomaría una eternidad.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (128, 'suggest_faction', 'I am killing for %faction every day now but still far from %level.', 0, 0, '', 'Je tue pour %faction tous les jours maintenant, mais encore loin du %level', '', '', '', 'Estoy matando por %faction todos los días ahora, pero aún estoy lejos del %level.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (129, 'suggest_faction', 'At %level AH deposits will decrease, right?', 0, 0, '', 'Au %level, les dépôts hôtel des ventes diminueront, n\'est-ce pas?', '', '', '', 'Al %level, los depósitos subastas disminuirán, ¿verdad?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (130, 'suggest_faction', 'How many exalted reps do you have?', 0, 0, '', 'Combien de représentants exaltés avez-vous ?', '', '', '', '¿Cuántas reputaciones exaltadas tienes?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (131, 'suggest_faction', 'Who wants to be %level with %faction?', 0, 0, '', 'Qui veut être au %level avec %faction ?', '', '', '', '¿Quién quiere estar en %level con %faction?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (132, 'suggest_faction', 'Damn. My guild did a good %faction grind yesterday without me.', 0, 0, '', 'Mince. Ma guilde a fait un bon travail de %faction hier sans moi.', '', '', '', 'Maldición. Mi hermandad hizo un buen farmeo de %faction ayer sin mí.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (133, 'suggest_faction', 'Nobody wants to help me because I am %level with %faction.', 0, 0, '', 'Personne ne veut m\'aider parce que je suis %level avec %faction', '', '', '', 'Nadie quiere ayudarme porque estoy %level con %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (134, 'suggest_faction', 'Please stay away from %faction.', 0, 0, '', 'Veuillez rester à l\'écart de %faction', '', '', '', 'Por favor manténgase alejado de %faction.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (135, 'suggest_something', 'Wanna party in %zone.', 0, 0, '', 'Je veux faire la fête dans %zone.', '', '', '', '¡Vamos a perrear a %zone!', '', 'Ищу группу в %zone.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (136, 'suggest_something', 'Anyone is looking for %role?', 0, 0, '', 'Quelqu\'un cherche un %role ?', '', '', '', '¿Alguien está buscando %role?', '', 'Кто-нибудь ищет %role?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (137, 'suggest_something', '%role is looking for quild.', 0, 0, '', '%role recherche une guilde.', '', '', '', '%role está buscando hermandad.', '', '%role ищу гильдию.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (138, 'suggest_something', 'Looking for gold.', 0, 0, '', 'A la recherche de l\'or.', '', '', '', 'Buscando oro.', '', 'Дайте голды');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (139, 'suggest_something', '%role wants to join a good guild.', 0, 0, '', '%role veut rejoindre une bonne guilde.', '', '', '', '%role quiere unirse a una buen hermandad.', '', '%role хочу в хорошую гильдию.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (140, 'suggest_something', 'Need a friend.', 0, 0, '', 'Besoin d\'un ami.', '', '', '', 'Necesito un amigo...', '', 'Ищу друга.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (141, 'suggest_something', 'Anyone feels alone?', 0, 0, '', 'Quelqu\'un se sent seul?', '', '', '', '¿Alguien se siente solo?', '', 'Кому-нибудь одиноко?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (142, 'suggest_something', 'Boring...', 0, 0, '', 'Ennuyeux...', '', '', '', 'Aburrido...', '', 'Скучно...');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (143, 'suggest_something', 'Who wants some?', 0, 0, '', 'Qui en veut?', '', '', '', '¿Quién quiere hacer grupo para levear?', '', 'Кому навалять?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (144, 'suggest_something', 'Go get me!', 0, 0, '', 'Allez me chercher !', '', '', '', '¡Ven a buscarme!', '', 'Поймайте меня!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (145, 'suggest_something', 'Maybe a duel in %zone?', 0, 0, '', 'Peut-être un duel dans %zone ?', '', '', '', '¿Quizás un duelo en %zone?', '', 'Кто на дуэль в %zone?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (146, 'suggest_something', 'Anybody doing something?', 0, 0, '', 'Quelqu\'un fait quelque chose?', '', '', '', '¿Alguien está haciendo algo?', '', 'Кто чем занят?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (147, 'suggest_something', '%zone: is anybody here?', 0, 0, '', '%zone : est-ce que quelqu\'un est là?', '', '', '', '%zone: ¿hay alguien aquí?', '', '%zone: есть кто нибудь?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (148, 'suggest_something', '%zone: where is everyone?', 0, 0, '', '%zone : où est tout le monde?', '', '', '', '¿Hay alguien en %zone?', '', '%zone: где все?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (149, 'suggest_something', 'Looks like I am alone in %zone.', 0, 0, '', 'On dirait que je suis seul dans %zone', '', '', '', 'Parece que estoy solo en %zone.', '', 'Похоже я один в %zone.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (150, 'suggest_something', 'Meet me in %zone.', 0, 0, '', 'Retrouvez-moi dans %zone', '', '', '', 'Encuéntrame en %zone.', '', 'Встретимся в %zone.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (151, 'suggest_something', 'Let\'s quest in %zone!', 0, 0, '', 'Partons en quête dans %zone !', '', '', '', '¡Vamos a hacer un grupo para levear en %zone!', '', 'Давайте квестить в %zone!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (152, 'suggest_something', '%zone is the best place to be!', 0, 0, '', '%zone est le meilleur endroit où être!', '', '', '', '%zone es el mejor lugar para estar!', '', '%zone лучшее место!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (153, 'suggest_something', 'Wanna go to %zone. Anybody with me?', 0, 0, '', 'Je veux aller à %zone Quelqu\'un avec moi?', '', '', '', 'Quiero ir a %zone. ¿Alguien se apunta?', '', 'Собираюсь в %zone. Кто со мной7');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (154, 'suggest_something', 'Who wants going to %zone?', 0, 0, '', 'Qui veut aller à %zone ?', '', '', '', '¿Quién quiere ir a %zone?', '', 'Кто собирается в %zone?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (155, 'suggest_something', 'I don\'t like %zone. Where to go?', 0, 0, '', 'Je n\'aime pas %zone Où aller?', '', '', '', 'No me gusta %zone. ¿Dónde podria ir?', '', 'Не нравится %zone. Куда идти?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (156, 'suggest_something', 'Are there a good quests in %zone?', 0, 0, '', 'Y a-t-il de bonnes quêtes dans %zone ?', '', '', '', '¿Hay buenas misiones en %zone?', '', 'А в %zone есть хорошие квесты?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (157, 'suggest_something', 'Where to go after %zone?', 0, 0, '', 'Où aller après %zone ?', '', '', '', '¿Adónde puedo ir después de %zone?', '', 'Куда идти после %zone?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (158, 'suggest_something', 'Who is in %zone?', 0, 0, '', 'Qui est dans %zone ?', '', '', '', '¿Quién está en %zone?', '', 'Кто в %zone?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (159, 'suggest_something', 'LFG in %zone.', 0, 0, '', 'Cherche un groupe dans %zone', '', '', '', 'Busco grupo en %zone.', '', 'ЛФГ %zone.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (160, 'suggest_something', '%zone is the worst place to be.', 0, 0, '', '%zone est le pire endroit où être.', '', '', '', '%zone es el peor lugar para estar', '', '%zone это худшее место.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (161, 'suggest_something', 'Catch me in %zone!', 0, 0, '', 'Attrape-moi dans %zone !', '', '', '', '¡Atrápame en %zone!', '', 'Поймай меня в %zone!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (162, 'suggest_something', 'Go for %zone!', 0, 0, '', 'Allez pour %zone !', '', '', '', 'Me voy a %zone!', '', 'Гоу в %zone!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (163, 'suggest_something', 'Wanna quest in %zone', 0, 0, '', 'Je veux une quête dans %zone', '', '', '', 'Quiero hacer una búsqueda en %zone', '', 'Хочешь поделать квесты в %zone');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (164, 'suggest_something', 'Anyone has quests in %zone?', 0, 0, '', 'Quelqu\'un a des quêtes dans %zone ?', '', '', '', '¿Alguien tiene misiones en %zone?', '', 'Есть у кого квесты в %zone?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (165, 'suggest_something', 'Come here to %zone!', 0, 0, '', 'Venez ici à %zone !', '', '', '', '¡Ven aquí a %zone!', '', 'Приходите сюда в %zone!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (166, 'suggest_something', 'Seems there is no Horde in %zone', 0, 0, '', 'Il semble qu\'il n\'y ait pas de Horde dans %zone', '', '', '', 'Parece que no hay Horda en %zone', '', '%zone Орды вроде нет.');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (167, 'suggest_something', 'Seems there is no Alliance in %zone', 0, 0, '', 'Il semble qu\'il n\'y ait pas d\'alliance dans %zone', '', '', '', 'Parece que no hay Alianza en %zone', '', '%zone Альянса вроде нет');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (168, 'suggest_something', 'I am really tired of %zone. Maybe go somewhere else?', 0, 0, '', 'Je suis vraiment fatigué de %zone Peut-être aller ailleurs?', '', '', '', 'Estoy realmente cansado de %zone. Quizás ire a otro lugar', '', 'В %zone устал уже, может в другое место пойдем?');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (169, 'suggest_sell', 'WTS %item for %gold.', 0, 0, '', 'Cherche à vendre %item pour %gold', '', '', '', 'Quiero vender %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (170, 'suggest_sell', 'Who wants %item for %gold?', 0, 0, '', 'Qui veut %item pour %gold ?', '', '', '', '¿Quién quiere %item por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (171, 'suggest_sell', 'Anyone wants %item? Only %gold.', 0, 0, '', 'Quelqu\'un veut %item ? Seulement %gold', '', '', '', '¿Alguien quiere %item? Solo %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (172, 'suggest_sell', 'Just %gold for %item!', 0, 0, '', 'Seulement %gold pour %item!', '', '', '', '¡Solo %gold para %item!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (173, 'suggest_sell', 'Selling %item for %gold.', 0, 0, '', 'Vendre %item pour %gold', '', '', '', 'Vendo %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (174, 'suggest_sell', '%item is yours just for %gold!', 0, 0, '', '%item est à vous juste pour %gold !', '', '', '', '%item es tuyo solo por %gold!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (175, 'suggest_sell', 'Ridiculus price of %gold for %item!', 0, 0, '', 'Prix ridicule de %gold pour %item !', '', '', '', '¡Precio ridículo de %gold para %item!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (176, 'suggest_sell', 'Wanna sell %item for %gold.', 0, 0, '', 'Je veux vendre %item pour %gold', '', '', '', 'Quiero vender %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (177, 'suggest_sell', 'Who needs %item? Only %gold.', 0, 0, '', 'Qui a besoin de %item ? Seulement %gold', '', '', '', '¿Quién necesita %item? Solo %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (178, 'suggest_sell', 'Anyone needs %item for %gold?', 0, 0, '', 'Quelqu\'un a besoin de %item pour %gold ?', '', '', '', '¿Alguien necesita %item por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (179, 'suggest_sell', '%gold for %item. Less than AH!', 0, 0, '', '%gold pour %item. Moins que l\'hôtel des ventes!', '', '', '', '%gold para %item. ¡Menos que en las subastas!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (180, 'suggest_sell', '%item is expensive, but I\'d sell it for %gold.', 0, 0, '', '%item est cher, mais je le vendrais pour %gold', '', '', '', '%item es caro, pero lo vendería por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (181, 'suggest_sell', 'You\'ll never find %item cheaper than %gold!', 0, 0, '', 'Vous ne trouverez jamais %item moins cher que %gold !', '', '', '', '¡Nunca encontrarás %item más barato que %gold!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (182, 'suggest_sell', 'Need more than %item!', 0, 0, '', 'Besoin de plus de %item !', '', '', '', '¡Necesito más %item!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (183, 'suggest_sell', 'I have %item and need more.', 0, 0, '', 'J\'ai %item et j\'en ai besoin de plus.', '', '', '', 'Tengo %item y necesito más. ¿Alguien me vende alguno?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (184, 'suggest_sell', 'Have %item. Who wants to buy for %gold?', 0, 0, '', 'Avoir %item. Qui veut acheter pour %gold ?', '', '', '', 'Tengo %item. ¿Quién quiere comprarlo por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (185, 'suggest_sell', 'Anyone WTB %item for %gold?', 0, 0, '', 'Quelqu\'un cherche à acheter %item pour %gold ?', '', '', '', '¿Alguien compra %item por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (186, 'suggest_sell', 'What about %item? For %gold.', 0, 0, '', 'Qu\'en est-il de %item ? Pour %gold', '', '', '', '¿Qué pasa con %item? Por el oro.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (187, 'suggest_sell', 'Who said I am a bastard? %item for %gold is a good price.', 0, 0, '', 'Qui a dit que j\'étais un bâtard? %item pour %gold est un bon prix.', '', '', '', '¿Quién ha dicho que soy un rata? %item por %gold es una ganga.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (188, 'suggest_sell', 'I am selling %item? Just %gold.', 0, 0, '', 'Je vends %item ? Juste %gold', '', '', '', '¿Vendo %item? Solo %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (189, 'suggest_sell', 'LFG for farming. You can still buy %item I have for %gold.', 0, 0, '', 'Cherche un groupe pour farming. Vous pouvez toujours acheter %item que j\'ai pour %gold', '', '', '', 'LFG para farmear. Todavía puedes comprar %item que tengo por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (190, 'suggest_sell', 'Sold almost everything today. Still have %item for %gold.', 0, 0, '', 'Vendu presque tout aujourd\'hui. Vous avez encore %item pour %gold', '', '', '', 'Se vendió casi todo hoy. Todavía tengo %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (191, 'suggest_sell', 'What use for trade chat? Of course to sell %item for %gold.', 0, 0, '', 'A quoi sert le tchat commercial? Bien sûr pour vendre %item pour %gold', '', '', '', '¿De qué sirve el chat comercial? Por supuesto, para vender %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (192, 'suggest_sell', 'Can anyone beat the price of %gold for %item?', 0, 0, '', 'Quelqu\'un peut-il battre le prix de %gold pour %item ?', '', '', '', '¿Alguien puede superar el precio de %gold por %item?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (193, 'suggest_sell', 'Wanna stop trade chat? Just buy %item? For %gold!', 0, 0, '', 'Vous voulez arrêter le chat commercial? Vous venez d\'acheter %item ? Pour %gold !', '', '', '', '¿Quieres detener el chat comercial? ¿Solo compra %item? ¡Por el oro!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (194, 'suggest_sell', 'Everybody spams in trade chat. Me too - %gold for %item!', 0, 0, '', 'Tout le monde spamme dans le chat commercial. Moi aussi - %gold pour %item !', '', '', '', 'Todo el mundo envía spam en el chat y yo también! ¡%item por %gold!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (195, 'suggest_sell', 'Is %item any use? Just selling it for %gold.', 0, 0, '', '%item est-il utile? Je le vends juste pour %gold', '', '', '', '¿Es %item útil? Solo lo vendo por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (196, 'suggest_sell', 'I have %item ready to sell you for %gold.', 0, 0, '', 'J\'ai %item prêt à vous vendre pour %gold', '', '', '', 'Tengo %item listo a la venta por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (197, 'suggest_sell', 'Did nothing yesterday but have got %item. Selling it for %gold.', 0, 0, '', 'Je n\'ai rien fait hier mais j\'ai %item Je le vends pour %gold', '', '', '', 'No hice nada ayer pero consegu\'i %item. Lo vendo por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (198, 'suggest_sell', 'Farmed yesterday and got %item. Anyone wtb for %gold?', 0, 0, '', 'Farmé hier et obtenu %item Quelqu\'un cherche à acheter pour %gold ?', '', '', '', 'Ayer farmee y conseguí mucho %item. ¿Alguien lo quiere comprar por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (199, 'suggest_sell', 'Bought %item yesterday. Anyone needs it for %gold?', 0, 0, '', 'Acheté %item hier. Quelqu\'un en a besoin pour %gold ?', '', '', '', 'Ayer compré %item. ¿Alguien lo quiere por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (200, 'suggest_sell', 'Who asked for %item? The price is the same - %gold.', 0, 0, '', 'Qui a demandé %item ? Le prix est le même - %gold', '', '', '', '¿Quién pidió %item? El precio es el mismo: %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (201, 'suggest_sell', 'I sill have %item. WTB for %gold?', 0, 0, '', 'J\'ai toujours %item. Cherche à acheter pour %gold ?', '', '', '', 'Todavía tengo %item. ¿Alguien lo compra por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (202, 'suggest_sell', 'I used to have more than %item. Now needs to sell it for %gold.', 0, 0, '', 'J\'avais plus de %item Il faut maintenant le vendre pour %gold', '', '', '', 'Solía tener más de %item. Ahora necesito venderlo por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (203, 'suggest_sell', 'I wish I have more than %item. You could buy it for %gold anyways.', 0, 0, '', 'J\'aimerais avoir plus de %item . Vous pouvez l\'acheter pour %gold de toute façon.', '', '', '', 'Desearía tener más de %item. Podrías comprarlo por %gold de todos modos.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (204, 'suggest_sell', 'What use for your gold? To buy my %item for %gold.', 0, 0, '', 'A quoi sert votre or ? Pour acheter mon %item pour %gold', '', '', '', '¿De qué sirve tu oro? Para comprar mi %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (205, 'suggest_sell', 'Please spare some gold for me. You can buy %item for %gold.', 0, 0, '', 'S\'il vous plaît, épargnez-moi de l\'or. Vous pouvez acheter %item pour %gold', '', '', '', 'Por favor, dame algo de oro. Puedes comprar %item por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (206, 'suggest_sell', 'Is %gold is a good price for %item?', 0, 0, '', '%gold est-il un bon prix pour %item ?', '', '', '', '¿%gold es un buen precio para %item?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (207, 'suggest_sell', 'Just bought yesterday %items, but do not need it anymore. Anyone wants for %gold?', 0, 0, '', 'Je viens d\'acheter hier %items , mais je n\'en ai plus besoin. Quelqu\'un veut %gold ?', '', '', '', 'Ayer compré %item, pero ya no los necesito. ¿Alguien lo quiere por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (208, 'suggest_sell', 'I am going to post %item on the AH but you can buy it now cheaper just for %gold.', 0, 0, '', 'Je vais poster %item à l\'hôtel des ventes mais vous pouvez l\'acheter maintenant moins cher juste pour %gold', '', '', '', 'Voy a poner %item en la casa de subastas pero puedes comprarlo ahora más barato solo por %gold.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (209, 'suggest_sell', 'Why the #!@ have I bought %item? Anyone needs it for %gold?', 0, 0, '', 'Pourquoi ai-je acheté le #!@ %item ? Quelqu\'un en a besoin pour %gold ?', '', '', '', '¿Por qué #!@ he comprado %item? ¿Alguien lo necesita por %gold?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (210, 'reply', 'what was that %s?', 0, 0, '', 'c\'était quoi ce %s?', '', '', '', '¿qué has dicho %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (211, 'reply', 'not sure I understand %s?', 0, 0, '', 'pas sûr de comprendre %s?', '', '', '', '¿no estoy seguro de entenderte %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (212, 'reply', 'uh... no clue what yer talkin bout', 0, 0, '', 'euh... aucune idée de quoi tu parles', '', '', '', 'uh... ni idea de lo que estás hablando', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (213, 'reply', 'you talkin to me %s?', 0, 0, '', 'tu me parles %s?', '', '', '', '¿Me hablas a mí %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (214, 'reply', 'whaaaa?', 0, 0, '', 'quoiaaa?', '', '', '', '¿quéaaa?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (215, 'reply', 'huh?', 0, 0, '', 'hein?', '', '', '', '¿eh?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (216, 'reply', 'what?', 0, 0, '', 'Quoi?', '', '', '', '¿qué?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (217, 'reply', 'are you talking?', 0, 0, '', 'parles-tu?', '', '', '', '¿estás hablando?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (218, 'reply', 'whatever dude', 0, 0, '', 'peu importe mec', '', '', '', 'Menudo tio...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (219, 'reply', 'you lost me', 0, 0, '', 'tu m\'as perdu', '', '', '', 'No entiendo ni papa', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (220, 'reply', 'Bla bla bla...', 0, 0, '', 'Bla bla bla...', '', '', '', 'Bla bla bla...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (221, 'reply', 'What did you say, %s?', 0, 0, '', 'Qu\'as-tu dis, %s?', '', '', '', '¿Qué me estas contando %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (222, 'reply', 'Concentrate on the game, %s!', 0, 0, '', 'Concentres-toi sur le jeu, %s!', '', '', '', '¡Concéntrate en el juego, %s!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (223, 'reply', 'Chatting with you %s is so great! I always wanted to meet you', 0, 0, '', 'Discuter avec vous %s est tellement génial! J\'ai toujours voulu te rencontrer', '', '', '', '¡%s, chatear contigo es genial! Siempre quise conocerte', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (224, 'reply', 'These chat-messages are freaking me out! I feel like I know you all!', 0, 0, '', 'Ces messages du chat me font flipper! J\'ai l\'impression de vous connaître tous!', '', '', '', '¡Estos mensajes de chat me están asustando! ¿De que cojones estais hablando?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (225, 'reply', 'YEAH RIGHT! HAHA SURE!!!', 0, 0, '', 'OUI EN EFFET! AHAH BIEN SÛR!!!', '', '', '', '¡SÍ, CORRECTO! ¡¡¡JAJA SEGURO!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (226, 'reply', 'I believe you!!!', 0, 0, '', 'Je te crois!!!', '', '', '', '¡Si, claro!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (227, 'reply', 'OK, uhuh LOL', 0, 0, '', 'OK, euh LOL', '', '', '', 'OK, uhuh LOL', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (228, 'reply', 'Why is everybody always saying the same things???', 0, 0, '', 'Pourquoi tout le monde dit toujours la même chose???', '', '', '', '¿Por qué todo el mundo siempre dice lo mismo?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (229, 'reply', 'Hey %s....oh nevermind!', 0, 0, '', 'Hé %s.... oh tant pis!', '', '', '', 'Oye %s... ¡oh, no importa!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (230, 'reply', 'What are you talking about %s', 0, 0, '', 'De quoi parlez-vous %s', '', '', '', 'De qué estás hablando %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (231, 'reply', 'Who said that? I resemble that remark', 0, 0, '', 'Qui a dit ça? je ressemble à cette remarque', '', '', '', '¿Quién ha dicho eso? ¿Estais hablando de mi?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (232, 'reply', 'hey %s i havent forgotten you', 0, 1, '', 'salut %s je ne t\'ai pas oublié', '', '', '', 'hey %s no te he olvidado', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (233, 'reply', 'you piss me off %s', 0, 1, '', 'tu me fais chier %s', '', '', '', 'me cabreas %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (234, 'reply', 'im gunna get you this time %s', 0, 1, '', 'je vais t\'avoir cette fois %s', '', '', '', 'voy a atraparte esta vez %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (235, 'reply', 'better watch your back %s', 0, 1, '', 'mieux vaut surveiller vos arrières %s', '', '', '', 'mejor cuida tu espalda %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (236, 'reply', 'i did not like last round so much', 0, 1, '', 'je n\'ai pas tellement aimé le dernier tour', '', '', '', 'no me gustó tanto la última ronda', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (237, 'reply', 'i sucked last round thanks to %s', 0, 1, '', 'j\'ai merdé le dernier tour grâce à %s', '', '', '', 'chupé la última ronda gracias a %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (238, 'reply', 'prepare to die %s', 0, 1, '', 'préparez-vous à mourir %s', '', '', '', 'prepárate para morir %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (239, 'reply', 'dont appreciate you killin me %s', 0, 1, '', 'j\'apprécie pas que tu me tues %s', '', '', '', 'no aprecio que me mates %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (240, 'reply', '%s, i hate you', 0, 1, '', '%s, je te déteste', '', '', '', '%s, te odio', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (241, 'reply', 'grrrrrr, ill get you this time %s', 0, 1, '', 'grrrrrr, je vais t\'avoir cette fois %s', '', '', '', 'grrrrrr, te libraste esta vez %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (242, 'reply', 'well fuck you', 0, 1, '', 'eh bien va te faire foutre', '', '', '', 'vamos a la mierda', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (243, 'reply', 'wtf', 0, 2, '', 'wtf', '', '', '', 'wtf', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (244, 'reply', 'wtf??', 0, 2, '', 'wtf??', '', '', '', 'wtf??', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (245, 'reply', 'low life', 0, 2, '', 'faible durée de vie', '', '', '', 'low life', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (246, 'reply', 'wth', 0, 2, '', 'wth', '', '', '', 'wth', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (247, 'reply', 'sucked', 0, 2, '', 'Ça craint', '', '', '', 'chupate esa', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (248, 'reply', 'REMATCH!!! im taking him down', 0, 2, '', 'REMATCH!!! je le descends', '', '', '', '¡¡REVANCHA!!! lo estoy derribando', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (249, 'reply', 'pathetic, i got killed by %s', 0, 2, '', 'pathétique, j\'ai été tué par %s', '', '', '', 'patético, me mató %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (250, 'reply', 'hehe, i nailed %s?', 0, 3, '', 'hehe, j\'ai cloué %s?', '', '', '', 'jeje, ¿acerté a %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (251, 'reply', 'that was too easy, killin %s', 0, 3, '', 'c\'était trop facile, de tuer %s', '', '', '', 'fue demasiado fácil matar a %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (252, 'reply', 'gotcha mofo', 0, 3, '', 'je t\'ai eu enfoiré', '', '', '', 'te pille hijo de perra', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (253, 'reply', 'ha ha', 0, 3, '', 'ha ha', '', '', '', 'ja, ja', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (254, 'reply', 'loser', 0, 3, '', 'loser', '', '', '', 'loser', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (255, 'reply', 'i killed %s and yer all next dudes', 0, 3, '', 'j\'ai tué %s et vous tous les prochains mecs', '', '', '', 'yo maté a %s y a todos los siguientes tipos', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (256, 'reply', 'oh yeah i owned him', 0, 3, '', 'oh ouais je l\'ai possédé', '', '', '', 'oh, sí, lo tenía', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (257, 'reply', 'im a killin machine', 0, 3, '', 'je suis une machine à tuer', '', '', '', 'soy una máquina de matar', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (258, 'reply', '%s,  this reminds me of a Slayer song...all this bloodshed', 0, 3, '', '%s, ça me rappelle une chanson de Slayer... tout ce bain de sang', '', '', '', '%s, esto me recuerda a una canción de Slayer... todo este derramamiento de sangre', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (259, 'reply', 'sorry, %s. can we do the scene again?', 0, 3, '', 'désolé, %s. peut-on refaire la scène?', '', '', '', 'lo siento, %s. ¿Podemos hacer la escena de nuevo?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (260, 'reply', 'so....how do you like being worm food %s???', 0, 3, '', 'alors... comment aimez-vous être de la nourriture pour vers %s???', '', '', '', 'así que... ¿cómo te gusta ser comida de gusanos %s???', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (261, 'reply', 'yer supposed to be dead, %s its part of the game!!!!!', 0, 3, '', 'tu es censé être mort, %s ça fait partie du jeu!!!!!', '', '', '', '¡¡Se supone que estás muerto, %s es parte del juego!!!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (262, 'reply', 'sorry, %s. that looked as good as an Andy Worhol painting!', 0, 3, '', 'désolé, %s. ça avait l\'air aussi bien qu\'une peinture d\'Andy Warhol!', '', '', '', 'lo siento, %s. ¡Eso se veía tan bien como una pintura de Andy Worhol!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (263, 'reply', '%s, ill use the rubber bullets next time !', 0, 3, '', '%s, j\'utiliserai pas les balles en caoutchouc la prochaine fois!', '', '', '', '%s, ¡usaré las balas de goma la próxima vez!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (264, 'reply', 'whatsamatter, %s?? lose your head? hahaha gotta keep cool!!', 0, 3, '', 'qu\'importe, %s ?? tu perds la tête? hahaha faut rester cool!!', '', '', '', '¿qué pasa, %s?? ¿has perdido la cabeza? jajaja tengo que mantener la calma!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (265, 'reply', 'i had to do it, %s. You understand. The Director said so!!', 0, 3, '', 'je devais le faire, %s. Tu comprends. Le directeur l\'a dit!!', '', '', '', 'Tenía que hacerlo, %s. Entiendelo... ¡¡Dios me lo ordenó!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (266, 'reply', 'hey %s.......MUAHAHAHAHAHAHAHAHAHAHA', 0, 3, '', 'Salut %s.......MUAHAHAHAHAHAHAHAHAHAHA', '', '', '', 'hey %s.......MUAHAHAHAHAHAHAHAHAHAHA', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (267, 'reply', '%s, i enjoyed that one!! Lets play it again Sam', 0, 3, '', '%s, j\'ai adoré celui-là !! Jouons à nouveau Sam', '', '', '', '%s, ¡disfruté ese! Juguemos de nuevo Sam', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (268, 'reply', 'hey, %s! ju can start callin me scarface.. ju piece of CHIT!!!!', 0, 3, '', 'Hé, %s ! ju peut commencer à m\'appeler Scarface .. ju merde!!!!', '', '', '', '¡oye, %s! ¡Puedes empezar a llamarme caracortada... ¡¡¡un trozo de CHIT!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (269, 'reply', 'are you talking to me %s??', 0, 3, '', 'tu me parles %s ??', '', '', '', '¿me estás hablando a mí %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (270, 'reply', '%s get it right this time, dont stand in front of my bullets.', 0, 3, '', '%s réussis cette fois, ne te tiens pas devant mes balles.', '', '', '', '%s hazlo bien esta vez, no te pares frente a mis balas.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (271, 'reply', '%s, what are you laying around for??? hehe', 0, 3, '', '%s, pourquoi traînes-tu??? hé hé', '', '', '', '%s, ¿para qué estás tirado? jeje', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (272, 'reply', 'hi %s', 0, 4, '', 'salut %s', '', '', '', 'hola %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (273, 'reply', 'oh, hi %s', 0, 4, '', 'oh, salut %s', '', '', '', 'oh, hola %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (274, 'reply', 'wazzup %s!!!', 0, 4, '', 'Quoi de neuf %s!!!', '', '', '', 'wazzup %s!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (275, 'reply', 'hi', 0, 4, '', 'salut', '', '', '', 'hi', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (276, 'reply', 'wazzup', 0, 4, '', 'wazzup', '', '', '', 'wazzup', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (277, 'reply', 'hello %s', 0, 4, '', 'bonjour %s', '', '', '', 'hola %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (278, 'reply', 'hi %s, do i know you?', 0, 4, '', 'Salut %s, est-ce que je te connais ?', '', '', '', 'hola %s, ¿te conozco?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (279, 'reply', 'hey %s', 0, 4, '', 'salut %s', '', '', '', 'hey %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (280, 'reply', 'hai %s', 0, 4, '', 'ha %s', '', '', '', 'hai %s', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (281, 'reply', 'wth', 0, 6, '', 'wth', '', '', '', 'wth', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (282, 'reply', 'wtf', 0, 6, '', 'wtf', '', '', '', 'que cojones!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (283, 'reply', 'this is bs', 0, 6, '', 'c\'est bs', '', '', '', 'esto es una mierda', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (284, 'reply', 'admin', 0, 6, '', 'admin', '', '', '', 'admin', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (285, 'reply', 'hey %s quit abusing your admin', 0, 6, '', 'hé %s arrête d\'abuser de ton admin', '', '', '', 'hey %s deja de abusar de tu poder de administrador', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (286, 'reply', 'leave me alone admin!', 0, 6, '', 'laissez-moi tranquille admin!', '', '', '', '¡déjame en paz administrador!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (287, 'reply', 'you suck admin', 0, 6, '', 'tu es nul admin', '', '', '', 'apestas administrador', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (288, 'reply', 'thats my name, what you want %s', 0, 5, '', 'c\'est mon nom, qu\'est-ce que tu veux %s', '', '', '', 'ese es mi nombre, ¿que quieres %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (289, 'reply', 'yes???', 0, 5, '', 'Oui???', '', '', '', 'sí???', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (290, 'reply', 'uh... what', 0, 5, '', 'euh ...quoi', '', '', '', 'uh... qué', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (291, 'reply', 'you talkin to me %s?', 0, 5, '', 'tu me parles %s ?', '', '', '', '¿Me hablas a mí %s?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (292, 'taunt', 'I have puppies under my armor!', 0, 0, '', 'J\'ai des chiots sous mon armure !', '', '', '', '¡Tengo cachorros bajo mi armadura!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (293, 'taunt', 'Bite me, <target>!', 0, 0, '', 'Mords moi, <target>!', '', '', '', '¡Muérdeme, <target>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (294, 'taunt', 'Hey <target>! Guess what your mom said last night!', 0, 0, '', 'Hey <target>! Devine ce que ta mère a dit hier soir!', '', '', '', '¡Oye, <target>! ¡Adivina lo que me dijo tu madre anoche!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (295, 'taunt', '<target>, you\'re so ugly you couldn\'t score in a monkey whorehouse with a bag of bananas!', 0, 0, '', '<target>, tu es si moche que tu ne pourrais pas marquer dans un bordel de singes avec un sac de bananes!', '', '', '', '<target>, ¡eres tan feo que no podrías anotar en un burdel de monos con una bolsa de plátanos!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (296, 'taunt', 'Shut up <target>, you\'ll never be the man your mother is!!', 0, 0, '', 'Tais-toi <target>, tu ne seras jamais l\'homme qu\'est ta mère!!', '', '', '', 'Cállate <target>, ¡nunca serás el hombre que es tu madre!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (297, 'taunt', 'Your mother was a hampster and your father smelt of elderberries!!!!', 0, 0, '', 'Ta mère était un hamster et ton père sentait le sureau!!!!', '', '', '', 'Tu madre era un hámster y tu padre olía a bayas de saúco!!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (298, 'taunt', 'I don\'t want to talk to you no more, you empty headed animal food trough wiper!!!', 0, 0, '', 'Je ne veux plus te parler, espèce d\'essuyeur d\'abreuvoirs pour animaux tête vide!!!', '', '', '', '¡¡No quiero hablar más contigo, limpiaparabrisas de cabeza vacía!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (299, 'taunt', 'I fart in your general direction!!!', 0, 0, '', 'Je pète dans votre direction générale!!!', '', '', '', '¡¡Me tiro un pedo en tu dirección general!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (300, 'taunt', 'Go and boil your bottom, you son of a silly person!!!', 0, 0, '', 'Va te faire cuire le cul, fils d\'idiot!!!', '', '', '', '¡Ve y hierve tu trasero, hijo de una persona tonta!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (301, 'taunt', 'What are you going to do <target>, bleed on me? HAVE AT YOU!', 0, 0, '', 'Qu\'est ce que tu vas faire <target>, saigner sur moi? A VOUS!', '', '', '', '¿Qué vas a hacer <target>, llorar?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (302, 'taunt', 'M-O-O-N! That spells aggro!', 0, 0, '', 'PUNAISE! Ce sort aggro!', '', '', '', '¡LUNA! ¡Eso deletrea agresividad!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (303, 'taunt', 'You\'re about as useful as a one-legged man in an ass kicking contest.', 0, 0, '', 'Tu es à peu près aussi utile qu\'un homme unijambiste dans un concours de coups de pied au cul.', '', '', '', 'Eres tan útil como un hombre con una sola pierna en un concurso de patadas en el culo.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (304, 'taunt', 'Hey <target>! Stop hitting on them, they\'re not your type. They aren\'t inflatable.', 0, 0, '', 'Hey <target>! Arrête de les draguer, ce n\'est pas ton genre. Ils ne sont pas gonflables.', '', '', '', '¡Oye, <target>! Deja de coquetear con ellos, no son tu tipo. No son inflables.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (305, 'taunt', '<target> you\'re so far outta your league, you\'re playing a different sport.', 0, 0, '', '<target> vous êtes tellement hors de votre ligue que vous pratiquez un sport différent.', '', '', '', '<target> estás tan lejos de tu liga, estás jugando un deporte diferente.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (306, 'taunt', 'You made a big mistake today <target>, you got out of bed.', 0, 0, '', 'Tu as fait une grosse erreur aujourd\'hui <target>, tu es sorti du lit.', '', '', '', 'Cometiste un gran error hoy <target>, te levantaste de la cama.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (307, 'taunt', 'I wanna try turning into a horse, but I need help. I\'ll be the front, you be yourself.', 0, 0, '', 'Je veux essayer de me transformer en cheval, mais j\'ai besoin d\'aide. Je serai devant, tu seras toi-même.', '', '', '', 'Quiero intentar convertirme en un caballo, pero necesito ayuda. Yo seré el frente, tú mismo.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (308, 'taunt', 'Can I borrow your face for a few days? My ass is going on holiday....', 0, 0, '', 'Puis-je emprunter votre visage pendant quelques jours? Mon cul part en vacances....', '', '', '', '¿Me prestas tu cara por unos días? Mi culo se va de vacaciones...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (309, 'taunt', 'I\'d like to give you a going away present... First you do your part.', 0, 0, '', 'J\'aimerais vous offrir un cadeau de départ... D\'abord, donnes ta part.', '', '', '', 'Me gustaría darte un regalo de despedida... Primero haz tu parte.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (310, 'taunt', 'Before you came along we were hungry, Now we\'re just fed up.', 0, 0, '', 'Avant que tu n\'arrives nous avions faim, maintenant nous en avons juste marre.', '', '', '', 'Antes de que llegaras teníamos hambre, ahora estamos hartos', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (311, 'taunt', 'I like you. People say I have no taste, but I like you.', 0, 0, '', 'Je t\'aime bien. Les gens disent que je n\'ai pas de goût, mais je t\'aime bien.', '', '', '', 'Me gustas. La gente dice que no tengo gusto, pero me gustas.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (312, 'taunt', 'I think you have an inferiority complex, but that\'s okay, it\'s justified.', 0, 0, '', 'Je pense que tu as un complexe d\'infériorité, mais il n\'y a pas de problème, c\'est justifié.', '', '', '', 'Creo que tienes complejo de inferioridad, pero está bien, está justificado', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (313, 'taunt', 'Hence rotten thing! Or I shall shake thy bones out of thy garments.', 0, 0, '', 'Par conséquent chose pourrie! Je vais secouer tes os de tes vêtements.', '', '', '', '¡Por lo tanto, cosa podrida! o te sacudiré los huesos de las vestiduras.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (314, 'taunt', 'I can\'t believe I\'m wasting my time with you!', 0, 0, '', 'Je n\'arrive pas à croire que je perds mon temps avec toi!', '', '', '', '¡No puedo creer que estoy perdiendo el tiempo contigo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (315, 'taunt', 'I love it when someone insults me, it means I don\'t have to be nice anymore.', 0, 0, '', 'J\'adore quand quelqu\'un m\'insulte, ça veut dire que je n\'ai plus besoin d\'être gentil.', '', '', '', 'Me encanta cuando alguien me insulta, significa que ya no tengo que ser amable', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (316, 'taunt', 'Thou leathern-jerkin, crystal-button, knot-pated, agatering, puke-stocking, caddis-garter, smooth-tongue, Spanish pouch!', 0, 0, '', 'Toi l\'agent fédéral, pourpoint en cuir, bouton de cristal, anneau d\'agate, bas vomi, jarretière caddis, pochette espagnole!', '', '', '', '¡Tú, jubón de cuero, botón de cristal, anudado, ágata, medias de vómito, liga de caddis, lengua suave, bolsa española!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (317, 'taunt', 'Thou qualling bat-fowling malt-worm!', 0, 0, '', 'Toi qualificatif de chauve-souris qui chasse le ver de malt!', '', '', '', '¡Tú, gusano de malta cazador de murciélagos!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (318, 'taunt', 'Thou art truely an idol of idiot-worshippers!', 0, 0, '', 'Tu es vraiment une idole d\'adorateurs d\'idiots!', '', '', '', '¡Eres verdaderamente un ídolo de los adoradores de idiotas!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (319, 'taunt', 'Thou misbegotten knotty-pated wagtail!', 0, 0, '', 'Tu es une bergeronnette printanière mal engendrée!', '', '', '', '¡Maldito lavandero nudoso!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (320, 'taunt', 'Thou whoreson mandrake, thou art fitter to be worn in my cap than to wait at my heels!', 0, 0, '', 'Toi putain de mandragore, tu es plus apte à être porté dans ma casquette qu\'à attendre sur mes talons!', '', '', '', '¡Hijo de puta mandrágora, eres mejor para que te lleve en mi gorra que para que me pise los talones!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (321, 'taunt', 'You! You scullion! You rampallian! You fustilarian! I\'ll tickle your catastrophe!', 0, 0, '', 'Toi ! Espèce de marmiton ! Espèce de rampallian ! Espèce de fusilier ! Je vais chatouiller ta catastrophe!', '', '', '', '¡Tú! ¡Scullion! ¡Ramaliano! ¡Fustilarista! ¡Te haré cosquillas en tu catástrofe!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (322, 'taunt', 'Oh <target>! Thou infectious ill-nurtured flax-wench!', 0, 0, '', 'Oh <target>! Tu es contagieuse et mal nourrie!', '', '', '', '¡Oh, <target>! ¡Tú, contagiosa moza del lino mal educada!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (323, 'taunt', 'We leak in your chimney, <target>!', 0, 0, '', 'On a une fuite dans votre cheminée, <target>!', '', '', '', '¡Tenemos una fuga en tu chimenea, <target>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (324, 'taunt', 'Oh thou bootless fen-sucked canker-blossom!', 0, 0, '', 'Oh toi, fleur de chancre sucée par les marais sans botte!', '', '', '', '¡Oh tú, flor de cancro chupada por el pantano sin botas!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (325, 'taunt', 'Were I like thee I\'d throw away myself!', 0, 0, '', 'Si j\'étais comme toi, je me jetterais!', '', '', '', '¡Si yo fuera como tú, me tiraría a la basura!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (326, 'taunt', 'O teach me <target>, how I should forget to think!', 0, 0, '', 'O apprends-moi <target>, comme je devrais oublier de penser!', '', '', '', '¡Oh, enséñame <target>, cómo debo olvidarme de pensar!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (327, 'taunt', 'Truly thou art damned, like an ill-roasted egg, all on one side!', 0, 0, '', 'Vraiment tu es damné, comme un œuf mal rôti, tout d\'un côté!', '', '', '', '¡Verdaderamente estás condenado, como un huevo mal asado, todo de un lado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (328, 'taunt', 'You starvelling, you eel-skin, you dried neat\'s-tongue, you bull\'s-pizzle, you stock-fish- O for breath to utter what is like thee!! -you tailor\'s-yard, you sheath, you bow-case, you vile standing tuck!', 0, 0, '', 'Toi affamé, espèce de peau d\'anguille, ta langue bien séchée, espèce de taureau, poisson séché, O pour le souffle de dire ce qui te ressemble !! -espèce de vergue de tailleur, espèce de fourreau, espèce d\'étui à archet, vil tuck debout', '', '', '', 'Estás muerto de hambre, piel de anguila, te secaste la lengua limpiamente, toro-pizzle, pescado-O para respirar pronunciar lo que es como tú !! ¡Tú, sastrería, vaina, estuche de arco, vil flaco de pie!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (329, 'taunt', 'Fie! Drop thee into the rotten mouth of Death!', 0, 0, '', 'Fi ! Jette-toi dans la bouche pourrie de la Mort!', '', '', '', '¡Fie! ¡Déjate caer en la podrida boca de la Muerte!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (330, 'taunt', '<target>, you are a fishmonger!', 0, 0, '', '<target>, vous êtes poissonnier!', '', '', '', '<target>, ¡eres un pescadero!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (331, 'taunt', 'I shall live to knock thy brains out!', 0, 0, '', 'Je vivrai pour te faire sauter la cervelle!', '', '', '', '¡Viviré para romperte los sesos!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (332, 'taunt', 'Most shallow are you, <target>!! Thou art worms-meat in respect of a good piece of flesh, indeed!!', 0, 0, '', 'Tu es très superficiel, <target>!! Tu es de la viande de vers par rapport à un bon morceau de chair, en effet!!', '', '', '', '¡¡Eres el más superficial, <target>!! ¡Eres carne de gusano con respecto a un buen trozo de carne, de hecho!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (333, 'taunt', 'Vile wretch! O <target>, thou odiferous hell-hated pignut!', 0, 0, '', 'Misérable ! O <target>, toi, ignoble cochon de l\'enfer!', '', '', '', '¡Miserable vil! ¡Oh, <target>, fétido cerdo odiado por el infierno!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (334, 'taunt', '<target>! Thy kiss is as comfortless as frozen water to a starved snake!', 0, 0, '', '<target>! Ton baiser est aussi désagréable que de l\'eau gelée pour un serpent affamé!', '', '', '', '<target>! ¡Tu beso es tan desconsolador como el agua helada para una serpiente hambrienta!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (335, 'taunt', 'I scorn you, scurvy companion. What, you poor, base, rascally, cheating, lack-linen mate! Away, you moldy rogue, away!', 0, 0, '', 'Je te méprise, compagnon du scorbut. Quoi, pauvre, bas, coquin, tricheur, camarade en manque de linge ! Partez, espèce de voyou moisi, partez!', '', '', '', 'Te desprecio, compañero escorbuto. ¡Qué, pobre, vil, pícaro, tramposo, compañero falto de lino! ¡Fuera, mohoso granuja, fuera!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (336, 'taunt', 'Out of my sight! Thou dost infect my eyes <target>!', 0, 0, '', 'Hors de ma vue! Tu infectes mes yeux <target>!', '', '', '', '¡Fuera de mi vista! ¡Me infectas los ojos <target>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (337, 'taunt', 'PLAY TIME!!!!', 0, 0, '', 'RÉCRÉATION!!!!', '', '', '', '¡¡¡HORA DE JUGAR!!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (338, 'taunt', 'None shall pass!', 0, 0, '', 'Personne ne passera!', '', '', '', '¡Ninguno pasará!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (339, 'taunt', 'We\'re under attack! A vast, ye swabs! Repel the invaders!', 0, 0, '', 'Nous sommes attaqués ! Un vaste écouvillons! Repoussez les envahisseurs!', '', '', '', '¡Estamos bajo ataque! ¡Un vasto, hisopos! ¡Repeler a los invasores!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (340, 'taunt', 'None may challenge the Brotherhood!', 0, 0, '', 'Personne ne peut défier la Confrérie!', '', '', '', '¡Nadie puede desafiar a la Hermandad!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (341, 'taunt', 'Foolsss...Kill the one in the dress!', 0, 0, '', 'Foolsss... Tuez celui qui porte la robe!', '', '', '', 'Tontosss... ¡Matad al del vestido!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (342, 'taunt', 'I\'ll feed your soul to Hakkar himself! ', 0, 0, '', 'Je donnerai ton âme à Hakkar lui-même! ', '', '', '', '¡Le daré de comer con tu alma al mismísimo Hakkar! ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (343, 'taunt', 'Pride heralds the end of your world! Come, mortals! Face the wrath of the <randomfaction>!', 0, 0, '', 'La fierté annonce la fin de votre monde ! Venez, mortels ! Affrontez la colère des <randomfaction>!', '', '', '', '¡El orgullo anuncia el fin de tu mundo! ¡Venid, mortales! ¡Enfréntate a la ira de la <facción aleatoria>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (344, 'taunt', 'All my plans have led to this!', 0, 0, '', 'Tous mes plans ont mené à cela!', '', '', '', '¡Todos mis planes me han llevado a esto!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (345, 'taunt', 'Ahh! More lambs to the slaughter!', 0, 0, '', 'Ahhh ! Plus d\'agneaux à l\'abattoir!', '', '', '', '¡Ahh! ¡Más corderos al matadero!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (346, 'taunt', 'Another day, another glorious battle!', 0, 0, '', 'Un autre jour, une autre bataille glorieuse!', '', '', '', '¡Otro día, otra batalla gloriosa!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (347, 'taunt', 'So, business... or pleasure?', 0, 0, '', 'Alors, affaires... ou plaisir?', '', '', '', 'Entonces, ¿negocios... o placer?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (348, 'taunt', 'You are not prepared!', 0, 0, '', 'Vous n\'êtes pas prêt!', '', '', '', '¡No estás preparado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (349, 'taunt', 'The <randomfaction>\'s final conquest has begun! Once again the subjugation of this world is within our grasp. Let none survive! ', 0, 0, '', 'La conquête finale de la <randomfaction> a commencé ! Une fois de plus, l\'assujettissement de ce monde est à notre portée. Que personne ne survive!', '', '', '', '¡La conquista final de <randomfaction> ha comenzado! Una vez más, la subyugación de este mundo está a nuestro alcance. ¡Que nadie sobreviva! ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (350, 'taunt', 'Your death will be a painful one. ', 0, 0, '', 'Ta mort sera douloureuse.', '', '', '', 'Tu muerte será dolorosa. ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (351, 'taunt', 'Cry for mercy! Your meaningless lives will soon be forfeit. ', 0, 0, '', 'Crie miséricorde ! Vos vies insignifiantes seront bientôt perdues.', '', '', '', '¡Llora por piedad! Sus vidas sin sentido pronto se perderán. ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (352, 'taunt', 'Abandon all hope! The <randomfaction> has returned to finish what was begun so many years ago. This time there will be no escape! ', 0, 0, '', 'Abandonner tout espoir! La <randomfaction> est revenue pour terminer ce qui avait été commencé il y a tant d\'années. Cette fois, il n\'y aura pas d\'échappatoire!', '', '', '', '¡Abandona toda esperanza! La <randomfaction> ha regresado para terminar lo que comenzó hace tantos años. ¡Esta vez no habrá escapatoria! ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (353, 'taunt', 'Alert! You are marked for Extermination! ', 0, 0, '', 'Alerte! Vous êtes marqué pour l\'extermination!', '', '', '', '¡Alerta! ¡Estás marcado para el exterminio! ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (354, 'taunt', 'The <subzone> is for guests only...', 0, 0, '', 'La <subzone> est réservée aux invités...', '', '', '', 'La <subzone> es solo para invitados...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (355, 'taunt', 'Ha ha ha! You are hopelessly outmatched!', 0, 0, '', 'Hahaha! Vous êtes désespérément surpassé!', '', '', '', '¡Ja, ja, ja! ¡Estás irremediablemente superado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (356, 'taunt', 'I will crush your delusions of grandeur! ', 0, 0, '', 'Je vais écraser vos illusions de grandeur!', '', '', '', '¡Aplastaré tus delirios de grandeza! ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (357, 'taunt', 'Forgive me, for you are about to lose the game.', 0, 0, '', 'Pardonnez-moi, car vous êtes sur le point de perdre la partie.', '', '', '', 'Perdóname, porque estás a punto de perder el juego.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (358, 'taunt', 'Struggling only makes it worse.', 0, 0, '', 'Lutter ne fait qu\'empirer les choses.', '', '', '', 'La lucha solo lo empeora.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (359, 'taunt', 'Vermin! Leeches! Take my blood and choke on it!', 0, 0, '', 'Vermine! sangsues ! Prends mon sang et étouffe-toi avec!', '', '', '', '¡Alimañas! ¡Sanguijuelas! ¡Toma mi sangre y atragantate con ella!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (360, 'taunt', 'Not again... NOT AGAIN!', 0, 0, '', 'Pas encore... PAS ENCORE!', '', '', '', 'No otra vez... ¡NO OTRA VEZ!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (361, 'taunt', 'My blood will be the end of you!', 0, 0, '', 'Mon sang sera ta fin!', '', '', '', '¡Mi sangre será tu fin!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (362, 'taunt', 'Good, now you fight me!', 0, 0, '', 'Bien, maintenant tu me combats!', '', '', '', 'Bien, ¡ahora pelea conmigo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (363, 'taunt', 'Get da move on, guards! It be killin\' time!', 0, 0, '', 'Allez-y, gardes ! Ça va tuer le temps!', '', '', '', '¡Muévanse, guardias! ¡Será para matar el tiempo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (364, 'taunt', 'Don\'t be delayin\' your fate. Come to me now. I make your sacrifice quick.', 0, 0, '', 'Ne retardez pas votre destin. Viens à moi maintenant. Je fais votre sacrifice rapide.', '', '', '', 'No demores tu destino. Ven a mí ahora. Hago que tu sacrificio sea rápido.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (365, 'taunt', 'You be dead soon enough!', 0, 0, '', 'Tu es mort bien assez tôt!', '', '', '', '¡Estarás muerto lo suficientemente pronto!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (366, 'taunt', 'Mua-ha-ha!', 0, 0, '', 'Mua-ha-ha!', '', '', '', '¡Mua-ja-ja!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (367, 'taunt', 'I be da predator! You da prey...', 0, 0, '', 'Je suis un prédateur ! Tu es une proie...', '', '', '', '¡Soy un depredador! Eres presa...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (368, 'taunt', 'You gonna leave in pieces!', 0, 0, '', 'Tu vas partir en morceaux!', '', '', '', '¡Te vas a ir en pedazos!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (369, 'taunt', 'Death comes. Will your conscience be clear? ', 0, 0, '', 'La mort vient. Votre conscience sera-t-elle claire?', '', '', '', 'La muerte llega. ¿Tu conciencia estará limpia? ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (370, 'taunt', 'Your behavior will not be tolerated.', 0, 0, '', 'Votre comportement ne sera pas toléré.', '', '', '', 'Tu comportamiento no será tolerado', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (371, 'taunt', 'The Menagerie is for guests only.', 0, 0, '', 'La Ménagerie est réservée aux invités.', '', '', '', 'The Menagerie es solo para invitados', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (372, 'taunt', 'Hmm, unannounced visitors, Preparations must be made... ', 0, 0, '', 'Hmm, visiteurs inopinés, il faut faire des préparatifs...', '', '', '', 'Hmm, visitantes inesperados, se deben hacer preparativos... ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (373, 'taunt', 'Hostile entities detected. Threat assessment protocol active. Primary target engaged. Time minus thirty seconds to re-evaluation.', 0, 0, '', 'Entités hostiles détectées. Protocole d\'évaluation de la menace actif. Cible principale engagée. Délai de réévaluation moins trente secondes.', '', '', '', 'Entidades hostiles detectadas. Protocolo de evaluación de amenazas activo. Objetivo principal comprometido. Tiempo menos treinta segundos para la reevaluación.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (374, 'taunt', 'New toys? For me? I promise I won\'t break them this time!', 0, 0, '', 'Nouveaux jouets? Pour moi? Promis je ne les casserai pas cette fois !', '', '', '', '¿Juguetes nuevos? ¿Para mi? ¡Te prometo que no los romperé esta vez!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (375, 'taunt', 'I\'m ready to play!', 0, 0, '', 'Je suis prêt à jouer!', '', '', '', '¡Estoy listo para jugar!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (376, 'taunt', 'Shhh... it will all be over soon.', 0, 0, '', 'Chut... tout sera bientôt fini.', '', '', '', 'Shhh... todo terminará pronto.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (377, 'taunt', 'Aaaaaughibbrgubugbugrguburgle!', 0, 0, '', 'Aaaaaughibbrgubugbugrguburgle!', '', '', '', '¡Aaaaaughibbrgubugbugrguburgle!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (378, 'taunt', 'RwlRwlRwlRwl!', 0, 0, '', 'RwlRwlRwlRwl!', '', '', '', 'RwlRwlRwlRwl!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (379, 'taunt', 'You too, shall serve!', 0, 0, '', 'Toi aussi, tu serviras!', '', '', '', '¡Tú también, debes servir!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (380, 'taunt', 'Tell me... tell me everything!  Naughty secrets! I\'ll rip the secrets from your flesh!', 0, 0, '', 'Dis-moi... dis-moi tout ! Secrets coquins ! J\'arracherai les secrets de ta chair!', '', '', '', 'Cuéntame... ¡cuéntame todo! ¡Secretos traviesos! ¡Arrancaré los secretos de tu carne!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (381, 'taunt', 'Prepare yourselves, the bells have tolled! Shelter your weak, your young and your old! Each of you shall pay the final sum! Cry for mercy; the reckoning has come!', 0, 0, '', 'Préparez-vous, les cloches ont sonné ! Mettez à l\'abri vos faibles, vos jeunes et vos vieux ! Chacun de vous paiera la somme finale ! Implorez la miséricorde ; le jugement est venu!', '', '', '', '¡Prepárense, las campanas han doblado! ¡Abriga a tus débiles, a tus jóvenes ya tus viejos! ¡Cada uno de ustedes pagará la suma final! Clama por misericordia; el ajuste de cuentas ha llegado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (382, 'taunt', 'Where in Bonzo\'s brass buttons am I?', 0, 0, '', 'Où suis-je dans les boutons en laiton de Bonzo?', '', '', '', '¿Dónde estoy en los botones de latón de Bonzo?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (383, 'taunt', 'I can bear it no longer! Goblin King! Goblin King! Wherever you may be! Take this <target> far away from me!', 0, 0, '', 'Je ne peux plus le supporter ! Roi Gobelin ! Roi Gobelin ! Où que vous soyez ! Emmenez cette <target> loin de moi!', '', '', '', '¡No puedo soportarlo más! ¡Rey de los duendes! ¡Rey de los duendes! ¡WHERE quiera que estés! ¡Lleva a este <target> lejos de mí!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (384, 'taunt', 'You have thirteen hours in which to solve the labyrinth, before your baby brother becomes one of us... forever.', 0, 0, '', 'Vous avez treize heures pour résoudre le labyrinthe, avant que ton petit frère ne devienne l\'un des nôtres... pour toujours.', '', '', '', 'Tienes trece horas para resolver el laberinto, antes de que tu hermanito se convierta en uno de nosotros... para siempre', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (385, 'taunt', 'So, the <subzone> is a piece of cake, is it? Well, let\'s see how you deal with this little slice... ', 0, 0, '', 'Donc, la <subzone> est un jeu d\'enfant, n\'est-ce pas ? Eh bien, voyons comment tu gères cette petite tranche...', '', '', '', 'Entonces, la <subzone> es pan comido, ¿verdad? Bueno, veamos cómo lidias con esta pequeña porción... ', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (386, 'taunt', 'Back off, I\'ll take you on, headstrong to take on anyone, I know that you are wrong, and this is not where you belong', 0, 0, '', 'Reculez, je vais vous attaquer, têtu à affronter n\'importe qui, je sais que vous vous trompez, et ce n\'est pas votre place', '', '', '', 'Atrás, te enfrentaré, testarudo para enfrentar a cualquiera, sé que estás equivocado, y este no es el lugar al que perteneces', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (387, 'taunt', 'Show me whatcha got!', 0, 0, '', 'Montre-moi ce que tu as!', '', '', '', '¡Muéstrame lo que tienes!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (388, 'taunt', 'To the death!', 0, 0, '', 'A la mort!', '', '', '', '¡Hasta la muerte!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (389, 'taunt', 'Twin blade action, for a clean close shave every time.', 0, 0, '', 'Action à double lame, pour un rasage de près propre à chaque fois.', '', '', '', 'Acción de cuchilla doble, para un afeitado limpio y apurado en todo momento.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (390, 'taunt', 'Bring it on!', 0, 0, '', 'Allez-y!', '', '', '', '¡Adelante!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (391, 'taunt', 'You\'re goin\' down!', 0, 0, '', 'Tu descends!', '', '', '', '¡Vas a caer!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (392, 'taunt', 'Stabby stab stab!', 0, 0, '', 'Coup de poignard poignardé!', '', '', '', '¡Puñalada puñalada puñalada!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (393, 'taunt', 'Let\'s get this over quick; time is mana.', 0, 0, '', 'Finissons-en vite ; le temps c\'est du mana.', '', '', '', 'Terminemos con esto rápido; el tiempo es maná.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (394, 'taunt', 'I do not think you realise the gravity of your situation.', 0, 0, '', 'Je ne pense pas que tu te rendes compte de la gravité de ta situation.', '', '', '', 'No creo que te des cuenta de la gravedad de tu situación.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (395, 'taunt', 'I will bring honor to my family and my kingdom!', 0, 0, '', 'Je ferai honneur à ma famille et à mon royaume!', '', '', '', '¡Llevaré honor a mi familia y mi reino!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (396, 'taunt', 'Light, give me strength!', 0, 0, '', 'Lumière, donne-moi la force!', '', '', '', '¡Luz, dame fuerza!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (397, 'taunt', 'My church is the field of battle - time to worship...', 0, 0, '', 'Mon église est le champ de bataille - il est temps d\'adorer...', '', '', '', 'Mi iglesia es el campo de batalla - hora de adorar...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (398, 'taunt', 'I hold you in contempt...', 0, 0, '', 'Je te méprise...', '', '', '', 'Te tengo en desacato...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (399, 'taunt', 'Face the hammer of justice!', 0, 0, '', 'Affrontez le marteau de la justice!', '', '', '', '¡Enfréntate al martillo de la justicia!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (400, 'taunt', 'Prove your worth in the test of arms under the Light!', 0, 0, '', 'Prouvez votre valeur dans l\'épreuve des armes sous la Lumière!', '', '', '', '¡Demuestra tu valía en la prueba de las armas bajo la Luz!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (401, 'taunt', 'All must fall before the might and right of my cause, you shall be next!', 0, 0, '', 'Tout doit tomber devant la force et le droit de ma cause, vous serez le prochain!', '', '', '', 'Todo debe caer ante el poder y el derecho de mi causa, ¡tú serás el próximo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (402, 'taunt', 'Prepare to die!', 0, 0, '', 'Préparez-vous à mourir!', '', '', '', '¡Prepárate para morir!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (403, 'taunt', 'The beast with me is nothing compared to the beast within...', 0, 0, '', 'La bête avec moi n\'est rien comparée à la bête à l\'intérieur...', '', '', '', 'La bestia conmigo no es nada comparada con la bestia interior...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (404, 'taunt', 'Witness the firepower of this fully armed huntsman!', 0, 0, '', 'Soyez témoin de la puissance de feu de ce chasseur entièrement armé!', '', '', '', '¡Sea testigo de la potencia de fuego de este cazador completamente armado!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (405, 'critical health', 'Heal me! Quick!', 0, 0, '', 'Soigne moi! Vite!', '', '', '', '¡Cúrame! ¡Rápido!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (406, 'critical health', 'Almost dead! Heal me!', 0, 0, '', 'Presque mort! Soigne moi!', '', '', '', '¡Estoy casi muerto! ¡Cúrame!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (407, 'critical health', 'Help! Heal me!', 0, 0, '', 'Aider! Soigne moi!', '', '', '', '¡Ayuda! ¡Cúrame!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (408, 'critical health', 'Somebody! Heal me!', 0, 0, '', 'Quelqu\'un! Soigne moi!', '', '', '', '¡Alguien! ¡Cúrame!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (409, 'critical health', 'Heal! Heal! Heal!', 0, 0, '', 'Soigner! Soigner! Soigner!', '', '', '', '¡Curame! ¡Saname! ¡Socorro!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (410, 'critical health', 'I am dying! Heal! Aaaaarhg!', 0, 0, '', 'Je meurs! Soigner! Aaaaarhg!', '', '', '', '¡Me estoy muriendo! ¡Saname! ¡Aaaaarhg!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (411, 'critical health', 'Heal me!', 0, 0, '', 'Soigne moi!', '', '', '', '¡Cúrame!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (412, 'critical health', 'I will die. I will die. I will die. Heal!', 0, 0, '', 'Je vais mourir. Je vais mourir. Je vais mourir. Soigner!', '', '', '', 'Voy a morir. Voy a morir. Voy a morir. ¡Saname!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (413, 'critical health', 'Healers, where are you? I am dying!', 0, 0, '', 'Guérisseurs, où êtes-vous ? Je meurs!', '', '', '', 'Sanadores, ¿dónde estais? ¡Me estoy muriendo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (414, 'critical health', 'Oh the pain. Heal me quick!', 0, 0, '', 'Ah la douleur. Guéris-moi vite!', '', '', '', 'Ouch, qué dolor. ¡Cúrame rápido!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (415, 'low health', 'Need heal', 0, 0, '', 'Besoin de guérir', '', '', '', 'Necesito una cura', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (416, 'low health', 'Low health', 0, 0, '', 'Santé faible', '', '', '', 'Salud baja', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (417, 'low health', 'Drop a heal. Please.', 0, 0, '', 'Dépose un soin. S\'il te plaît.', '', '', '', 'Una sanación por favor.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (418, 'low health', 'Could somebody drop a heal on me?', 0, 0, '', 'Quelqu\'un pourrait-il me soigner?', '', '', '', '¿Alguien podría curarme?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (419, 'low health', 'Hey! Better heal me now than rez later', 0, 0, '', 'Hey! Mieux vaut me soigner maintenant que rez plus tard', '', '', '', '¡Oye! Mejor curarme ahora que resucitarme después', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (420, 'low health', 'I am sorry. Need another heal', 0, 0, '', 'Je suis désolé. J\'ai besoin d\'un autre soin', '', '', '', 'Lo siento. Necesito otra curación', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (421, 'low health', 'Damn mobs. Heal me please', 0, 0, '', 'Maudits mobs. Guéris moi s\'il te plait', '', '', '', '¡Malditos bichos! ¡Una curita por favor!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (422, 'low health', 'One more hit and I am done for. Heal please', 0, 0, '', 'Un coup de plus et c\'est fini. Guéris moi s\'il te plait', '', '', '', 'Un golpe más y estoy acabado. Cura por favor', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (423, 'low health', 'Are there any healers?', 0, 0, '', 'Y a-t-il des guérisseurs?', '', '', '', '¿Hay sanadores?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (424, 'low health', 'Why do they always punch me in the face? Need heal', 0, 0, '', 'Pourquoi me frappent-ils toujours au visage? Besoin de soins', '', '', '', '¿Por qué siempre me golpean en la cara? Necesito sanacion', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (425, 'low health', 'Can anybody heal me a bit?', 0, 0, '', 'Quelqu\'un peut-il me guérir un peu?', '', '', '', '¿Alguien puede curarme un poco?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (426, 'low mana', 'OOM', 0, 0, '', 'MOO', '', '', '', 'No tengo mana!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (427, 'low mana', 'I am out of mana', 0, 0, '', 'je n\'ai plus de mana', '', '', '', 'No tengo maná', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (428, 'low mana', 'Damn I wasted all my mana on this', 0, 0, '', 'Putain j\'ai gaspillé tout mon mana sur ça', '', '', '', 'Me cago en todo! Malgasté todo mi maná enseguida', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (429, 'low mana', 'You should wait until I drink or regenerate my mana', 0, 0, '', 'Vous devriez attendre que je boive ou que je régénère mon mana', '', '', '', 'Deberías esperar hasta que beba o regenere mi maná', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (430, 'low mana', 'Low mana', 0, 0, '', 'Mana faible', '', '', '', 'Maná bajo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (431, 'low mana', 'No mana. Again?', 0, 0, '', 'Pas de mana. De nouveau?', '', '', '', 'Sin maná. ¿Otra vez?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (432, 'low mana', 'Low mana. Wanna drink', 0, 0, '', 'Mana faible. Je veux boire', '', '', '', 'Maná bajo. Quiero beber', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (433, 'low mana', 'Do we have a vending machine? Out of mana again', 0, 0, '', 'Avons-nous un distributeur automatique? Plus de mana à nouveau', '', '', '', '¿Tenemos una máquina expendedora? Sin maná otra vez', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (434, 'low mana', 'My mana is history', 0, 0, '', 'Mon mana appartient à l\'histoire', '', '', '', 'Mi maná es historia', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (435, 'low mana', 'I\'d get some drinks next time. Out of mana', 0, 0, '', 'Je prendrais quelques verres la prochaine fois. Manque de mana', '', '', '', '¡No tengo maná! Tengo que comprar bebidas la próxima vez...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (436, 'low mana', 'Where is my mana?', 0, 0, '', 'Où est mon mana?', '', '', '', '¿Dónde está mi maná?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (437, 'aoe', 'Oh god!', 0, 0, '', 'Oh mon Dieu!', '', '', '', '¡Oh, Dios!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (438, 'aoe', 'I am scared', 0, 0, '', 'j\'ai peur', '', '', '', 'Tengo miedo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (439, 'aoe', 'We are done for', 0, 0, '', 'Nous avons fini pour', '', '', '', 'Hemos terminado', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (440, 'aoe', 'This is over', 0, 0, '', 'C\'est terminé', '', '', '', 'Esto se acabó', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (441, 'aoe', 'This ends now', 0, 0, '', 'Cela se termine maintenant', '', '', '', 'Esto termina ahora', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (442, 'aoe', 'Could somebody cast blizzard or something?', 0, 0, '', 'Quelqu\'un pourrait-il lancer le blizzard ou quelque chose comme ça?', '', '', '', '¿Alguien podría lanzar ventisca o algo así?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (443, 'aoe', 'Damn. The tank aggroed all the mobs around', 0, 0, '', 'Mince. Le tank a agro toutes les mobs autour', '', '', '', '¡Me cago en todo! El tanque atrajo a todos los mobs...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (444, 'aoe', 'We gonna die. We gonna die. We gonna die.', 0, 0, '', 'Nous allons mourir. Nous allons mourir. Nous allons mourir.', '', '', '', 'Vamos a morir. Vamos a morir. Vamos a morir.', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (445, 'aoe', 'Whoa! So many toys to play with', 0, 0, '', 'Ouah ! Tant de jouets avec lesquels jouer', '', '', '', '¡Vaya! Tantos juguetes con los que jugar', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (446, 'aoe', 'I gonna kill them all!', 0, 0, '', 'Je vais tous les tuer!', '', '', '', '¡Voy a matarlos a todos!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (447, 'aoe', 'If the tank dies we are history', 0, 0, '', 'Si le tank meurt, nous appartenons à l\'histoire', '', '', '', 'Si el tanque muere somos historia', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (448, 'aoe', 'Aaaaaargh!', 0, 0, '', 'Aaaaaargh!', '', '', '', '¡Aaaaaargh!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (449, 'aoe', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', 0, 0, '', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', '', '', '', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (450, 'aoe', 'Right. What do we have in AOE?', 0, 0, '', 'D\'accord. Qu\'avons-nous en dégats de zone?', '', '', '', 'Claro. ¿Qué tenemos en AOE?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (451, 'aoe', 'This gets interesting', 0, 0, '', 'Cela devient intéressant', '', '', '', 'Esto se pone interesante', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (452, 'aoe', 'Cool. Get them in one place for a good flamestrike', 0, 0, '', 'Cool. Rassemblez-les au même endroit pour un bon coup de flamme', '', '', '', 'Genial! Ponlos todos juntos para un buen ataque en area', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (453, 'aoe', 'Kill! Kill! Kill!', 0, 0, '', 'Tuer! Tuer! Tuer!', '', '', '', '¡Matar! ¡Matar! ¡Matar!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (454, 'aoe', 'I think my pants are wet', 0, 0, '', 'Je pense que mon pantalon est mouillé', '', '', '', 'Creo que mis pantalones están mojados', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (455, 'aoe', 'We are history', 0, 0, '', 'Nous sommes l\'histoire', '', '', '', 'Somos historia', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (456, 'aoe', 'I hope healers are ready. Leeeeroy!', 0, 0, '', 'J\'espère que les guérisseurs sont prêts. Leeeeeroy!', '', '', '', 'Espero que los sanadores estén listos. ¡Leeeroy!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (457, 'aoe', 'I hope they won\'t come for me', 0, 0, '', 'j\'espère qu\'ils ont gagné, qu\'ils ne viendront pas pour moi', '', '', '', 'Espero que no vengan por mí', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (458, 'aoe', 'Oh no. I can\'t see at this slaugther', 0, 0, '', 'Oh non. Je ne peux pas voir à ce massacre', '', '', '', 'Oh, no. No puedo ver esta matanza', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (459, 'loot', 'I hope there will be some money', 0, 0, '', 'j\'espère qu\'il y aura de l\'argent', '', '', '', 'Espero que haya algo de dinero...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (460, 'loot', 'Loot! Loot!', 0, 0, '', 'Butin! Butin!', '', '', '', '¡Botín! ¡Botín!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (461, 'loot', 'My precious', 0, 0, '', 'Mon précieux', '', '', '', 'Mi tesoro...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (462, 'loot', 'I hope there is a shiny epic item waiting for me there', 0, 0, '', 'J\'espère qu\'il y a un objet épique brillant qui m\'attend ici', '', '', '', 'Espero que haya un objeto épico brillante esperándome allí', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (463, 'loot', 'I have deep pockets and bags', 0, 0, '', 'J\'ai des poches et des sacs profonds', '', '', '', 'Tengo bolsillos profundos y infinitos', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (464, 'loot', 'All is mine!', 0, 0, '', 'Tout est à moi!', '', '', '', '¡Todo es mío!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (465, 'loot', 'Hope no gray shit today', 0, 0, '', 'J\'espère pas de merde grise aujourd\'hui', '', '', '', 'Espero que hoy no haya mierda gris', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (466, 'loot', 'This loot is MINE!', 0, 0, '', 'Ce butin est à MOI!', '', '', '', '¡Este botín es MÍO!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (467, 'loot', 'Looting is disgusting but I need money', 0, 0, '', 'Le pillage est dégoûtant mais j\'ai besoin d\'argent', '', '', '', 'El saqueo es repugnante pero necesito dinero...', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (468, 'loot', 'Gold!', 0, 0, '', 'Or!', '', '', '', '¡Oro!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (469, 'loot', 'OK. Let\'s see what they\'ve got', 0, 0, '', 'D\'ACCORD. Voyons ce qu\'ils ont', '', '', '', 'OK. Veamos qué tienen', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (470, 'loot', 'Do not worry. I will loot eveything', 0, 0, '', 'Ne t\'inquiète pas. je vais tout piller', '', '', '', 'No te preocupes. Saquearé todo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (471, 'loot', 'I am loot ninja', 0, 0, '', 'je suis un ninja de butin', '', '', '', 'Soy un ladron de tesoros', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (472, 'loot', 'Do I neeed to roll?', 0, 0, '', 'Dois-je recommencer?', '', '', '', '¿Necesito lanzar dados?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (473, 'loot', 'Somebody explain me, where they did put all this stuff?', 0, 0, '', 'Quelqu\'un m\'explique, où ils ont mis tout ça?', '', '', '', 'Alguien me explica, ¿dónde pusieron todas estas cosas?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (474, 'loot', 'No, I won\'t loot gray shit', 0, 0, '', 'Non, je ne pillerai pas la merde grise', '', '', '', 'No, no saquearé mierda gris', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (475, 'loot', 'I\'m first. I\'m first. I\'m first.', 0, 0, '', 'Je suis le premier. Je suis le premier. Je suis le premier.', '', '', '', '¡Es mio! ¡Es mio! ¡Es mio!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (476, 'loot', 'Give me your money!', 0, 0, '', 'Donne-moi ton argent!', '', '', '', '¡Dame todo tu dinero!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (477, 'loot', 'My pockets are empty, I need to fill them', 0, 0, '', 'Mes poches sont vides, j\'ai besoin de les remplir', '', '', '', 'Mis bolsillos están vacíos y necesitan llenarse!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (478, 'loot', 'I\'ve got a new bag for this', 0, 0, '', 'J\'ai un nouveau sac pour ça', '', '', '', 'Tengo una nueva bolsa para esto', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (479, 'loot', 'I hope I won\'t aggro anybody while looting', 0, 0, '', 'J\'espère que je n\'agresserai personne pendant le pillage', '', '', '', 'Espero no ofender a nadie mientras saqueo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (480, 'loot', 'Please don\'t watch. I am looting', 0, 0, '', 'S\'il vous plaît, ne regardez pas. je pille', '', '', '', 'Por favor, no mires. Estoy saqueando', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (481, 'loot', 'Ha! You won\'t get any piece of it!', 0, 0, '', 'Ha! Vous n\'en aurez aucun morceau!', '', '', '', '¡Ja! ¡No obtendrás nada de eso!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (482, 'loot', 'Looting is cool', 0, 0, '', 'Le pillage c\'est cool', '', '', '', 'Saquear es genial', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (483, 'loot', 'I like new gear', 0, 0, '', 'j\'aime le nouveau matos', '', '', '', 'Me gusta el equipo nuevo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (484, 'loot', 'I\'l quit if there is nothing valuable again', 0, 0, '', 'J\'arrêterai s\'il n\'y a plus rien de précieux', '', '', '', 'Me doy por vencido si no hay nada util', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (485, 'loot', 'I hope it is be a pretty ring', 0, 0, '', 'j\'espère que c\'est une jolie bague', '', '', '', 'Espero que sea un anillo bonito', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (486, 'loot', 'I\'l rip the loot from you', 0, 0, '', 'Je t\'arracherai le butin', '', '', '', 'Te arrancaré el botín', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (487, 'loot', 'Everybody stay off. I\'m going to loot', 0, 0, '', 'Tout le monde reste à l\'écart. je vais piller', '', '', '', '¡Alejaos todos! Voy a lootear', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (488, 'loot', 'Sweet loot', 0, 0, '', 'Doux butin', '', '', '', 'Dulce botín', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (489, 'loot', 'The Roll God! Give me an epic today', 0, 0, '', 'Le Dieu du rouleau ! Donnez-moi de l\'épique aujourd\'hui', '', '', '', '¡El Dios de los dados! Dame un epico hoy', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (490, 'loot', 'Please give me new toys', 0, 0, '', 'S\'il te plaît, donne-moi de nouveaux jouets', '', '', '', 'Por favor, dame nuevos juguetes', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (491, 'loot', 'I hope they carry tasties', 0, 0, '', 'J\'espère qu\'ils portent des saveurs', '', '', '', 'Espero que caiga algo sabrosos', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (492, 'loot', 'The gold is mine. I\'l leave everyting, I promise', 0, 0, '', 'L\'or est à moi. Je laisse tout, je promets', '', '', '', 'El oro es mío. Dejaré todo lo demas, lo prometo!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (493, 'loot', 'No, I can\'t resist', 0, 0, '', 'Non, je ne peux pas résister', '', '', '', 'No, no puedo resistir', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (494, 'loot', 'I want more!', 0, 0, '', 'Je veux plus!', '', '', '', '¡Quiero más!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (495, 'low ammo', 'I have few <ammo> left!', 0, 0, '', 'Il me reste peu de <ammo>!', '', '', '', '¡Me quedan pocas <ammo>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (496, 'low ammo', 'I need more <ammo>!', 0, 0, '', 'J\'ai besoin de plus de <ammo>!', '', '', '', '¡Necesito más <ammo>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (497, 'low ammo', '100 <ammo> left!', 0, 0, '', 'Il reste 100 <ammo>!', '', '', '', '¡Quedan 100 <ammo>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (498, 'no ammo', 'That\'s it! No <ammo>!', 0, 0, '', 'C\'est ça! Pas de <ammo>!', '', '', '', '¡Eso es todo! ¡Sin <ammo>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (499, 'no ammo', 'And you have my bow... Oops, no <ammo>!', 0, 0, '', 'Et vous avez mon arc... Oups, pas de <ammo>!', '', '', '', 'Y tú tienes mi arco... ¡Uy, sin <ammo>!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (500, 'no ammo', 'Need ammo!', 0, 0, '', 'Besoin de munitions!', '', '', '', '¡Necesito munición!', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (501, 'hello', 'Hello', 0, 0, '', '', '', '', '', 'Hola', '', 'Привет');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (502, 'hello', 'Hello!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Привет!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (503, 'hello', 'Hi', 0, 0, '', '', '', '', '', 'Hola', '', 'Прив');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (504, 'hello', 'Hi!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Прив!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (505, 'hello', 'Hello there!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Здарова!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (506, 'hello_follow', 'Hello, I follow you!', 0, 0, '', '', '', '', '', '¡Hola, te sigo!', '', 'Привет, иду за тобой!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (507, 'hello_follow', 'Hello, lead the way!', 0, 0, '', '', '', '', '', '¡Hola, guía el camino!', '', 'Привет, веди!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (508, 'hello_follow', 'Hi, lead the way!', 0, 0, '', '', '', '', '', '¡Hola, guía el camino!', '', 'Прив, веди!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (509, 'logout_cancel', 'Logout cancelled!', 0, 0, '', '', '', '', '', 'Cerrar sesión cancelado!', '', 'Логаут отменен!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (510, 'logout_start', 'I\'m logging out!', 0, 0, '', '', '', '', '', '¡Me estoy desconectando!', '', 'Я выхожу из игры!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (511, 'goodbye', 'Goodbye!', 0, 0, '', '', '', '', '', '¡Adiós!', '', 'Пока!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (512, 'goodbye', 'Bye bye!', 0, 0, '', '', '', '', '', '¡Adiós!', '', 'Пока пока!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (513, 'goodbye', 'See you later!', 0, 0, '', '', '', '', '', '¡Hasta luego!', '', 'Увидимся позже!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (514, 'quest_accept', 'Quest accepted', 0, 0, '', '', '', '', '', 'Misión aceptada', '', 'Квест взят');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (515, 'quest_remove', 'Quest removed', 0, 0, '', '', '', '', '', 'Misión eliminada', '', 'Квест отменен');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (516, 'quest_cant_take', 'I can\'t take this quest', 0, 0, '', '', '', '', '', 'No puedo tomar esta búsqueda', '', 'Я не могу взять этот квест');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (517, 'following', 'Following', 0, 0, '', '', '', '', '', 'Te sigo', '', 'Следую');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (518, 'staying', 'Staying', 0, 0, '', '', '', '', '', 'Me quedo aqui', '', 'Стою');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (519, 'fleeing', 'Fleeing', 0, 0, '', '', '', '', '', 'Huyendo', '', 'Убегаю');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (520, 'fleeing_far', 'I won\'t flee with you, you are too far away', 0, 0, '', '', '', '', '', 'No huiré contigo, estás demasiado lejos', '', 'Я с тобой не побегу, ты слишком далеко');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (521, 'grinding', 'Grinding', 0, 0, '', '', '', '', '', 'Farmeando', '', 'Гриндю');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (522, 'attacking', 'Attacking', 0, 0, '', '', '', '', '', 'Atacando', '', 'Атакую');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (523, 'wait_travel_close', 'I am close, wait for me!', 0, 0, '', '', '', '', '', '¡Estoy cerca, espérame!', '', 'Я тут рядом, подожди!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (524, 'wait_travel_close', 'I\'m not far, please wait!', 0, 0, '', '', '', '', '', 'No estoy lejos, ¡esperame por favor!', '', 'Я недалеко, погодите!');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (525, 'wait_travel_medium', 'I\'m heading to your location', 0, 0, '', '', '', '', '', 'Me dirijo a tu ubicación', '', 'Двигаюсь к тебе');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (526, 'wait_travel_medium', 'I\'m coming to you', 0, 0, '', '', '', '', '', 'Voy hacia ti', '', 'Иду к тебе');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (527, 'wait_travel_far', 'I\'m traveling to your location', 0, 0, '', '', '', '', '', 'Voy a viajar a tu ubicación', '', 'Направляюсь к тебе');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (528, 'wait_travel_far', 'I\'m trying to get to you', 0, 0, '', '', '', '', '', 'Estoy tratando de llegar a ti', '', 'Пытаюсь до тебя добраться');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (529, 'error_far', 'It is too far away', 0, 0, '', '', '', '', '', 'Estas demasiado lejos', '', 'Слишком далеко');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (530, 'error_water', 'It is under water', 0, 0, '', '', '', '', '', 'Estas debajo del agua', '', 'Это под водой');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (531, 'error_cant_go', 'I can\'t go there', 0, 0, '', '', '', '', '', 'No puedo ir allí', '', 'Я не могу туда пройти');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (532, 'error_guild', 'I\'m not in your guild!', 0, 0, '', '', '', '', '', '¡No estoy en tu hermandad!', '', 'Я не в твоей гильдии');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (533, 'error_gbank_found', 'Can not find a guild bank nearby', 0, 0, '', '', '', '', '', 'No se puede encontrar un banco de hermandad cercano', '', 'Не могу найти гильд банк рядом');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (534, 'error_cant_put', 'I can\'t put ', 0, 0, '', '', '', '', '', 'No puedo depositar ', '', 'Я не могу положить');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (535, 'error_gbank_rights', 'I have no rights to put items in the first guild bank tab', 0, 0, '', '', '', '', '', 'No tengo derechos para depositar objetos en la primera pestaña del banco de hermandad', '', 'Нет прав чтобы класть вещи в первую вкладку гильд банка');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (536, 'gbank_put', ' put to guild bank', 0, 0, '', '', '', '', '', ' depositado en el banco de hermandad', '', ' теперь в гильд банке');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (537, 'free_moving', 'Free moving', 0, 0, '', '', '', '', '', 'Moviendome libremente', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (538, 'guarding', 'Guarding', 0, 0, '', '', '', '', '', 'Protegiendo la posición', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (539, 'use_command', 'Using %target', 0, 0, '', '', '', '', '', 'Usando %target', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (540, 'command_target_unit', 'on %unit', 0, 0, '', '', '', '', '', 'en %unit', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (541, 'use_command_remaining', '(%amount available)', 0, 0, '', '', '', '', '', '(%amount restante)', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (542, 'use_command_last', '(the last one)', 0, 0, '', '', '', '', '', '(el último)', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (543, 'use_command_socket_error', 'The socket does not fit', 0, 0, '', '', '', '', '', 'La ranura no sirve', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (545, 'command_target_trade', 'on trade item', 0, 0, '', '', '', '', '', 'en objeto comerciado', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (546, 'command_target_self', 'on myself', 0, 0, '', '', '', '', '', 'en mi', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (547, 'command_target_item', 'on %item', 0, 0, '', '', '', '', '', 'en %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (548, 'command_target_go', 'on %gameobject', 0, 0, '', '', '', '', '', 'en %gameobject', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (549, 'loot_command', 'Looting %item', 0, 0, '', '', '', '', '', 'Despojando %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (550, 'cast_spell_command_summon', 'Summoning %target', 0, 0, '', '', '', '', '', 'Invocando a %target', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (551, 'cast_spell_command_summon_error_members', 'I don\'t have enough party members around to cast a summon', 0, 0, '', '', '', '', '', 'No tengo suficientes miembros de grupo alrededor para invocar', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (552, 'cast_spell_command_summon_error_target', 'Failed to find the summon target', 0, 0, '', '', '', '', '', 'No he podido encontrar al objetivo de la invocación', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (553, 'cast_spell_command_summon_error_combat', 'I can\'t summon while I\'m in combat', 0, 0, '', '', '', '', '', 'No puedo invocar durante un combate', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (554, 'cast_spell_command_error_unknown_spell', 'I don\'t know the spell %spell', 0, 0, '', '', '', '', '', 'No conozco el hechizo %spell', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (555, 'cast_spell_command_spell', 'Casting %spell', 0, 0, '', '', '', '', '', 'Lanzando %spell', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (556, 'cast_spell_command_craft', 'Crafting %spell', 0, 0, '', '', '', '', '', 'Creando %spell', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (557, 'cast_spell_command_error', 'Cannot cast %spell', 0, 0, '', '', '', '', '', 'No puedo lanzar %spell', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (558, 'cast_spell_command_error_failed', 'Failed to cast %spell', 0, 0, '', '', '', '', '', 'Fallo al lanzar %spell', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (559, 'cast_spell_command_amount', ' |cffffff00(x%amount left)|r', 0, 0, '', '', '', '', '', ' |cffffff00(x%amount restante)|r', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (560, 'join_group', 'Hey %player, do you want join my group?', 0, 0, '', '', '', '', '', 'Oye %player, ¿Quieres unirte a mi grupo?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (561, 'join_raid', 'Hey %player, do you want join my group?', 0, 0, '', '', '', '', '', 'Oye %player, ¿Quieres unirte a mi banda?', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (562, 'quest_error_talk', 'I can\'t talk with the quest giver', 0, 0, '', '', '', '', '', 'No puedo hablar con el propietario de la mision', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (563, 'quest_error_completed', 'I have already completed %quest', 0, 0, '', '', '', '', '', 'Ya he completado la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (564, 'quest_error_have_quest', 'I already have %quest', 0, 0, '', '', '', '', '', 'Ya tengo la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (565, 'quest_error_cant_take', 'I can\'t take %quest', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (566, 'quest_error_log_full', 'I can\'t take %quest because my quest log is full', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest porque mi registro de misiones esta completo', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (567, 'quest_error_bag_full', 'I can\'t take %quest because my bag is full', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest porque mi inventario esta lleno', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (568, 'quest_accepted', 'I have accepted %quest', 0, 0, '', '', '', '', '', 'He aceptado la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (569, 'quest_status_incomplete', 'I have not completed the quest %quest', 0, 0, '', '', '', '', '', 'No he completado la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (570, 'quest_status_available', 'Quest %quest available', 0, 0, '', '', '', '', '', 'Mision %quest disponible', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (571, 'quest_status_failed', 'I have failed the quest %quest', 0, 0, '', '', '', '', '', 'He fallado la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (572, 'quest_status_unable_to_complete', 'I am unable to turn in the quest %quest', 0, 0, '', '', '', '', '', 'No puedo entregar la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (573, 'quest_status_completed', 'I have completed the quest %quest', 0, 0, '', '', '', '', '', 'He completado la mision %quest', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (574, 'quest_status_complete_single_reward', 'I have completed the quest %quest and received %item', 0, 0, '', '', '', '', '', 'He completado la mision %quest y he recibido %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (575, 'quest_status_complete_pick_reward', 'Which reward should I pick for completing the quest %quest?%rewards', 0, 0, '', '', '', '', '', '¿Que recompensa deberia escoger por completar la mision %quest?%rewards', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (576, 'quest_choose_reward', 'Okay, I will pick %item as a reward', 0, 0, '', '', '', '', '', 'De acuerdo, voy a escoger %item de recompensa', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (577, 'equip_command', 'Equipping %item', 0, 0, '', '', '', '', '', 'Me he equipado %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (578, 'unequip_command', '%item unequipped', 0, 0, '', '', '', '', '', 'Me he quitado %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (579, 'auto_learn_spell', 'I have learned the spells: %spells', 0, 0, '', '', '', '', '', 'He aprendido los hechizos: %spells', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (580, 'use_command_item_cooldown', '%item is in cooldown', 0, 0, '', '', '', '', '', '%item esta recargandose', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (581, 'use_command_item_not_owned', 'I don''t have %item in my inventory', 0, 0, '', '', '', '', '', 'No tengo %item en mi inventario', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (582, 'use_command_invalid_item', 'The item with the id %item does not exist', 0, 0, '', '', '', '', '', 'El objeto con el id %item no existe', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (583, 'use_command_socket', 'Socketing %gem into %item', 0, 0, '', '', '', '', '', 'Insertando %gem en %item', '', '');
-INSERT INTO `ai_playerbot_texts` (`id`, `name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES (584, 'use_command_item_error', 'I can''t use %item', 0, 0, '', '', '', '', '', 'No puedo usar %item', '', '');
+INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`, `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`) VALUES
+
+-- strings
+('string_unknown_area', 'the middle of nowhere', 0, 0, '', '', '', '', '', '', '', ''),
+('string_unknown_area', 'an undisclosed location', 0, 0, '', '', '', '', '', '', '', ''),
+('string_unknown_area', 'somewhere', 0, 0, '', '', '', '', '', '', '', ''),
+
+('string_empty_link', 'something', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- looting item events
+-- usable placeholders:
+-- %item_link
+-- %zone_name
+-- %area_name
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_looting_item_normal', 'wonder what %item_link tastes like', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_poor', 'nooo, I got %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_poor', 'aww not this trash again %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_poor', 'seem to be looting trash %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_poor', 'well, it\'s better than nothing I guess %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_poor', 'not sure what to do with %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_normal', 'wonder what %item_link tastes like', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_normal', 'well, I can keep looting %item_link all day', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_normal', 'another day, another %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_normal', 'looted some %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_normal', 'some %item_link is alright', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_uncommon', 'not bad, I just got %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_uncommon', 'just looted %item_link in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_uncommon', 'I could put that to good use %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_uncommon', 'money money money %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_uncommon', 'got %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_rare', '%item_link is hunter bis', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', '%item_link is %my_class bis', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', 'RNG is not bad today %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', 'sweet %item_link, freshly looted', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', 'wow, I just got %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_rare', '%item_link is hunter bis', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', '%item_link is %my_class bis', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', 'RNG is not bad today %item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_rare', 'sweet %item_link, freshly looted', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_looting_item_epic', 'OMG, look at what I just got %item_link!!!', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_legendary', 'No @#$@% way! This can not be, I got %item_link, this is insane', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_looting_item_artifact', 'No @#$@% way! This can not be, I got %item_link, this is insane', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+
+-- quest events
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_accepted_generic', 'I have just taken the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_accepted_generic', 'just accepted %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_accepted_generic', '%quest_link gonna try to complete this one', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_accepted_generic', 'took %quest_link in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %quest_obj_available
+-- %quest_obj_required
+-- %quest_obj_missing
+-- %quest_obj_name
+-- %quest_obj_full_formatted
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_objective_completed_generic', 'Finally done with the %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_objective_completed_generic', 'finally got %quest_obj_available/%quest_obj_required of %quest_obj_name for the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_objective_completed_generic', '%quest_obj_full_formatted for the %quest_link, at last', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_quest_objective_progress_generic', 'Oof, got %quest_obj_available/%quest_obj_required %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_objective_progress_generic', 'still need %quest_obj_missing more of %quest_obj_name for %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_objective_progress_generic', '%quest_obj_full_formatted, still working on %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- usable placeholders:
+-- %quest_link
+-- %zone_name
+-- %area_name
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_quest_completed_generic', 'Yess, I have finally completed the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_completed_generic', 'completed the %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_completed_generic', 'managed to finish %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_completed_generic', 'just finished %quest_link', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_quest_completed_generic', 'just finished %quest_link in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- kill mob events
+-- usable placeholders:
+-- %victim_name
+-- %zone_name
+-- %area_name
+-- %victim_level
+-- %my_race
+-- %my_class
+-- %my_level
+('broadcast_killed_normal', 'another %victim_name down', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_normal', 'I keep killing %victim_name, nothing to talk about', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_normal', 'another %victim_name bites the dust', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_normal', 'one less %victim_name in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_elite', 'Took down this elite bastard %victim_name!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_player', 'killed elite %victim_name in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_rareelite', 'Fooof, managed to take down %victim_name!', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_worldboss', 'That was sick! Just killed %victim_name! Can tell tales now', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_rare', 'Yoo, I just killed %victim_name!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_player', 'killed rare %victim_name in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_unknown', 'WTF did I just kill? %victim_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_killed_pet', 'Just killed that pet %victim_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- for broadcast_killed_player additionally can use %victim_class
+('broadcast_killed_player', 'Oh yeah, I just killed %victim_name', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_killed_player', 'killed %victim_name in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- levelup events
+-- usable placeholders:
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('broadcast_levelup_generic', 'Ding!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_generic', 'Yess, I am level %my_level!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_generic', 'I just leveled up', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_levelup_10x', 'I am level %my_level!!!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_10x', 'getting stronger, already level %my_level!!!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_10x', 'Just reached level %my_level!!!', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_levelup_max_level', 'OMG, finally level %my_level!!!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_max_level', '%my_level!!! can do endgame content now', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_max_level', 'fresh new level %my_level %my_class!!!', 0, 0, '', '', '', '', '', '', '', ''),
+('broadcast_levelup_max_level', 'one more level %my_level %my_race %my_class!', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- guild
+-- usable placeholders:
+-- %other_name
+-- %other_class
+-- %other_race
+-- %other_level
+('broadcast_guild_promotion', 'Good job %other_name. You deserved this.', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+('broadcast_guild_demotion', 'That was awful %other_name. I hate to do this but...', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+
+-- /////////////////////////////
+-- suggestions
+
+
+-- random instance
+-- usable placeholders:
+-- %my_role
+-- %instance_name
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_instance', 'Anyone wants %instance_name?', 0, 0, '', 'Quelqu\'un fait %instance_name ?', '', '', '', '¿Alguien quiere ir a %instance_name?', '', ''),
+('suggest_instance', 'Any groups for %instance_name?', 0, 0, '', 'Des groupes pour %instance_name ?', '', '', '', '¿Algún grupo para %instance_name?', '', ''),
+('suggest_instance', 'Need help for %instance_name?', 0, 0, '', 'Besoin d\'aide pour %instance_name ?', '', '', '', '¿Alguien necesita ayuda con %instance_name?', '', ''),
+('suggest_instance', 'LFD: %instance_name.', 0, 0, '', 'Cherche à faire : %instance_name', '', '', '', 'Busco grupo para %instance_name.', '', ''),
+('suggest_instance', 'Anyone needs %my_role for %instance_name?', 0, 0, '', 'Quelqu\'un a besoin de %my_role pour %instance_name ?', '', '', '', '¿Alguien necesita un %my_role para %instance_name?', '', ''),
+('suggest_instance', 'Missing %my_role for %instance_name?', 0, 0, '', '%my_role manquant pour %instance_name ?', '', '', '', '¿Buscando un %my_role para %instance_name?', '', ''),
+('suggest_instance', 'Can be a %my_role for %instance_name.', 0, 0, '', 'Peut être un %my_role pour %instance_name', '', '', '', 'Puedo ser un %my_role para %instance_name.', '', ''),
+('suggest_instance', 'Need help with %instance_name?', 0, 0, '', 'Besoin d\'aide avec %instance_name ?', '', '', '', '¿Alguien necesita ayuda con %instance_name?', '', ''),
+('suggest_instance', 'Need %my_role help with %instance_name?', 0, 0, '', 'Besoin d\'aide %my_role avec %instance_name ?', '', '', '', '¿Necesitas ayuda de %my_role con %instance_name?', '', ''),
+('suggest_instance', 'Anyone needs gear from %instance_name?', 0, 0, '', 'Quelqu\'un a besoin d\'équipement de %instance_name ?', '', '', '', '¿Alguien necesita equipo de %instance_name?', '', ''),
+('suggest_instance', 'A little grind in %instance_name?', 0, 0, '', 'Un peu de grind dans %instance_name ?', '', '', '', '¿Un poco de farmeo en %instance_name?', '', ''),
+('suggest_instance', 'WTR %instance_name', 0, 0, '', 'Cherche à rejoindre %instance_name', '', '', '', 'WTR %instance_name', '', ''),
+('suggest_instance', 'Need help for %instance_name.', 0, 0, '', 'Besoin d\'aide pour %instance_name', '', '', '', 'Necesito ayuda para %instance_name.', '', ''),
+('suggest_instance', 'Wanna run %instance_name.', 0, 0, '', 'Je veux faire %instance_name', '', '', '', 'Quiero hacer %instance_name.', '', ''),
+('suggest_instance', '%my_role looks for %instance_name.', 0, 0, '', '%my_role recherche %instance_name', '', '', '', '%my_role busca %instance_name.', '', ''),
+('suggest_instance', 'What about %instance_name?', 0, 0, '', 'Et %instance_name ?', '', '', '', '¿Qué pasa con %instance_name?', '', ''),
+('suggest_instance', 'Who wants to farm %instance_name?', 0, 0, '', 'Qui veut exploiter %instance_name ?', '', '', '', '¿Quién quiere farmear %instance_name?', '', ''),
+('suggest_instance', 'Go in %instance_name?', 0, 0, '', 'Aller à %instance_name ?', '', '', '', '¿Vamos a %instance_name?', '', ''),
+('suggest_instance', 'Looking for %instance_name.', 0, 0, '', 'À la recherche de %instance_name', '', '', '', 'Buscando gente para %instance_name.', '', ''),
+('suggest_instance', 'Need help with %instance_name quests?', 0, 0, '', 'Besoin d\'aide pour les quêtes %instance_name ?', '', '', '', '¿Necesitas ayuda con las misiones en %instance_name?', '', ''),
+('suggest_instance', 'Wanna quest in %instance_name.', 0, 0, '', 'Je veux une quête dans %instance_name', '', '', '', 'Quiero hacer una vuelta rapida en %instance_name.', '', ''),
+('suggest_instance', 'Anyone with quests in %instance_name?', 0, 0, '', 'Quelqu\'un a des quêtes dans %instance_name ?', '', '', '', '¿Alguien con misiones en %instance_name?', '', ''),
+('suggest_instance', 'Could help with quests in %instance_name.', 0, 0, '', 'Peux aider pour les quêtes dans %instance_name', '', '', '', 'Podría ayudar con las misiones en %instance_name.', '', ''),
+('suggest_instance', '%my_role: any place in group for %instance_name?', 0, 0, '', '%my_role : n\'importe quel rôle dans le groupe pour %instance_name ?', '', '', '', '%my_role: ¿algún lugar en el grupo para %instance_name?', '', ''),
+('suggest_instance', 'Does anybody still run %instance_name this days?', 0, 0, '', 'Est-ce que quelqu\'un fait encore %instance_name ces jours-ci ?', '', '', '', '¿Alguien todavía hace %instance_name estos días?', '', ''),
+('suggest_instance', '%instance_name: anyone wants to take a %my_role?', 0, 0, '', '%instance_name : quelqu\'un veut prendre un %my_role ?', '', '', '', '¿Alguien quiere un %my_role para %instance_name?', '', ''),
+('suggest_instance', 'Is there any point being %my_role in %instance_name?', 0, 0, '', 'Y a-t-il un intérêt à être %my_role dans %instance_name ?', '', '', '', '¿Tiene algún sentido ser %my_role en %instance_name?', '', ''),
+('suggest_instance', 'It is really worth to go to %instance_name?', 0, 0, '', 'Cela vaut-il vraiment la peine d\'aller dans %instance_name ?', '', '', '', '¿Realmente vale la pena ir a %instance_name?', '', ''),
+('suggest_instance', 'Anybody needs more people for %instance_name?', 0, 0, '', 'Quelqu\'un a besoin de plus de personnes pour %instance_name ?', '', '', '', '¿Alguien necesita más personas para %instance_name?', '', ''),
+('suggest_instance', '%instance_name bosses drop good gear. Wanna run?', 0, 0, '', 'Les boss %instance_name drop du bon équipement. Tu veux courir ?', '', '', '', 'Los jefes en %instance_name sueltan buen equipo. ¿Quieres ir?', '', ''),
+('suggest_instance', 'What about %instance_name?', 0, 0, '', 'Et %instance_name ?', '', '', '', '¿Qué pasa con %instance_name?', '', ''),
+('suggest_instance', 'Anybody needs %my_role?', 0, 0, '', 'Quelqu\'un a besoin de %my_role ?', '', '', '', '¿Alguien necesita un %my_role?', '', ''),
+('suggest_instance', 'Anyone needs %my_role?', 0, 0, '', 'Quelqu\'un a besoin de %my_role ?', '', '', '', '¿Alguien hacer un grupo con un %my_role?', '', ''),
+('suggest_instance', 'Who wants %instance_name?', 0, 0, '', 'Qui veut %instance_name ?', '', '', '', '¿Quién quiere %instance_name?', '', ''),
+('suggest_instance', 'Can anybody summon me at %instance_name?', 0, 0, '', 'Quelqu\'un peut-il me TP à %instance_name ?', '', '', '', '¿Alguien puede invocarme en %instance_name?', '', ''),
+('suggest_instance', 'Meet me in %instance_name', 0, 0, '', 'Rencontrez-moi dans %instance_name', '', '', '', 'Encuéntrame en %instance_name', '', ''),
+('suggest_instance', 'Wanna quick %instance_name run', 0, 0, '', 'Je veux faire rapidement %instance_name', '', '', '', 'Quiero ir a %instance_name rápido', '', ''),
+('suggest_instance', 'Wanna full %instance_name run', 0, 0, '', 'Je veux faire %instance_name complètement', '', '', '', 'Quiero hacer %instance_name completa', '', ''),
+('suggest_instance', 'How many times were you in %instance_name?', 0, 0, '', 'Combien de fois avez-vous été dans %instance_name ?', '', '', '', '¿Cuántas veces estuviste en %instance_name?', '', ''),
+('suggest_instance', 'Another %instance_name run?', 0, 0, '', 'Une autre exécution de %instance_name ?', '', '', '', '¿Otra vuelta en %instance_name ?', '', ''),
+('suggest_instance', 'Wiped in %instance_name? Take me instead!', 0, 0, '', 'Effacé dans %instance_name ? Prends-moi plutôt !', '', '', '', '¿Borrado en %instance_name? ¡Tómame a mí en su lugar!', '', ''),
+('suggest_instance', 'Take me in %instance_name please.', 0, 0, '', 'Prenez-moi dans %instance_name s\'il vous plaît.', '', '', '', 'Tómame en %instance_name por favor.', '', ''),
+('suggest_instance', 'Quick %instance_name run?', 0, 0, '', 'Faire rapidement %instance_name ?', '', '', '', '¿Partida rápida de %instance_name?', '', ''),
+('suggest_instance', 'Full %instance_name run?', 0, 0, '', 'Clean complet dans %instance_name ?', '', '', '', '¿Partida completa de %instance_name?', '', ''),
+('suggest_instance', 'Who can take %my_role to %instance_name?', 0, 0, '', 'Qui peut prendre %my_role à %instance_name ?', '', '', '', '¿Quién puede ir de %my_role para %instance_name?', '', ''),
+('suggest_instance', 'LFG %instance_name, I am %my_role', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_instance', '%my_role LFG %instance_name', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- random quest
+-- usable placeholders:
+-- %my_role
+-- %quest_link
+-- %quest_level
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_quest', 'Need help with %quest_link?', 0, 0, '', 'Besoin d\'aide avec %quest_link ?', '', '', '', '¿Alguien necesita ayuda con %quest_link?', '', ''),
+('suggest_quest', 'Anyone wants to share %quest_link?', 0, 0, '', 'Quelqu\'un veut partager %quest_link ?', '', '', '', '¿Alguien quiere hacer %quest_link?', '', ''),
+('suggest_quest', 'Anyone doing %quest_link?', 0, 0, '', 'Quelqu\'un fait %quest_link ?', '', '', '', '¿Alguien está haciendo %quest_link?', '', ''),
+('suggest_quest', 'Wanna do %quest_link.', 0, 0, '', 'Je veux faire %quest_link', '', '', '', '¿Una ayudita con %quest_link?', '', ''),
+
+
+-- random trade?
+-- usable placeholders:
+-- %my_role
+-- %category
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_trade', 'Anyone to farm %category?', 0, 0, '', 'Quelqu\'un pour farm %category ?', '', '', '', '¿Alguien para farmear %category?', '', ''),
+('suggest_trade', 'Looking for help farming %category.', 0, 0, '', 'Vous cherchez de l\'aide pour farmer %category', '', '', '', 'Buscando ayuda para farmear %category.', '', ''),
+('suggest_trade', 'Damn %category are so expensive!', 0, 0, '', 'Putain %category sont si chers!', '', '', '', '¡Malditas %category son tan caras!', '', ''),
+('suggest_trade', 'Wanna %category.', 0, 0, '', 'Je veux %category', '', '', '', 'Quiero %category.', '', ''),
+('suggest_trade', 'Need help with %category.', 0, 0, '', 'Besoin d\'aide avec %category', '', '', '', 'Necesito ayuda con %category.', '', ''),
+('suggest_trade', 'WTB %category.', 0, 0, '', 'Cherche à acheter %category', '', '', '', 'Quiero comprar %category.', '', ''),
+('suggest_trade', 'Anyone interested in %category?', 0, 0, '', 'Quiconque est intéressé par %category?', '', '', '', '¿Alguien interesado en %category?', '', ''),
+('suggest_trade', 'WTS %category.', 0, 0, '', 'Cherche à vendre %category', '', '', '', 'Quiero vender %category.', '', ''),
+('suggest_trade', 'I am selling %category cheaper than AH.', 0, 0, '', 'Je vends %category moins cher que l\'hôtel des ventes.', '', '', '', 'Estoy vendiendo %category más barato que en las subastas.', '', ''),
+('suggest_trade', 'Who wants to farm %category?', 0, 0, '', 'Qui veut farmer %category ?', '', '', '', '¿Quién quiere farmear %category?', '', ''),
+('suggest_trade', 'Wanna farm %category.', 0, 0, '', 'Je veux farmer %category', '', '', '', 'Quiero farmear %category.', '', ''),
+('suggest_trade', 'Looking for party after %category.', 0, 0, '', 'Recherche de partie après %category', '', '', '', 'Buscando grupo después de %category.', '', ''),
+('suggest_trade', 'Any %category are appreciated.', 0, 0, '', 'Toute %category est appréciée.', '', '', '', 'Cualquier %category es apreciada.', '', ''),
+('suggest_trade', 'Buying anything of %category.', 0, 0, '', 'Acheter quoi que ce soit de %category', '', '', '', 'Comprando algo de %category.', '', ''),
+('suggest_trade', 'Wow, anybody is farming %category!', 0, 0, '', 'Wow, quelqu\'un farm %category !', '', '', '', '¡Guau, alguien está farmeando %category!', '', ''),
+('suggest_trade', '%category are selling mad in the AH.', 0, 0, '', '%category se vendent follement dans l\'hôtel des ventes.', '', '', '', '%category están vendiendo locos en las subastas.', '', ''),
+('suggest_trade', 'AH is hot for %category.', 0, 0, '', 'Hôtel des ventes est chaud pour %category', '', '', '', 'Las subastas estan caliente para %category.', '', ''),
+('suggest_trade', '%category are on the market.', 0, 0, '', '%category sont sur le marché.', '', '', '', '%category están en el mercado.', '', ''),
+('suggest_trade', 'Wanna trade some %category.', 0, 0, '', 'Je veux échanger une %category', '', '', '', 'Quiero intercambiar alguna %category.', '', ''),
+('suggest_trade', 'Need more %category.', 0, 0, '', 'Besoin de plus de %category', '', '', '', 'Necesito más %category.', '', ''),
+('suggest_trade', 'Anybody can spare some %category?', 0, 0, '', 'Quelqu\'un peut-il épargner une %category ?', '', '', '', '¿Alguien puede ahorrar algo de %category?', '', ''),
+('suggest_trade', 'Who wants %category?', 0, 0, '', 'Qui veut %category ?', '', '', '', '¿Quién quiere %category?', '', ''),
+('suggest_trade', 'Some %category please?', 0, 0, '', 'Une %category s\'il vous plaît ?', '', '', '', '¿Alguna %category, por favor?', '', ''),
+('suggest_trade', 'I should have got skill for %category.', 0, 0, '', 'J\'aurais dû avoir une compétence pour %category', '', '', '', 'Debería haber adquirido habilidad para %category.', '', ''),
+('suggest_trade', 'I am dying for %category.', 0, 0, '', 'Je meurs d\'envie pour %category', '', '', '', 'Me muero por %category.', '', ''),
+('suggest_trade', 'People are killing for %category.', 0, 0, '', 'Les gens tuent pour %category', '', '', '', 'La gente está matando por %category.', '', ''),
+('suggest_trade', '%category is a great bargain!', 0, 0, '', '%category est une bonne affaire!', '', '', '', '%category es una gran ganga!', '', ''),
+('suggest_trade', 'Everybody is mad for %category!', 0, 0, '', 'Tout le monde est fou de %category !', '', '', '', '¡Todo el mundo está loco por %category!', '', ''),
+('suggest_trade', 'Where is the best place to farm for %category?', 0, 0, '', 'Quel est le meilleur endroit pour farmer pour %category ?', '', '', '', '¿Dónde está el mejor lugar para farmear para %category?', '', ''),
+('suggest_trade', 'I am all set for %category.', 0, 0, '', 'Je suis prêt pour %category', '', '', '', 'Estoy listo para %category.', '', ''),
+('suggest_trade', 'Is it good to sell %category?', 0, 0, '', 'Est-il bon de vendre %category ?', '', '', '', '¿Es bueno vender %category?', '', ''),
+('suggest_trade', 'I\'d probably keep all my %category with me.', 0, 0, '', 'Je garderais probablement toute ma %category avec moi.', '', '', '', 'Probablemente mantendría toda mi %category conmigo', '', ''),
+('suggest_trade', 'Need group? Maybe to farm some %category?', 0, 0, '', 'Besoin de groupe ? Peut-être pour farmer une certaine %category ?', '', '', '', '¿Necesitas un grupo? ¿Tal vez para farmear alguna %category?', '', ''),
+('suggest_trade', 'I am still thinking about %category.', 0, 0, '', 'Je pense toujours à %category', '', '', '', 'Todavía estoy pensando en %category.', '', ''),
+('suggest_trade', 'I heard about %category already, but my pockets are empty.', 0, 0, '', 'J\'ai déjà entendu parler de %category , mais mes poches sont vides.', '', '', '', 'Ya escuché sobre %category, pero mis bolsillos están vacíos.', '', ''),
+('suggest_trade', 'LFG for %category', 0, 0, '', 'Cherche un groupe pour %category', '', '', '', 'Busco grupo para %category', '', ''),
+('suggest_trade', 'Would selling %category make me rich?', 0, 0, '', 'Vendre %category me rendrait-il riche?', '', '', '', '¿Vender %category me haría rico?', '', ''),
+('suggest_trade', 'OK. I an farming %category tomorrow.', 0, 0, '', 'D\'ACCORD. Je farm %category demain.', '', '', '', 'OK. Tengo una sesion de farmeo de %category mañana.', '', ''),
+('suggest_trade', 'Everyone is talking about %category.', 0, 0, '', 'Tout le monde parle de %category', '', '', '', 'Todos hablan de %category', '', ''),
+('suggest_trade', 'I saw at least ten people farming for %category.', 0, 0, '', 'J\'ai vu au moins dix personnes farmer pour %category', '', '', '', 'Vi al menos diez personas farmeando para %category.', '', ''),
+('suggest_trade', 'I sold all my %category yesterday. I am completely broke!', 0, 0, '', 'J\'ai vendu tout mon %category hier. Je suis complètement fauché!', '', '', '', 'Ayer vendí todo mi %category. ¡Estoy completamente arruinado!', '', ''),
+('suggest_trade', 'Wanna join a guild farming for %category.', 0, 0, '', 'Je veux rejoindre une guilde farmant pour %category', '', '', '', 'Quiero unirme a una hermandad de farmeo para %category.', '', ''),
+
+
+
+-- random faction rep grind
+-- usable placeholders:
+-- %my_role
+-- %rep_level
+-- %rndK
+-- %faction
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_faction', 'Anyone farming %faction rep?', 0, 0, '', 'Quelqu\'un farm la réput de %faction ?', '', '', '', '¿Alguien farmea reputación con %faction?', '', ''),
+('suggest_faction', 'Anyone help with %faction?', 0, 0, '', 'Quelqu\'un aide-t-il %faction ?', '', '', '', '¿Alguien me ayuda con %faction?', '', ''),
+('suggest_faction', 'Wanna quest for %faction.', 0, 0, '', 'Je veux quêter %faction', '', '', '', 'Quiero buscar a %faction.', '', ''),
+('suggest_faction', '%faction is the best.', 0, 0, '', '%faction est la meilleure.', '', '', '', '%faction es el mejor.', '', ''),
+('suggest_faction', 'Need just a bit to be %rep_level with %faction.', 0, 0, '', 'J\'ai besoin d\'un peu pour être au %rep_level avec %faction', '', '', '', 'Solo necesito un poco para estar %rep_level con %faction.', '', ''),
+('suggest_faction', 'Anyone got %rep_level with %faction?', 0, 0, '', 'Quelqu\'un a-t-il %rep_level avec %faction ?', '', '', '', '¿Alguien tiene %rep_level con %faction?', '', ''),
+('suggest_faction', 'Who wants to be %rep_level with %faction?', 0, 0, '', 'Qui veut être au %rep_level avec %faction ?', '', '', '', '¿Quién quiere estar en %rep_level con %faction?', '', ''),
+('suggest_faction', 'I\'ll never be %rep_level with %faction.', 0, 0, '', 'Je ne serai jamais au %rep_level avec %faction', '', '', '', 'Nunca estaré %rep_level con %faction.', '', ''),
+('suggest_faction', 'Someone missing %faction rep?', 0, 0, '', 'Quelqu\'un manque de reput de %faction ?', '', '', '', '¿Alguien falta reputación con %faction?', '', ''),
+('suggest_faction', 'Could help farming %faction rep.', 0, 0, '', 'Pourrait aider à farmer réput de %faction', '', '', '', 'Podría ayudar a farmear %faction rep.', '', ''),
+('suggest_faction', 'The more rep the better. Especially with %faction.', 0, 0, '', 'Plus il y a de réput, mieux c\'est. Surtout avec %faction', '', '', '', 'Cuantas más repeticiones, mejor. Especialmente con %faction.', '', ''),
+('suggest_faction', '%faction: need %rndK for %rep_level.', 0, 0, '', '%faction: besoin %rndK pour %rep_level.', '', '', '', '%faction: necesita %rndK para %rep_level.', '', ''),
+('suggest_faction', 'Who can share %faction quests?', 0, 0, '', 'Qui peut partager les quêtes de %faction ?', '', '', '', '¿Quién puede compartir misiones de %faction?', '', ''),
+('suggest_faction', 'Any dungeons for %faction?', 0, 0, '', 'Des donjons pour %faction ?', '', '', '', '¿Alguna mazmorra para %faction?', '', ''),
+('suggest_faction', 'Wanna do %faction rep grind.', 0, 0, '', 'Je veux faire monter ma réput %faction', '', '', '', 'Quiero hacer %faction rep grind.', '', ''),
+('suggest_faction', 'Let\'s farm %faction rep!', 0, 0, '', 'Farmons la réput %faction !', '', '', '', '¡Vamos a farmear reputación con %faction!', '', ''),
+('suggest_faction', 'Farming for %faction rep.', 0, 0, '', 'Farmons pour la réput %faction', '', '', '', 'Farming for %faction rep.', '', ''),
+('suggest_faction', 'Wanna farm for %faction.', 0, 0, '', 'Je veux farmer pour %faction', '', '', '', 'Quiero farmear para %faction.', '', ''),
+('suggest_faction', 'Need help with %faction.', 0, 0, '', 'Besoin d\'aide avec %faction', '', '', '', 'Necesito ayuda con %faction.', '', ''),
+('suggest_faction', 'Is %faction sells something useful?', 0, 0, '', 'Est-ce que %faction vend quelque chose d\'utile ?', '', '', '', '¿%faction vende algo útil?', '', ''),
+('suggest_faction', 'Are there %faction vendors?', 0, 0, '', 'Y a-t-il des vendeurs %faction ?', '', '', '', '¿Hay %proveedores de facciones?', '', ''),
+('suggest_faction', 'Who farms %faction?', 0, 0, '', 'Qui farm %faction ?', '', '', '', '¿Quién farmea %faction?', '', ''),
+('suggest_faction', 'Which is the best way to farm %faction?', 0, 0, '', 'Quelle est la meilleure façon de farmer %faction ?', '', '', '', '¿Cuál es la mejor manera de farmear %faction?', '', ''),
+('suggest_faction', 'I hate %faction rep grind.', 0, 0, '', 'Je déteste le travail de %faction rep.', '', '', '', 'Odio %repetir de facción', '', ''),
+('suggest_faction', 'I am so tired of %faction.', 0, 0, '', 'Je suis tellement fatigué de %faction', '', '', '', 'Estoy tan cansado de %faction.', '', ''),
+('suggest_faction', 'Go for %faction?', 0, 0, '', 'Vous optez pour %faction ?', '', '', '', '¿Quereis ir a por %faction?', '', ''),
+('suggest_faction', 'Seems everyone is %rep_level with %faction. Only me is late as usually.', 0, 0, '', 'On dirait que tout le monde est %rep_level avec %faction Il n\'y a que moi qui suis en retard comme d\'habitude.', '', '', '', 'Parece que todo el mundo está %rep_level con %faction. Solo yo llego tarde como siempre.', '', ''),
+('suggest_faction', 'LFG for %faction rep grind?', 0, 0, '', 'Cherche un groupe pour monter la réput des représentants de %faction ?', '', '', '', 'Busco grupo para subir reputación con %faction', '', ''),
+('suggest_faction', 'Can anobody suggest a good spot for %faction rep grind?', 0, 0, '', 'Quelqu\'un peut-il suggérer un bon endroit pour monter les réput de %faction ?', '', '', '', '¿Alguien puede sugerir un buen lugar farmear reputacion con %faction?', '', ''),
+('suggest_faction', 'Would %faction rep benefit me?', 0, 0, '', 'Est-ce que la réput %faction me serait bénéfique ?', '', '', '', '¿Me beneficiaría subir reputación con %faction?', '', ''),
+('suggest_faction', 'Who would\'ve thought that %faction rep will be useful after all...', 0, 0, '', 'Qui aurait pensé que le représentant de %faction serait utile après tout...', '', '', '', 'Quién hubiera pensado que subir reputacion con %faction sería útil después de todo...', '', ''),
+('suggest_faction', 'I wanna be exalted with all factions, starting with %faction.', 0, 0, '', 'Je veux être exalté avec toutes les factions, à commencer par %faction', '', '', '', 'Quiero ser exaltado con todas las facciones, comenzando con %faction.', '', ''),
+('suggest_faction', 'Is there any point to improve my rep with %faction?', 0, 0, '', 'Y a-t-il un intérêt à améliorer ma réputation avec %faction ?', '', '', '', '¿Hay algún punto para mejorar mi reputación con %faction?', '', ''),
+('suggest_faction', 'What is better for %faction? Quests or mob grinding?', 0, 0, '', 'Quoi de mieux pour %faction ? Quêtes ou mob pour XP?', '', '', '', '¿Qué es mejor para %faction? ¿Misiones o mafiosos?', '', ''),
+('suggest_faction', 'Will grind %faction rep for you. Just give me some gold.', 0, 0, '', 'Monte la reput de %faction pour vous. Donnez-moi juste de l\'or.', '', '', '', 'Ganare reputacion con %faction por ti. Sólo dame un poco de oro.', '', ''),
+('suggest_faction', 'I think grinding rep with %faction would take forever.', 0, 0, '', 'Je pense que monter la réput avec %faction prendrait une éternité.', '', '', '', 'Creo que subir la reputación con %faction tomaría una eternidad.', '', ''),
+('suggest_faction', 'I am killing for %faction every day now but still far from %rep_level.', 0, 0, '', 'Je tue pour %faction tous les jours maintenant, mais encore loin du %rep_level', '', '', '', 'Estoy matando por %faction todos los días ahora, pero aún estoy lejos del %rep_level.', '', ''),
+('suggest_faction', 'At %my_level AH deposits will decrease, right?', 0, 0, '', 'Au %rep_level, les dépôts hôtel des ventes diminueront, n\'est-ce pas?', '', '', '', 'Al %rep_level, los depósitos subastas disminuirán, ¿verdad?', '', ''),
+('suggest_faction', 'How many exalted reps do you have?', 0, 0, '', 'Combien de représentants exaltés avez-vous ?', '', '', '', '¿Cuántas reputaciones exaltadas tienes?', '', ''),
+('suggest_faction', 'Who wants to be %my_level with %faction?', 0, 0, '', 'Qui veut être au %rep_level avec %faction ?', '', '', '', '¿Quién quiere estar en %rep_level con %faction?', '', ''),
+('suggest_faction', 'Damn. My guild did a good %faction grind yesterday without me.', 0, 0, '', 'Mince. Ma guilde a fait un bon travail de %faction hier sans moi.', '', '', '', 'Maldición. Mi hermandad hizo un buen farmeo de %faction ayer sin mí.', '', ''),
+('suggest_faction', 'Nobody wants to help me because I am %rep_level with %faction.', 0, 0, '', 'Personne ne veut m\'aider parce que je suis %rep_level avec %faction', '', '', '', 'Nadie quiere ayudarme porque estoy %rep_level con %faction.', '', ''),
+('suggest_faction', 'Please stay away from %faction.', 0, 0, '', 'Veuillez rester à l\'écart de %faction', '', '', '', 'Por favor manténgase alejado de %faction.', '', ''),
+
+
+
+-- random generic
+-- usable placeholders:
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_something', 'Wanna party in %zone_name.', 0, 0, '', 'Je veux faire la fête dans %zone_name.', '', '', '', '¡Vamos a perrear a %zone_name!', '', 'Ищу группу в %zone_name.'),
+('suggest_something', 'Anyone is looking for %my_role?', 0, 0, '', 'Quelqu\'un cherche un %my_role ?', '', '', '', '¿Alguien está buscando %my_role?', '', 'Кто-нибудь ищет %my_role?'),
+('suggest_something', '%my_role is looking for quild.', 0, 0, '', '%my_role recherche une guilde.', '', '', '', '%my_role está buscando hermandad.', '', '%my_role ищу гильдию.'),
+('suggest_something', 'Looking for gold.', 0, 0, '', 'A la recherche de l\'or.', '', '', '', 'Buscando oro.', '', 'Дайте голды'),
+('suggest_something', '%my_role wants to join a good guild.', 0, 0, '', '%my_role veut rejoindre une bonne guilde.', '', '', '', '%my_role quiere unirse a una buen hermandad.', '', '%my_role хочу в хорошую гильдию.'),
+('suggest_something', 'Need a friend.', 0, 0, '', 'Besoin d\'un ami.', '', '', '', 'Necesito un amigo...', '', 'Ищу друга.'),
+('suggest_something', 'Anyone feels alone?', 0, 0, '', 'Quelqu\'un se sent seul?', '', '', '', '¿Alguien se siente solo?', '', 'Кому-нибудь одиноко?'),
+('suggest_something', 'Boring...', 0, 0, '', 'Ennuyeux...', '', '', '', 'Aburrido...', '', 'Скучно...'),
+('suggest_something', 'Who wants some?', 0, 0, '', 'Qui en veut?', '', '', '', '¿Quién quiere hacer grupo para levear?', '', 'Кому навалять?'),
+('suggest_something', 'Go get me!', 0, 0, '', 'Allez me chercher !', '', '', '', '¡Ven a buscarme!', '', 'Поймайте меня!'),
+('suggest_something', 'Maybe a duel in %zone_name?', 0, 0, '', 'Peut-être un duel dans %zone_name ?', '', '', '', '¿Quizás un duelo en %zone_name?', '', 'Кто на дуэль в %zone_name?'),
+('suggest_something', 'Anybody doing something?', 0, 0, '', 'Quelqu\'un fait quelque chose?', '', '', '', '¿Alguien está haciendo algo?', '', 'Кто чем занят?'),
+('suggest_something', '%zone_name: is anybody here?', 0, 0, '', '%zone_name : est-ce que quelqu\'un est là?', '', '', '', '%zone_name: ¿hay alguien aquí?', '', '%zone_name: есть кто нибудь?'),
+('suggest_something', '%zone_name: where is everyone?', 0, 0, '', '%zone_name : où est tout le monde?', '', '', '', '¿Hay alguien en %zone_name?', '', '%zone_name: где все?'),
+('suggest_something', 'Looks like I am alone in %zone_name.', 0, 0, '', 'On dirait que je suis seul dans %zone_name', '', '', '', 'Parece que estoy solo en %zone_name.', '', 'Похоже я один в %zone_name.'),
+('suggest_something', 'Meet me in %zone_name.', 0, 0, '', 'Retrouvez-moi dans %zone_name', '', '', '', 'Encuéntrame en %zone_name.', '', 'Встретимся в %zone_name.'),
+('suggest_something', 'Let\'s quest in %zone_name!', 0, 0, '', 'Partons en quête dans %zone_name !', '', '', '', '¡Vamos a hacer un grupo para levear en %zone_name!', '', 'Давайте квестить в %zone_name!'),
+('suggest_something', '%zone_name is the best place to be!', 0, 0, '', '%zone_name est le meilleur endroit où être!', '', '', '', '%zone_name es el mejor lugar para estar!', '', '%zone_name лучшее место!'),
+('suggest_something', 'Wanna go to %zone_name. Anybody with me?', 0, 0, '', 'Je veux aller à %zone_name Quelqu\'un avec moi?', '', '', '', 'Quiero ir a %zone_name. ¿Alguien se apunta?', '', 'Собираюсь в %zone_name. Кто со мной7'),
+('suggest_something', 'Who wants going to %zone_name?', 0, 0, '', 'Qui veut aller à %zone_name ?', '', '', '', '¿Quién quiere ir a %zone_name?', '', 'Кто собирается в %zone_name?'),
+('suggest_something', 'I don\'t like %zone_name. Where to go?', 0, 0, '', 'Je n\'aime pas %zone_name Où aller?', '', '', '', 'No me gusta %zone_name. ¿Dónde podria ir?', '', 'Не нравится %zone_name. Куда идти?'),
+('suggest_something', 'Are there a good quests in %zone_name?', 0, 0, '', 'Y a-t-il de bonnes quêtes dans %zone_name ?', '', '', '', '¿Hay buenas misiones en %zone_name?', '', 'А в %zone_name есть хорошие квесты?'),
+('suggest_something', 'Where to go after %zone_name?', 0, 0, '', 'Où aller après %zone_name ?', '', '', '', '¿Adónde puedo ir después de %zone_name?', '', 'Куда идти после %zone_name?'),
+('suggest_something', 'Who is in %zone_name?', 0, 0, '', 'Qui est dans %zone_name ?', '', '', '', '¿Quién está en %zone_name?', '', 'Кто в %zone_name?'),
+('suggest_something', 'LFG in %zone_name.', 0, 0, '', 'Cherche un groupe dans %zone_name', '', '', '', 'Busco grupo en %zone_name.', '', 'ЛФГ %zone_name.'),
+('suggest_something', '%zone_name is the worst place to be.', 0, 0, '', '%zone_name est le pire endroit où être.', '', '', '', '%zone_name es el peor lugar para estar', '', '%zone_name это худшее место.'),
+('suggest_something', 'Catch me in %zone_name!', 0, 0, '', 'Attrape-moi dans %zone_name !', '', '', '', '¡Atrápame en %zone_name!', '', 'Поймай меня в %zone_name!'),
+('suggest_something', 'Go for %zone_name!', 0, 0, '', 'Allez pour %zone_name !', '', '', '', 'Me voy a %zone_name!', '', 'Гоу в %zone_name!'),
+('suggest_something', 'Wanna quest in %zone_name', 0, 0, '', 'Je veux une quête dans %zone_name', '', '', '', 'Quiero hacer una búsqueda en %zone_name', '', 'Хочешь поделать квесты в %zone_name'),
+('suggest_something', 'Anyone has quests in %zone_name?', 0, 0, '', 'Quelqu\'un a des quêtes dans %zone_name ?', '', '', '', '¿Alguien tiene misiones en %zone_name?', '', 'Есть у кого квесты в %zone_name?'),
+('suggest_something', 'Come here to %zone_name!', 0, 0, '', 'Venez ici à %zone_name !', '', '', '', '¡Ven aquí a %zone_name!', '', 'Приходите сюда в %zone_name!'),
+('suggest_something', 'Seems there is no Horde in %zone_name', 0, 0, '', 'Il semble qu\'il n\'y ait pas de Horde dans %zone_name', '', '', '', 'Parece que no hay Horda en %zone_name', '', '%zone_name Орды вроде нет.'),
+('suggest_something', 'Seems there is no Alliance in %zone_name', 0, 0, '', 'Il semble qu\'il n\'y ait pas d\'alliance dans %zone_name', '', '', '', 'Parece que no hay Alianza en %zone_name', '', '%zone_name Альянса вроде нет'),
+('suggest_something', 'I am really tired of %zone_name. Maybe go somewhere else?', 0, 0, '', 'Je suis vraiment fatigué de %zone_name Peut-être aller ailleurs?', '', '', '', 'Estoy realmente cansado de %zone_name. Quizás ire a otro lugar', '', 'В %zone устал уже, может в другое место пойдем?'),
+('suggest_something', 'GL', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'I want to go home, and then edge', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'does anyone know what you need to dual wield?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'hi everyone!', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', '%zone_name is comfy', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'i feel great', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'i don\'t ignore people i troll them until they ignore me', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'What do you guys think about my build? %my_role', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'good to see chat still remembers', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'like all weapons its hunter BIS', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'whole point to the game for me is soloing and finding new ways to solo stuff', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'i\'ve NEVER ripped off anyone', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'ah yes the world of warcraft, where i come for life advice', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'HELLO?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Time to fight my way into %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', '%zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'gotta poop', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'if you don\'t loot your skinnable kills your pp loses 1mm permanently', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'NOOOOOOOOOOOOO', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'I LIKE POTATO', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'w chat', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'hi how are you guys', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'i just logged out and logged back in', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'can you guys keep it down a bit, im lost in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'anyone want to have a drink with me at %zone_name ...hic!', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'hahahahaheeeeeeee dirin diring ingggggg hahahahaheeeeeeeeeeeeee', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'bait used to be believeable', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'maybe you just lost your innocence', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'any guilds willing to carry %my_role?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'once you start getting higher, gold is so easy to get', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'morning', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'why does my ass hurt?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'I feel like spirit is bis for leveling', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Even more for troll', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'CAN SOMEONE INVITE ME', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'need a lot of drinks', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'damn gnomes', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'no one likes gnomes', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'gnomes are only good for one thing', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Well', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'mushrooms', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'automatic thoughts are a scary thing', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'the mind is more pliable than we\'d like to believe', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'any leveling guilds out there?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'brb', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Why is snow white but Ice is clear ? made of the same thing', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'why is whipped cream fluffy and regular not', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'why do feet smell if they have no nose', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'seems a can of newbies arrived', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'stop trolling new players with BS answers', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Is there PvP on this server?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'duh', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'phew... :)', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'did you guys know that', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'i don\'t try to imagine what other creatures feel like', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'oh whoops, wrong chat', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'bruh you guys are wildin out today', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'just let it be known that my text was here', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'grrr angyy', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'the grind is fun', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Wow keeps me sharp', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'hey have a question where can i take the roll for more xp? im in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'do you guys like sausages?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'Invite me. I\'ll help', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'which class do you think is better for pvp?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'where the fuck is the cooking trainer in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'you know what happens in %zone_name?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something', 'I need to craft something', 0, 0, '', '', '', '', '', '', '', ''),
+
+-- random generic toxic phrases
+-- usable placeholders:
+-- %random_inventory_item_link
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_something_toxic', 'what is ligma', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'what is sugma', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'ligma balls', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'sugma balls', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'I EAT ASS', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'I want to shove %random_inventory_item_link up my ass', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'I want to shove %random_inventory_item_link up your ass', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'Darnasses', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'seems like your suffering from sugma', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'deez nutz in ur mouth', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'cool boner, bro', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'ERP?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'i tried everything, but at the end ERP did the trick', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'I want to bonk in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'looking for female gnome with gorilla pet for erp in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'i may understand an asshole, but a pervert?', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'there is no gyat in %zone_name', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'I\'m killing all the animals in %zone_name. Fuck the animals!!!', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'good think i got 3 legs', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'dont be mad im goonin like a sigma', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_something_toxic', 'try finger, but hole', 0, 0, '', '', '', '', '', '', '', ''),
+
+-- random generic toxic item links
+-- usable placeholders:
+-- %random_taken_quest_or_item_link
+-- %random_inventory_item_link
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_toxic_links', 'gnomes %random_taken_quest_or_item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_toxic_links', 'gnomes %random_inventory_item_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- random WTS
+-- usable placeholders:
+-- %%item_formatted_link
+-- %item_formatted_link
+-- %item_count
+-- %cost_gold
+-- %my_class
+-- %my_race
+-- %my_level
+('suggest_sell', 'WTS %item_formatted_link for %cost_gold.', 0, 0, '', 'Cherche à vendre %item_formatted_link pour %cost_gold', '', '', '', 'Quiero vender %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'Who wants %item_formatted_link for %cost_gold?', 0, 0, '', 'Qui veut %item_formatted_link pour %cost_gold ?', '', '', '', '¿Quién quiere %item_formatted_link por %cost_gold?', '', ''),
+('suggest_sell', 'Anyone wants %item_formatted_link? Only %cost_gold.', 0, 0, '', 'Quelqu\'un veut %item_formatted_link ? Seulement %cost_gold', '', '', '', '¿Alguien quiere %item_formatted_link? Solo %cost_gold.', '', ''),
+('suggest_sell', 'Just %cost_gold for %item_formatted_link!', 0, 0, '', 'Seulement %cost_gold pour %item_formatted_link!', '', '', '', '¡Solo %cost_gold para %item_formatted_link!', '', ''),
+('suggest_sell', 'Selling %item_formatted_link for %cost_gold.', 0, 0, '', 'Vendre %item_formatted_link pour %cost_gold', '', '', '', 'Vendo %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', '%item_formatted_link is yours just for %cost_gold!', 0, 0, '', '%item_formatted_link est à vous juste pour %cost_gold !', '', '', '', '%item_formatted_link es tuyo solo por %cost_gold!', '', ''),
+('suggest_sell', 'Ridiculus price of %cost_gold for %item_formatted_link!', 0, 0, '', 'Prix ridicule de %cost_gold pour %item_formatted_link !', '', '', '', '¡Precio ridículo de %cost_gold para %item_formatted_link_link!', '', ''),
+('suggest_sell', 'Wanna sell %item_formatted_link for %cost_gold.', 0, 0, '', 'Je veux vendre %item_formatted_link pour %cost_gold', '', '', '', 'Quiero vender %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'Who needs %item_formatted_link? Only %cost_gold.', 0, 0, '', 'Qui a besoin de %item_formatted_link ? Seulement %cost_gold', '', '', '', '¿Quién necesita %item_formatted_link? Solo %cost_gold.', '', ''),
+('suggest_sell', 'Anyone needs %item_formatted_link for %cost_gold?', 0, 0, '', 'Quelqu\'un a besoin de %item pour %cost_gold ?', '', '', '', '¿Alguien necesita %item_formatted_link_link por %cost_gold?', '', ''),
+('suggest_sell', '%cost_gold for %item_formatted_link. Less than AH!', 0, 0, '', '%cost_gold pour %item_formatted_link. Moins que l\'hôtel des ventes!', '', '', '', '%cost_gold para %item_formatted_link. ¡Menos que en las subastas!', '', ''),
+('suggest_sell', '%item_formatted_link is expensive, but I\'d sell it for %cost_gold.', 0, 0, '', '%item_formatted_link est cher, mais je le vendrais pour %cost_gold', '', '', '', '%item_formatted_link es caro, pero lo vendería por %cost_gold.', '', ''),
+('suggest_sell', 'You\'ll never find %item_formatted_link cheaper than %cost_gold!', 0, 0, '', 'Vous ne trouverez jamais %item_formatted_link moins cher que %cost_gold !', '', '', '', '¡Nunca encontrarás %item_formatted_link más barato que %cost_gold!', '', ''),
+('suggest_sell', 'Need more than %item_formatted_link!', 0, 0, '', 'Besoin de plus de %item_formatted_link !', '', '', '', '¡Necesito más %item_formatted_link!', '', ''),
+('suggest_sell', 'I have %item_formatted_link and need more.', 0, 0, '', 'J\'ai %item_formatted_link et j\'en ai besoin de plus.', '', '', '', 'Tengo %item_formatted_link y necesito más. ¿Alguien me vende alguno?', '', ''),
+('suggest_sell', 'Have %item_formatted_link. Who wants to buy for %cost_gold?', 0, 0, '', 'Avoir %item_formatted_link. Qui veut acheter pour %cost_gold ?', '', '', '', 'Tengo %item_formatted_link. ¿Quién quiere comprarlo por %cost_gold?', '', ''),
+('suggest_sell', 'Anyone WTB %item_formatted_link for %cost_gold?', 0, 0, '', 'Quelqu\'un cherche à acheter %item_formatted_link pour %cost_gold ?', '', '', '', '¿Alguien compra %item_formatted_link por %cost_gold?', '', ''),
+('suggest_sell', 'What about %item_formatted_link? For %cost_gold.', 0, 0, '', 'Qu\'en est-il de %item_formatted_link ? Pour %cost_gold', '', '', '', '¿Qué pasa con %item_formatted_link? Por el oro.', '', ''),
+('suggest_sell', 'Who said I am a bastard? %item_formatted_link for %cost_gold is a good price.', 0, 0, '', 'Qui a dit que j\'étais un bâtard? %item_formatted_link pour %cost_gold est un bon prix.', '', '', '', '¿Quién ha dicho que soy un rata? %item_formatted_link por %cost_gold es una ganga.', '', ''),
+('suggest_sell', 'I am selling %item_formatted_link? Just %cost_gold.', 0, 0, '', 'Je vends %item_formatted_link ? Juste %cost_gold', '', '', '', '¿Vendo %item_formatted_link? Solo %cost_gold.', '', ''),
+('suggest_sell', 'LFG for farming. You can still buy %item_formatted_link I have for %cost_gold.', 0, 0, '', 'Cherche un groupe pour farming. Vous pouvez toujours acheter %item_formatted_link que j\'ai pour %cost_gold', '', '', '', 'LFG para farmear. Todavía puedes comprar %item_formatted_link que tengo por %cost_gold.', '', ''),
+('suggest_sell', 'Sold almost everything today. Still have %item_formatted_link for %cost_gold.', 0, 0, '', 'Vendu presque tout aujourd\'hui. Vous avez encore %item_formatted_link pour %cost_gold', '', '', '', 'Se vendió casi todo hoy. Todavía tengo %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'What use for trade chat? Of course to sell %item_formatted_link for %cost_gold.', 0, 0, '', 'A quoi sert le tchat commercial? Bien sûr pour vendre %item_formatted_link pour %cost_gold', '', '', '', '¿De qué sirve el chat comercial? Por supuesto, para vender %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'Can anyone beat the price of %cost_gold for %item_formatted_link?', 0, 0, '', 'Quelqu\'un peut-il battre le prix de %cost_gold pour %item_formatted_link ?', '', '', '', '¿Alguien puede superar el precio de %cost_gold por %item_formatted_link?', '', ''),
+('suggest_sell', 'Wanna stop trade chat? Just buy %item_formatted_link? For %cost_gold!', 0, 0, '', 'Vous voulez arrêter le chat commercial? Vous venez d\'acheter %item_formatted_link ? Pour %cost_gold !', '', '', '', '¿Quieres detener el chat comercial? ¿Solo compra %item_formatted_link? ¡Por el oro!', '', ''),
+('suggest_sell', 'Everybody spams in trade chat. Me too - %cost_gold for %item_formatted_link!', 0, 0, '', 'Tout le monde spamme dans le chat commercial. Moi aussi - %cost_gold pour %item_formatted_link !', '', '', '', 'Todo el mundo envía spam en el chat y yo también! ¡%item_formatted_link por %cost_gold!', '', ''),
+('suggest_sell', 'Is %item_formatted_link any use? Just selling it for %cost_gold.', 0, 0, '', '%item_formatted_link est-il utile? Je le vends juste pour %cost_gold', '', '', '', '¿Es %item_formatted_link útil? Solo lo vendo por %cost_gold.', '', ''),
+('suggest_sell', 'I have %item_formatted_link ready to sell you for %cost_gold.', 0, 0, '', 'J\'ai %item_formatted_link prêt à vous vendre pour %cost_gold', '', '', '', 'Tengo %item_formatted_link listo a la venta por %cost_gold.', '', ''),
+('suggest_sell', 'Did nothing yesterday but have got %item_formatted_link. Selling it for %cost_gold.', 0, 0, '', 'Je n\'ai rien fait hier mais j\'ai %item_formatted_link Je le vends pour %cost_gold', '', '', '', 'No hice nada ayer pero consegu\'i %item_formatted_link. Lo vendo por %cost_gold.', '', ''),
+('suggest_sell', 'Farmed yesterday and got %item_formatted_link. Anyone wtb for %cost_gold?', 0, 0, '', 'Farmé hier et obtenu %item_formatted_link Quelqu\'un cherche à acheter pour %cost_gold ?', '', '', '', 'Ayer farmee y conseguí mucho %item_formatted_link. ¿Alguien lo quiere comprar por %cost_gold?', '', ''),
+('suggest_sell', 'Bought %item_formatted_link yesterday. Anyone needs it for %cost_gold?', 0, 0, '', 'Acheté %item_formatted_link hier. Quelqu\'un en a besoin pour %cost_gold ?', '', '', '', 'Ayer compré %item_formatted_link. ¿Alguien lo quiere por %cost_gold?', '', ''),
+('suggest_sell', 'Who asked for %item_formatted_link? The price is the same - %cost_gold.', 0, 0, '', 'Qui a demandé %item_formatted_link ? Le prix est le même - %cost_gold', '', '', '', '¿Quién pidió %item_formatted_link? El precio es el mismo: %cost_gold.', '', ''),
+('suggest_sell', 'I sill have %item_formatted_link. WTB for %cost_gold?', 0, 0, '', 'J\'ai toujours %item_formatted_link. Cherche à acheter pour %cost_gold ?', '', '', '', 'Todavía tengo %item_formatted_link. ¿Alguien lo compra por %cost_gold?', '', ''),
+('suggest_sell', 'I used to have more than %item_formatted_link. Now needs to sell it for %cost_gold.', 0, 0, '', 'J\'avais plus de %item_formatted_link Il faut maintenant le vendre pour %cost_gold', '', '', '', 'Solía tener más de %item_formatted_link. Ahora necesito venderlo por %cost_gold.', '', ''),
+('suggest_sell', 'I wish I have more than %item_formatted_link. You could buy it for %cost_gold anyways.', 0, 0, '', 'J\'aimerais avoir plus de %item_formatted_link . Vous pouvez l\'acheter pour %cost_gold de toute façon.', '', '', '', 'Desearía tener más de %item_formatted_link. Podrías comprarlo por %cost_gold de todos modos.', '', ''),
+('suggest_sell', 'What use for your gold? To buy my %item_formatted_link for %cost_gold.', 0, 0, '', 'A quoi sert votre or ? Pour acheter mon %item_formatted_link pour %cost_gold', '', '', '', '¿De qué sirve tu oro? Para comprar mi %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'Please spare some gold for me. You can buy %item_formatted_link for %cost_gold.', 0, 0, '', 'S\'il vous plaît, épargnez-moi de l\'or. Vous pouvez acheter %item_formatted_link pour %cost_gold', '', '', '', 'Por favor, dame algo de oro. Puedes comprar %item_formatted_link por %cost_gold.', '', ''),
+('suggest_sell', 'Is %cost_gold is a good price for %item_formatted_link?', 0, 0, '', '%cost_gold est-il un bon prix pour %item_formatted_link ?', '', '', '', '¿%cost_gold es un buen precio para %item_formatted_link?', '', ''),
+('suggest_sell', 'Just bought yesterday %item_formatted_links, but do not need it anymore. Anyone wants for %cost_gold?', 0, 0, '', 'Je viens d\'acheter hier %item_formatted_links , mais je n\'en ai plus besoin. Quelqu\'un veut %cost_gold ?', '', '', '', 'Ayer compré %item_formatted_link, pero ya no los necesito. ¿Alguien lo quiere por %cost_gold?', '', ''),
+('suggest_sell', 'I am going to post %item_formatted_link on the AH but you can buy it now cheaper just for %cost_gold.', 0, 0, '', 'Je vais poster %item_formatted_link à l\'hôtel des ventes mais vous pouvez l\'acheter maintenant moins cher juste pour %cost_gold', '', '', '', 'Voy a poner %item_formatted_link en la casa de subastas pero puedes comprarlo ahora más barato solo por %cost_gold.', '', ''),
+('suggest_sell', 'Why the #!@ have I bought %item_formatted_link? Anyone needs it for %cost_gold?', 0, 0, '', 'Pourquoi ai-je acheté le #!@ %item_formatted_link ? Quelqu\'un en a besoin pour %cost_gold ?', '', '', '', '¿Por qué #!@ he comprado %item_formatted_link? ¿Alguien lo necesita por %cost_gold?', '', ''),
+
+
+
+
+-- /////////////////////////////
+-- generic events
+
+-- quest
+('quest_accept', 'Quest accepted', 0, 0, '', '', '', '', '', 'Misión aceptada', '', 'Квест взят'),
+
+
+
+('quest_remove', 'Quest removed', 0, 0, '', '', '', '', '', 'Misión eliminada', '', 'Квест отменен'),
+
+
+
+('quest_cant_take', 'I can\'t take this quest', 0, 0, '', '', '', '', '', 'No puedo tomar esta búsqueda', '', 'Я не могу взять этот квест'),
+
+
+('quest_error_talk', 'I can\'t talk with the quest giver', 0, 0, '', '', '', '', '', 'No puedo hablar con el propietario de la mision', '', ''),
+
+
+
+('quest_error_completed', 'I have already completed %quest', 0, 0, '', '', '', '', '', 'Ya he completado la mision %quest', '', ''),
+
+
+
+('quest_error_have_quest', 'I already have %quest', 0, 0, '', '', '', '', '', 'Ya tengo la mision %quest', '', ''),
+
+
+
+('quest_error_cant_take', 'I can\'t take %quest', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest', '', ''),
+
+
+
+('quest_error_log_full', 'I can\'t take %quest because my quest log is full', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest porque mi registro de misiones esta completo', '', ''),
+
+
+
+('quest_error_bag_full', 'I can\'t take %quest because my bag is full', 0, 0, '', '', '', '', '', 'No puedo aceptar la mision %quest porque mi inventario esta lleno', '', ''),
+
+
+
+('quest_accepted', 'I have accepted %quest', 0, 0, '', '', '', '', '', 'He aceptado la mision %quest', '', ''),
+
+
+
+('quest_status_incomplete', 'I have not completed the quest %quest', 0, 0, '', '', '', '', '', 'No he completado la mision %quest', '', ''),
+
+
+
+('quest_status_available', 'Quest %quest available', 0, 0, '', '', '', '', '', 'Mision %quest disponible', '', ''),
+
+
+
+('quest_status_failed', 'I have failed the quest %quest', 0, 0, '', '', '', '', '', 'He fallado la mision %quest', '', ''),
+
+
+
+('quest_status_unable_to_complete', 'I am unable to turn in the quest %quest', 0, 0, '', '', '', '', '', 'No puedo entregar la mision %quest', '', ''),
+
+
+
+('quest_status_completed', 'I have completed the quest %quest', 0, 0, '', '', '', '', '', 'He completado la mision %quest', '', ''),
+
+
+
+('quest_status_complete_single_reward', 'I have completed the quest %quest and received %item', 0, 0, '', '', '', '', '', 'He completado la mision %quest y he recibido %item', '', ''),
+
+
+
+('quest_status_complete_pick_reward', 'Which reward should I pick for completing the quest %quest?%rewards', 0, 0, '', '', '', '', '', '¿Que recompensa deberia escoger por completar la mision %quest?%rewards', '', ''),
+
+
+
+('quest_choose_reward', 'Okay, I will pick %item as a reward', 0, 0, '', '', '', '', '', 'De acuerdo, voy a escoger %item de recompensa', '', ''),
+
+
+
+
+
+
+-- stuff
+('hello', 'Hello', 0, 0, '', '', '', '', '', 'Hola', '', 'Привет'),
+('hello', 'Hello!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Привет!'),
+('hello', 'Hi', 0, 0, '', '', '', '', '', 'Hola', '', 'Прив'),
+('hello', 'Hi!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Прив!'),
+('hello', 'Hello there!', 0, 0, '', '', '', '', '', '¡Hola!', '', 'Здарова!'),
+
+
+
+('hello_follow', 'Hello, I follow you!', 0, 0, '', '', '', '', '', '¡Hola, te sigo!', '', 'Привет, иду за тобой!'),
+('hello_follow', 'Hello, lead the way!', 0, 0, '', '', '', '', '', '¡Hola, guía el camino!', '', 'Привет, веди!'),
+('hello_follow', 'Hi, lead the way!', 0, 0, '', '', '', '', '', '¡Hola, guía el camino!', '', 'Прив, веди!'),
+
+
+
+('join_group', 'Hey %player, do you want join my group?', 0, 0, '', '', '', '', '', 'Oye %player, ¿Quieres unirte a mi grupo?', '', ''),
+
+
+
+('join_raid', 'Hey %player, do you want join my group?', 0, 0, '', '', '', '', '', 'Oye %player, ¿Quieres unirte a mi banda?', '', ''),
+
+
+
+('logout_cancel', 'Logout cancelled!', 0, 0, '', '', '', '', '', 'Cerrar sesión cancelado!', '', 'Логаут отменен!'),
+
+
+
+('logout_start', 'I\'m logging out!', 0, 0, '', '', '', '', '', '¡Me estoy desconectando!', '', 'Я выхожу из игры!'),
+
+
+
+('goodbye', 'Goodbye!', 0, 0, '', '', '', '', '', '¡Adiós!', '', 'Пока!'),
+('goodbye', 'Bye bye!', 0, 0, '', '', '', '', '', '¡Adiós!', '', 'Пока пока!'),
+('goodbye', 'See you later!', 0, 0, '', '', '', '', '', '¡Hasta luego!', '', 'Увидимся позже!'),
+
+
+
+-- /////////////////////////////
+-- replies
+
+
+-- replies 0
+('reply', 'what was that %s?', 0, 0, '', 'c\'était quoi ce %s?', '', '', '', '¿qué has dicho %s?', '', ''),
+('reply', 'not sure I understand %s?', 0, 0, '', 'pas sûr de comprendre %s?', '', '', '', '¿no estoy seguro de entenderte %s?', '', ''),
+('reply', 'uh... no clue what yer talkin bout', 0, 0, '', 'euh... aucune idée de quoi tu parles', '', '', '', 'uh... ni idea de lo que estás hablando', '', ''),
+('reply', 'you talkin to me %s?', 0, 0, '', 'tu me parles %s?', '', '', '', '¿Me hablas a mí %s?', '', ''),
+('reply', 'whaaaa?', 0, 0, '', 'quoiaaa?', '', '', '', '¿quéaaa?', '', ''),
+('reply', 'huh?', 0, 0, '', 'hein?', '', '', '', '¿eh?', '', ''),
+('reply', 'what?', 0, 0, '', 'Quoi?', '', '', '', '¿qué?', '', ''),
+('reply', 'are you talking?', 0, 0, '', 'parles-tu?', '', '', '', '¿estás hablando?', '', ''),
+('reply', 'whatever dude', 0, 0, '', 'peu importe mec', '', '', '', 'Menudo tio...', '', ''),
+('reply', 'you lost me', 0, 0, '', 'tu m\'as perdu', '', '', '', 'No entiendo ni papa', '', ''),
+('reply', 'Bla bla bla...', 0, 0, '', 'Bla bla bla...', '', '', '', 'Bla bla bla...', '', ''),
+('reply', 'What did you say, %s?', 0, 0, '', 'Qu\'as-tu dis, %s?', '', '', '', '¿Qué me estas contando %s?', '', ''),
+('reply', 'Concentrate on the game, %s!', 0, 0, '', 'Concentres-toi sur le jeu, %s!', '', '', '', '¡Concéntrate en el juego, %s!', '', ''),
+('reply', 'Chatting with you %s is so great! I always wanted to meet you', 0, 0, '', 'Discuter avec vous %s est tellement génial! J\'ai toujours voulu te rencontrer', '', '', '', '¡%s, chatear contigo es genial! Siempre quise conocerte', '', ''),
+('reply', 'These chat-messages are freaking me out! I feel like I know you all!', 0, 0, '', 'Ces messages du chat me font flipper! J\'ai l\'impression de vous connaître tous!', '', '', '', '¡Estos mensajes de chat me están asustando! ¿De que cojones estais hablando?', '', ''),
+('reply', 'YEAH RIGHT! HAHA SURE!!!', 0, 0, '', 'OUI EN EFFET! AHAH BIEN SÛR!!!', '', '', '', '¡SÍ, CORRECTO! ¡¡¡JAJA SEGURO!!!', '', ''),
+('reply', 'I believe you!!!', 0, 0, '', 'Je te crois!!!', '', '', '', '¡Si, claro!', '', ''),
+('reply', 'OK, uhuh LOL', 0, 0, '', 'OK, euh LOL', '', '', '', 'OK, uhuh LOL', '', ''),
+('reply', 'Why is everybody always saying the same things???', 0, 0, '', 'Pourquoi tout le monde dit toujours la même chose???', '', '', '', '¿Por qué todo el mundo siempre dice lo mismo?', '', ''),
+('reply', 'Hey %s....oh nevermind!', 0, 0, '', 'Hé %s.... oh tant pis!', '', '', '', 'Oye %s... ¡oh, no importa!', '', ''),
+('reply', 'What are you talking about %s', 0, 0, '', 'De quoi parlez-vous %s', '', '', '', 'De qué estás hablando %s', '', ''),
+('reply', 'Who said that? I resemble that remark', 0, 0, '', 'Qui a dit ça? je ressemble à cette remarque', '', '', '', '¿Quién ha dicho eso? ¿Estais hablando de mi?', '', ''),
+('reply', 'wtf are you all talking about', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'fr fr no cap on a stack', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'your not getting jack shit', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'are you begging for head ?', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'swag', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'ty!', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'no', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'Yep', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'f', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '%s no shit xD', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'why is that', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'lmao', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'thought i should remain silent, was getting confused from chat again', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'i can get realy jealous', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '%s you can\'t hear the dripping sarcasm in my text', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'he said no homo, it\'s fine', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'dwarf moment', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'Yes %s', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'interesting...', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'lol', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '%s fuck you man :D', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', ':^)', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'ty', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '%s well said', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'yay', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'yeah', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'ooooooh', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'hmm', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'yeah right', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'you made me gag wtf', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'hot', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'hoes mad', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'what have you been eating %s', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'wtf', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'i will attempt to understand that comment', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '*confused*', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'fuck yea', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '0/10 would not read again', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '10/10 would read again', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '6/10 would read', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', '7/10 would', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'based', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'oh yeah maybe', 0, 0, '', '', '', '', '', '', '', ''),
+('reply', 'yeah so what', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+
+
+
+
+-- replies 1
+('reply', 'hey %s i havent forgotten you', 0, 1, '', 'salut %s je ne t\'ai pas oublié', '', '', '', 'hey %s no te he olvidado', '', ''),
+('reply', 'you piss me off %s', 0, 1, '', 'tu me fais chier %s', '', '', '', 'me cabreas %s', '', ''),
+('reply', 'im gunna get you this time %s', 0, 1, '', 'je vais t\'avoir cette fois %s', '', '', '', 'voy a atraparte esta vez %s', '', ''),
+('reply', 'better watch your back %s', 0, 1, '', 'mieux vaut surveiller vos arrières %s', '', '', '', 'mejor cuida tu espalda %s', '', ''),
+('reply', 'i did not like last round so much', 0, 1, '', 'je n\'ai pas tellement aimé le dernier tour', '', '', '', 'no me gustó tanto la última ronda', '', ''),
+('reply', 'i sucked last round thanks to %s', 0, 1, '', 'j\'ai merdé le dernier tour grâce à %s', '', '', '', 'chupé la última ronda gracias a %s', '', ''),
+('reply', 'prepare to die %s', 0, 1, '', 'préparez-vous à mourir %s', '', '', '', 'prepárate para morir %s', '', ''),
+('reply', 'dont appreciate you killin me %s', 0, 1, '', 'j\'apprécie pas que tu me tues %s', '', '', '', 'no aprecio que me mates %s', '', ''),
+('reply', '%s, i hate you', 0, 1, '', '%s, je te déteste', '', '', '', '%s, te odio', '', ''),
+('reply', 'grrrrrr, ill get you this time %s', 0, 1, '', 'grrrrrr, je vais t\'avoir cette fois %s', '', '', '', 'grrrrrr, te libraste esta vez %s', '', ''),
+('reply', 'well fuck you', 0, 1, '', 'eh bien va te faire foutre', '', '', '', 'vamos a la mierda', '', ''),
+('reply', '%s i\'ll vomit into your fkin mouth', 0, 1, '', '', '', '', '', '', '', ''),
+('reply', 'dont fucking judge me', 0, 1, '', '', '', '', '', '', '', ''),
+('reply', 'Yo momma so fat, she can\'t even fit through the Dark Portal', 0, 1, '', '', '', '', '', '', '', ''),
+
+
+
+-- replies 2
+('reply', 'wtf', 0, 2, '', 'wtf', '', '', '', 'wtf', '', ''),
+('reply', 'wtf??', 0, 2, '', 'wtf??', '', '', '', 'wtf??', '', ''),
+('reply', 'low life', 0, 2, '', 'faible durée de vie', '', '', '', 'low life', '', ''),
+('reply', 'wth', 0, 2, '', 'wth', '', '', '', 'wth', '', ''),
+('reply', 'sucked', 0, 2, '', 'Ça craint', '', '', '', 'chupate esa', '', ''),
+('reply', 'REMATCH!!! im taking him down', 0, 2, '', 'REMATCH!!! je le descends', '', '', '', '¡¡REVANCHA!!! lo estoy derribando', '', ''),
+('reply', 'pathetic, i got killed by %s', 0, 2, '', 'pathétique, j\'ai été tué par %s', '', '', '', 'patético, me mató %s', '', ''),
+('reply', 'ok i\'m done', 0, 2, '', '', '', '', '', '', '', ''),
+
+
+
+-- replies 3
+('reply', 'hehe, i nailed %s?', 0, 3, '', 'hehe, j\'ai cloué %s?', '', '', '', 'jeje, ¿acerté a %s?', '', ''),
+('reply', 'that was too easy, killin %s', 0, 3, '', 'c\'était trop facile, de tuer %s', '', '', '', 'fue demasiado fácil matar a %s', '', ''),
+('reply', 'gotcha mofo', 0, 3, '', 'je t\'ai eu enfoiré', '', '', '', 'te pille hijo de perra', '', ''),
+('reply', 'ha ha', 0, 3, '', 'ha ha', '', '', '', 'ja, ja', '', ''),
+('reply', 'loser', 0, 3, '', 'loser', '', '', '', 'loser', '', ''),
+('reply', 'i killed %s and yer all next dudes', 0, 3, '', 'j\'ai tué %s et vous tous les prochains mecs', '', '', '', 'yo maté a %s y a todos los siguientes tipos', '', ''),
+('reply', 'oh yeah i owned him', 0, 3, '', 'oh ouais je l\'ai possédé', '', '', '', 'oh, sí, lo tenía', '', ''),
+('reply', 'im a killin machine', 0, 3, '', 'je suis une machine à tuer', '', '', '', 'soy una máquina de matar', '', ''),
+('reply', '%s,  this reminds me of a Slayer song...all this bloodshed', 0, 3, '', '%s, ça me rappelle une chanson de Slayer... tout ce bain de sang', '', '', '', '%s, esto me recuerda a una canción de Slayer... todo este derramamiento de sangre', '', ''),
+('reply', 'sorry, %s. can we do the scene again?', 0, 3, '', 'désolé, %s. peut-on refaire la scène?', '', '', '', 'lo siento, %s. ¿Podemos hacer la escena de nuevo?', '', ''),
+('reply', 'so....how do you like being worm food %s???', 0, 3, '', 'alors... comment aimez-vous être de la nourriture pour vers %s???', '', '', '', 'así que... ¿cómo te gusta ser comida de gusanos %s???', '', ''),
+('reply', 'yer supposed to be dead, %s its part of the game!!!!!', 0, 3, '', 'tu es censé être mort, %s ça fait partie du jeu!!!!!', '', '', '', '¡¡Se supone que estás muerto, %s es parte del juego!!!!!', '', ''),
+('reply', 'sorry, %s. that looked as good as an Andy Worhol painting!', 0, 3, '', 'désolé, %s. ça avait l\'air aussi bien qu\'une peinture d\'Andy Warhol!', '', '', '', 'lo siento, %s. ¡Eso se veía tan bien como una pintura de Andy Worhol!', '', ''),
+('reply', '%s, ill use the rubber bullets next time !', 0, 3, '', '%s, j\'utiliserai pas les balles en caoutchouc la prochaine fois!', '', '', '', '%s, ¡usaré las balas de goma la próxima vez!', '', ''),
+('reply', 'whatsamatter, %s?? lose your head? hahaha gotta keep cool!!', 0, 3, '', 'qu\'importe, %s ?? tu perds la tête? hahaha faut rester cool!!', '', '', '', '¿qué pasa, %s?? ¿has perdido la cabeza? jajaja tengo que mantener la calma!!', '', ''),
+('reply', 'i had to do it, %s. You understand. The Director said so!!', 0, 3, '', 'je devais le faire, %s. Tu comprends. Le directeur l\'a dit!!', '', '', '', 'Tenía que hacerlo, %s. Entiendelo... ¡¡Dios me lo ordenó!!', '', ''),
+('reply', 'hey %s.......MUAHAHAHAHAHAHAHAHAHAHA', 0, 3, '', 'Salut %s.......MUAHAHAHAHAHAHAHAHAHAHA', '', '', '', 'hey %s.......MUAHAHAHAHAHAHAHAHAHAHA', '', ''),
+('reply', '%s, i enjoyed that one!! Lets play it again Sam', 0, 3, '', '%s, j\'ai adoré celui-là !! Jouons à nouveau Sam', '', '', '', '%s, ¡disfruté ese! Juguemos de nuevo Sam', '', ''),
+('reply', 'hey, %s! ju can start callin me scarface.. ju piece of CHIT!!!!', 0, 3, '', 'Hé, %s ! ju peut commencer à m\'appeler Scarface .. ju merde!!!!', '', '', '', '¡oye, %s! ¡Puedes empezar a llamarme caracortada... ¡¡¡un trozo de CHIT!!!', '', ''),
+('reply', 'are you talking to me %s??', 0, 3, '', 'tu me parles %s ??', '', '', '', '¿me estás hablando a mí %s?', '', ''),
+('reply', '%s get it right this time, dont stand in front of my bullets.', 0, 3, '', '%s réussis cette fois, ne te tiens pas devant mes balles.', '', '', '', '%s hazlo bien esta vez, no te pares frente a mis balas.', '', ''),
+('reply', '%s, what are you laying around for??? hehe', 0, 3, '', '%s, pourquoi traînes-tu??? hé hé', '', '', '', '%s, ¿para qué estás tirado? jeje', '', ''),
+('reply', 'laughed real hard', 0, 3, '', '', '', '', '', '', '', ''),
+
+
+
+-- replies 4
+('reply', 'hi %s', 0, 4, '', 'salut %s', '', '', '', 'hola %s', '', ''),
+('reply', 'oh, hi %s', 0, 4, '', 'oh, salut %s', '', '', '', 'oh, hola %s', '', ''),
+('reply', 'wazzup %s!!!', 0, 4, '', 'Quoi de neuf %s!!!', '', '', '', 'wazzup %s!!!', '', ''),
+('reply', 'hi', 0, 4, '', 'salut', '', '', '', 'hi', '', ''),
+('reply', 'wazzup', 0, 4, '', 'wazzup', '', '', '', 'wazzup', '', ''),
+('reply', 'hello %s', 0, 4, '', 'bonjour %s', '', '', '', 'hola %s', '', ''),
+('reply', 'hi %s, do i know you?', 0, 4, '', 'Salut %s, est-ce que je te connais ?', '', '', '', 'hola %s, ¿te conozco?', '', ''),
+('reply', 'hey %s', 0, 4, '', 'salut %s', '', '', '', 'hey %s', '', ''),
+('reply', 'hai %s', 0, 4, '', 'ha %s', '', '', '', 'hai %s', '', ''),
+('reply', 'wth', 0, 6, '', 'wth', '', '', '', 'wth', '', ''),
+('reply', 'wtf', 0, 6, '', 'wtf', '', '', '', 'que cojones!', '', ''),
+('reply', 'this is bs', 0, 6, '', 'c\'est bs', '', '', '', 'esto es una mierda', '', ''),
+('reply', 'admin', 0, 6, '', 'admin', '', '', '', 'admin', '', ''),
+('reply', 'hey %s quit abusing your admin', 0, 6, '', 'hé %s arrête d\'abuser de ton admin', '', '', '', 'hey %s deja de abusar de tu poder de administrador', '', ''),
+('reply', 'leave me alone admin!', 0, 6, '', 'laissez-moi tranquille admin!', '', '', '', '¡déjame en paz administrador!', '', ''),
+('reply', 'you suck admin', 0, 6, '', 'tu es nul admin', '', '', '', 'apestas administrador', '', ''),
+('reply', 'thats my name, what you want %s', 0, 5, '', 'c\'est mon nom, qu\'est-ce que tu veux %s', '', '', '', 'ese es mi nombre, ¿que quieres %s?', '', ''),
+('reply', 'yes???', 0, 5, '', 'Oui???', '', '', '', 'sí???', '', ''),
+('reply', 'uh... what', 0, 5, '', 'euh ...quoi', '', '', '', 'uh... qué', '', ''),
+('reply', 'you talkin to me %s?', 0, 5, '', 'tu me parles %s ?', '', '', '', '¿Me hablas a mí %s?', '', ''),
+
+
+
+
+
+-- taunts
+('taunt', 'I have puppies under my armor!', 0, 0, '', 'J\'ai des chiots sous mon armure !', '', '', '', '¡Tengo cachorros bajo mi armadura!', '', ''),
+('taunt', 'Bite me, <target>!', 0, 0, '', 'Mords moi, <target>!', '', '', '', '¡Muérdeme, <target>!', '', ''),
+('taunt', 'Hey <target>! Guess what your mom said last night!', 0, 0, '', 'Hey <target>! Devine ce que ta mère a dit hier soir!', '', '', '', '¡Oye, <target>! ¡Adivina lo que me dijo tu madre anoche!', '', ''),
+('taunt', '<target>, you\'re so ugly you couldn\'t score in a monkey whorehouse with a bag of bananas!', 0, 0, '', '<target>, tu es si moche que tu ne pourrais pas marquer dans un bordel de singes avec un sac de bananes!', '', '', '', '<target>, ¡eres tan feo que no podrías anotar en un burdel de monos con una bolsa de plátanos!', '', ''),
+('taunt', 'Shut up <target>, you\'ll never be the man your mother is!!', 0, 0, '', 'Tais-toi <target>, tu ne seras jamais l\'homme qu\'est ta mère!!', '', '', '', 'Cállate <target>, ¡nunca serás el hombre que es tu madre!', '', ''),
+('taunt', 'Your mother was a hampster and your father smelt of elderberries!!!!', 0, 0, '', 'Ta mère était un hamster et ton père sentait le sureau!!!!', '', '', '', 'Tu madre era un hámster y tu padre olía a bayas de saúco!!!!', '', ''),
+('taunt', 'I don\'t want to talk to you no more, you empty headed animal food trough wiper!!!', 0, 0, '', 'Je ne veux plus te parler, espèce d\'essuyeur d\'abreuvoirs pour animaux tête vide!!!', '', '', '', '¡¡No quiero hablar más contigo, limpiaparabrisas de cabeza vacía!', '', ''),
+('taunt', 'I fart in your general direction!!!', 0, 0, '', 'Je pète dans votre direction générale!!!', '', '', '', '¡¡Me tiro un pedo en tu dirección general!!!', '', ''),
+('taunt', 'Go and boil your bottom, you son of a silly person!!!', 0, 0, '', 'Va te faire cuire le cul, fils d\'idiot!!!', '', '', '', '¡Ve y hierve tu trasero, hijo de una persona tonta!', '', ''),
+('taunt', 'What are you going to do <target>, bleed on me? HAVE AT YOU!', 0, 0, '', 'Qu\'est ce que tu vas faire <target>, saigner sur moi? A VOUS!', '', '', '', '¿Qué vas a hacer <target>, llorar?', '', ''),
+('taunt', 'M-O-O-N! That spells aggro!', 0, 0, '', 'PUNAISE! Ce sort aggro!', '', '', '', '¡LUNA! ¡Eso deletrea agresividad!', '', ''),
+('taunt', 'You\'re about as useful as a one-legged man in an ass kicking contest.', 0, 0, '', 'Tu es à peu près aussi utile qu\'un homme unijambiste dans un concours de coups de pied au cul.', '', '', '', 'Eres tan útil como un hombre con una sola pierna en un concurso de patadas en el culo.', '', ''),
+('taunt', 'Hey <target>! Stop hitting on them, they\'re not your type. They aren\'t inflatable.', 0, 0, '', 'Hey <target>! Arrête de les draguer, ce n\'est pas ton genre. Ils ne sont pas gonflables.', '', '', '', '¡Oye, <target>! Deja de coquetear con ellos, no son tu tipo. No son inflables.', '', ''),
+('taunt', '<target> you\'re so far outta your league, you\'re playing a different sport.', 0, 0, '', '<target> vous êtes tellement hors de votre ligue que vous pratiquez un sport différent.', '', '', '', '<target> estás tan lejos de tu liga, estás jugando un deporte diferente.', '', ''),
+('taunt', 'You made a big mistake today <target>, you got out of bed.', 0, 0, '', 'Tu as fait une grosse erreur aujourd\'hui <target>, tu es sorti du lit.', '', '', '', 'Cometiste un gran error hoy <target>, te levantaste de la cama.', '', ''),
+('taunt', 'I wanna try turning into a horse, but I need help. I\'ll be the front, you be yourself.', 0, 0, '', 'Je veux essayer de me transformer en cheval, mais j\'ai besoin d\'aide. Je serai devant, tu seras toi-même.', '', '', '', 'Quiero intentar convertirme en un caballo, pero necesito ayuda. Yo seré el frente, tú mismo.', '', ''),
+('taunt', 'Can I borrow your face for a few days? My ass is going on holiday....', 0, 0, '', 'Puis-je emprunter votre visage pendant quelques jours? Mon cul part en vacances....', '', '', '', '¿Me prestas tu cara por unos días? Mi culo se va de vacaciones...', '', ''),
+('taunt', 'I\'d like to give you a going away present... First you do your part.', 0, 0, '', 'J\'aimerais vous offrir un cadeau de départ... D\'abord, donnes ta part.', '', '', '', 'Me gustaría darte un regalo de despedida... Primero haz tu parte.', '', ''),
+('taunt', 'Before you came along we were hungry, Now we\'re just fed up.', 0, 0, '', 'Avant que tu n\'arrives nous avions faim, maintenant nous en avons juste marre.', '', '', '', 'Antes de que llegaras teníamos hambre, ahora estamos hartos', '', ''),
+('taunt', 'I like you. People say I have no taste, but I like you.', 0, 0, '', 'Je t\'aime bien. Les gens disent que je n\'ai pas de goût, mais je t\'aime bien.', '', '', '', 'Me gustas. La gente dice que no tengo gusto, pero me gustas.', '', ''),
+('taunt', 'I think you have an inferiority complex, but that\'s okay, it\'s justified.', 0, 0, '', 'Je pense que tu as un complexe d\'infériorité, mais il n\'y a pas de problème, c\'est justifié.', '', '', '', 'Creo que tienes complejo de inferioridad, pero está bien, está justificado', '', ''),
+('taunt', 'Hence rotten thing! Or I shall shake thy bones out of thy garments.', 0, 0, '', 'Par conséquent chose pourrie! Je vais secouer tes os de tes vêtements.', '', '', '', '¡Por lo tanto, cosa podrida! o te sacudiré los huesos de las vestiduras.', '', ''),
+('taunt', 'I can\'t believe I\'m wasting my time with you!', 0, 0, '', 'Je n\'arrive pas à croire que je perds mon temps avec toi!', '', '', '', '¡No puedo creer que estoy perdiendo el tiempo contigo!', '', ''),
+('taunt', 'I love it when someone insults me, it means I don\'t have to be nice anymore.', 0, 0, '', 'J\'adore quand quelqu\'un m\'insulte, ça veut dire que je n\'ai plus besoin d\'être gentil.', '', '', '', 'Me encanta cuando alguien me insulta, significa que ya no tengo que ser amable', '', ''),
+('taunt', 'Thou leathern-jerkin, crystal-button, knot-pated, agatering, puke-stocking, caddis-garter, smooth-tongue, Spanish pouch!', 0, 0, '', 'Toi l\'agent fédéral, pourpoint en cuir, bouton de cristal, anneau d\'agate, bas vomi, jarretière caddis, pochette espagnole!', '', '', '', '¡Tú, jubón de cuero, botón de cristal, anudado, ágata, medias de vómito, liga de caddis, lengua suave, bolsa española!', '', ''),
+('taunt', 'Thou qualling bat-fowling malt-worm!', 0, 0, '', 'Toi qualificatif de chauve-souris qui chasse le ver de malt!', '', '', '', '¡Tú, gusano de malta cazador de murciélagos!', '', ''),
+('taunt', 'Thou art truely an idol of idiot-worshippers!', 0, 0, '', 'Tu es vraiment une idole d\'adorateurs d\'idiots!', '', '', '', '¡Eres verdaderamente un ídolo de los adoradores de idiotas!', '', ''),
+('taunt', 'Thou misbegotten knotty-pated wagtail!', 0, 0, '', 'Tu es une bergeronnette printanière mal engendrée!', '', '', '', '¡Maldito lavandero nudoso!', '', ''),
+('taunt', 'Thou whoreson mandrake, thou art fitter to be worn in my cap than to wait at my heels!', 0, 0, '', 'Toi putain de mandragore, tu es plus apte à être porté dans ma casquette qu\'à attendre sur mes talons!', '', '', '', '¡Hijo de puta mandrágora, eres mejor para que te lleve en mi gorra que para que me pise los talones!', '', ''),
+('taunt', 'You! You scullion! You rampallian! You fustilarian! I\'ll tickle your catastrophe!', 0, 0, '', 'Toi ! Espèce de marmiton ! Espèce de rampallian ! Espèce de fusilier ! Je vais chatouiller ta catastrophe!', '', '', '', '¡Tú! ¡Scullion! ¡Ramaliano! ¡Fustilarista! ¡Te haré cosquillas en tu catástrofe!', '', ''),
+('taunt', 'Oh <target>! Thou infectious ill-nurtured flax-wench!', 0, 0, '', 'Oh <target>! Tu es contagieuse et mal nourrie!', '', '', '', '¡Oh, <target>! ¡Tú, contagiosa moza del lino mal educada!', '', ''),
+('taunt', 'We leak in your chimney, <target>!', 0, 0, '', 'On a une fuite dans votre cheminée, <target>!', '', '', '', '¡Tenemos una fuga en tu chimenea, <target>!', '', ''),
+('taunt', 'Oh thou bootless fen-sucked canker-blossom!', 0, 0, '', 'Oh toi, fleur de chancre sucée par les marais sans botte!', '', '', '', '¡Oh tú, flor de cancro chupada por el pantano sin botas!', '', ''),
+('taunt', 'Were I like thee I\'d throw away myself!', 0, 0, '', 'Si j\'étais comme toi, je me jetterais!', '', '', '', '¡Si yo fuera como tú, me tiraría a la basura!', '', ''),
+('taunt', 'O teach me <target>, how I should forget to think!', 0, 0, '', 'O apprends-moi <target>, comme je devrais oublier de penser!', '', '', '', '¡Oh, enséñame <target>, cómo debo olvidarme de pensar!', '', ''),
+('taunt', 'Truly thou art damned, like an ill-roasted egg, all on one side!', 0, 0, '', 'Vraiment tu es damné, comme un œuf mal rôti, tout d\'un côté!', '', '', '', '¡Verdaderamente estás condenado, como un huevo mal asado, todo de un lado!', '', ''),
+('taunt', 'You starvelling, you eel-skin, you dried neat\'s-tongue, you bull\'s-pizzle, you stock-fish- O for breath to utter what is like thee!! -you tailor\'s-yard, you sheath, you bow-case, you vile standing tuck!', 0, 0, '', 'Toi affamé, espèce de peau d\'anguille, ta langue bien séchée, espèce de taureau, poisson séché, O pour le souffle de dire ce qui te ressemble !! -espèce de vergue de tailleur, espèce de fourreau, espèce d\'étui à archet, vil tuck debout', '', '', '', 'Estás muerto de hambre, piel de anguila, te secaste la lengua limpiamente, toro-pizzle, pescado-O para respirar pronunciar lo que es como tú !! ¡Tú, sastrería, vaina, estuche de arco, vil flaco de pie!', '', ''),
+('taunt', 'Fie! Drop thee into the rotten mouth of Death!', 0, 0, '', 'Fi ! Jette-toi dans la bouche pourrie de la Mort!', '', '', '', '¡Fie! ¡Déjate caer en la podrida boca de la Muerte!', '', ''),
+('taunt', '<target>, you are a fishmonger!', 0, 0, '', '<target>, vous êtes poissonnier!', '', '', '', '<target>, ¡eres un pescadero!', '', ''),
+('taunt', 'I shall live to knock thy brains out!', 0, 0, '', 'Je vivrai pour te faire sauter la cervelle!', '', '', '', '¡Viviré para romperte los sesos!', '', ''),
+('taunt', 'Most shallow are you, <target>!! Thou art worms-meat in respect of a good piece of flesh, indeed!!', 0, 0, '', 'Tu es très superficiel, <target>!! Tu es de la viande de vers par rapport à un bon morceau de chair, en effet!!', '', '', '', '¡¡Eres el más superficial, <target>!! ¡Eres carne de gusano con respecto a un buen trozo de carne, de hecho!', '', ''),
+('taunt', 'Vile wretch! O <target>, thou odiferous hell-hated pignut!', 0, 0, '', 'Misérable ! O <target>, toi, ignoble cochon de l\'enfer!', '', '', '', '¡Miserable vil! ¡Oh, <target>, fétido cerdo odiado por el infierno!', '', ''),
+('taunt', '<target>! Thy kiss is as comfortless as frozen water to a starved snake!', 0, 0, '', '<target>! Ton baiser est aussi désagréable que de l\'eau gelée pour un serpent affamé!', '', '', '', '<target>! ¡Tu beso es tan desconsolador como el agua helada para una serpiente hambrienta!', '', ''),
+('taunt', 'I scorn you, scurvy companion. What, you poor, base, rascally, cheating, lack-linen mate! Away, you moldy rogue, away!', 0, 0, '', 'Je te méprise, compagnon du scorbut. Quoi, pauvre, bas, coquin, tricheur, camarade en manque de linge ! Partez, espèce de voyou moisi, partez!', '', '', '', 'Te desprecio, compañero escorbuto. ¡Qué, pobre, vil, pícaro, tramposo, compañero falto de lino! ¡Fuera, mohoso granuja, fuera!', '', ''),
+('taunt', 'Out of my sight! Thou dost infect my eyes <target>!', 0, 0, '', 'Hors de ma vue! Tu infectes mes yeux <target>!', '', '', '', '¡Fuera de mi vista! ¡Me infectas los ojos <target>!', '', ''),
+('taunt', 'PLAY TIME!!!!', 0, 0, '', 'RÉCRÉATION!!!!', '', '', '', '¡¡¡HORA DE JUGAR!!!!', '', ''),
+('taunt', 'None shall pass!', 0, 0, '', 'Personne ne passera!', '', '', '', '¡Ninguno pasará!', '', ''),
+('taunt', 'We\'re under attack! A vast, ye swabs! Repel the invaders!', 0, 0, '', 'Nous sommes attaqués ! Un vaste écouvillons! Repoussez les envahisseurs!', '', '', '', '¡Estamos bajo ataque! ¡Un vasto, hisopos! ¡Repeler a los invasores!', '', ''),
+('taunt', 'None may challenge the Brotherhood!', 0, 0, '', 'Personne ne peut défier la Confrérie!', '', '', '', '¡Nadie puede desafiar a la Hermandad!', '', ''),
+('taunt', 'Foolsss...Kill the one in the dress!', 0, 0, '', 'Foolsss... Tuez celui qui porte la robe!', '', '', '', 'Tontosss... ¡Matad al del vestido!', '', ''),
+('taunt', 'I\'ll feed your soul to Hakkar himself! ', 0, 0, '', 'Je donnerai ton âme à Hakkar lui-même! ', '', '', '', '¡Le daré de comer con tu alma al mismísimo Hakkar! ', '', ''),
+('taunt', 'Pride heralds the end of your world! Come, mortals! Face the wrath of the <randomfaction>!', 0, 0, '', 'La fierté annonce la fin de votre monde ! Venez, mortels ! Affrontez la colère des <randomfaction>!', '', '', '', '¡El orgullo anuncia el fin de tu mundo! ¡Venid, mortales! ¡Enfréntate a la ira de la <facción aleatoria>!', '', ''),
+('taunt', 'All my plans have led to this!', 0, 0, '', 'Tous mes plans ont mené à cela!', '', '', '', '¡Todos mis planes me han llevado a esto!', '', ''),
+('taunt', 'Ahh! More lambs to the slaughter!', 0, 0, '', 'Ahhh ! Plus d\'agneaux à l\'abattoir!', '', '', '', '¡Ahh! ¡Más corderos al matadero!', '', ''),
+('taunt', 'Another day, another glorious battle!', 0, 0, '', 'Un autre jour, une autre bataille glorieuse!', '', '', '', '¡Otro día, otra batalla gloriosa!', '', ''),
+('taunt', 'So, business... or pleasure?', 0, 0, '', 'Alors, affaires... ou plaisir?', '', '', '', 'Entonces, ¿negocios... o placer?', '', ''),
+('taunt', 'You are not prepared!', 0, 0, '', 'Vous n\'êtes pas prêt!', '', '', '', '¡No estás preparado!', '', ''),
+('taunt', 'The <randomfaction>\'s final conquest has begun! Once again the subjugation of this world is within our grasp. Let none survive! ', 0, 0, '', 'La conquête finale de la <randomfaction> a commencé ! Une fois de plus, l\'assujettissement de ce monde est à notre portée. Que personne ne survive!', '', '', '', '¡La conquista final de <randomfaction> ha comenzado! Una vez más, la subyugación de este mundo está a nuestro alcance. ¡Que nadie sobreviva! ', '', ''),
+('taunt', 'Your death will be a painful one. ', 0, 0, '', 'Ta mort sera douloureuse.', '', '', '', 'Tu muerte será dolorosa. ', '', ''),
+('taunt', 'Cry for mercy! Your meaningless lives will soon be forfeit. ', 0, 0, '', 'Crie miséricorde ! Vos vies insignifiantes seront bientôt perdues.', '', '', '', '¡Llora por piedad! Sus vidas sin sentido pronto se perderán. ', '', ''),
+('taunt', 'Abandon all hope! The <randomfaction> has returned to finish what was begun so many years ago. This time there will be no escape! ', 0, 0, '', 'Abandonner tout espoir! La <randomfaction> est revenue pour terminer ce qui avait été commencé il y a tant d\'années. Cette fois, il n\'y aura pas d\'échappatoire!', '', '', '', '¡Abandona toda esperanza! La <randomfaction> ha regresado para terminar lo que comenzó hace tantos años. ¡Esta vez no habrá escapatoria! ', '', ''),
+('taunt', 'Alert! You are marked for Extermination! ', 0, 0, '', 'Alerte! Vous êtes marqué pour l\'extermination!', '', '', '', '¡Alerta! ¡Estás marcado para el exterminio! ', '', ''),
+('taunt', 'The <subzone> is for guests only...', 0, 0, '', 'La <subzone> est réservée aux invités...', '', '', '', 'La <subzone> es solo para invitados...', '', ''),
+('taunt', 'Ha ha ha! You are hopelessly outmatched!', 0, 0, '', 'Hahaha! Vous êtes désespérément surpassé!', '', '', '', '¡Ja, ja, ja! ¡Estás irremediablemente superado!', '', ''),
+('taunt', 'I will crush your delusions of grandeur! ', 0, 0, '', 'Je vais écraser vos illusions de grandeur!', '', '', '', '¡Aplastaré tus delirios de grandeza! ', '', ''),
+('taunt', 'Forgive me, for you are about to lose the game.', 0, 0, '', 'Pardonnez-moi, car vous êtes sur le point de perdre la partie.', '', '', '', 'Perdóname, porque estás a punto de perder el juego.', '', ''),
+('taunt', 'Struggling only makes it worse.', 0, 0, '', 'Lutter ne fait qu\'empirer les choses.', '', '', '', 'La lucha solo lo empeora.', '', ''),
+('taunt', 'Vermin! Leeches! Take my blood and choke on it!', 0, 0, '', 'Vermine! sangsues ! Prends mon sang et étouffe-toi avec!', '', '', '', '¡Alimañas! ¡Sanguijuelas! ¡Toma mi sangre y atragantate con ella!', '', ''),
+('taunt', 'Not again... NOT AGAIN!', 0, 0, '', 'Pas encore... PAS ENCORE!', '', '', '', 'No otra vez... ¡NO OTRA VEZ!', '', ''),
+('taunt', 'My blood will be the end of you!', 0, 0, '', 'Mon sang sera ta fin!', '', '', '', '¡Mi sangre será tu fin!', '', ''),
+('taunt', 'Good, now you fight me!', 0, 0, '', 'Bien, maintenant tu me combats!', '', '', '', 'Bien, ¡ahora pelea conmigo!', '', ''),
+('taunt', 'Get da move on, guards! It be killin\' time!', 0, 0, '', 'Allez-y, gardes ! Ça va tuer le temps!', '', '', '', '¡Muévanse, guardias! ¡Será para matar el tiempo!', '', ''),
+('taunt', 'Don\'t be delayin\' your fate. Come to me now. I make your sacrifice quick.', 0, 0, '', 'Ne retardez pas votre destin. Viens à moi maintenant. Je fais votre sacrifice rapide.', '', '', '', 'No demores tu destino. Ven a mí ahora. Hago que tu sacrificio sea rápido.', '', ''),
+('taunt', 'You be dead soon enough!', 0, 0, '', 'Tu es mort bien assez tôt!', '', '', '', '¡Estarás muerto lo suficientemente pronto!', '', ''),
+('taunt', 'Mua-ha-ha!', 0, 0, '', 'Mua-ha-ha!', '', '', '', '¡Mua-ja-ja!', '', ''),
+('taunt', 'I be da predator! You da prey...', 0, 0, '', 'Je suis un prédateur ! Tu es une proie...', '', '', '', '¡Soy un depredador! Eres presa...', '', ''),
+('taunt', 'You gonna leave in pieces!', 0, 0, '', 'Tu vas partir en morceaux!', '', '', '', '¡Te vas a ir en pedazos!', '', ''),
+('taunt', 'Death comes. Will your conscience be clear? ', 0, 0, '', 'La mort vient. Votre conscience sera-t-elle claire?', '', '', '', 'La muerte llega. ¿Tu conciencia estará limpia? ', '', ''),
+('taunt', 'Your behavior will not be tolerated.', 0, 0, '', 'Votre comportement ne sera pas toléré.', '', '', '', 'Tu comportamiento no será tolerado', '', ''),
+('taunt', 'The Menagerie is for guests only.', 0, 0, '', 'La Ménagerie est réservée aux invités.', '', '', '', 'The Menagerie es solo para invitados', '', ''),
+('taunt', 'Hmm, unannounced visitors, Preparations must be made... ', 0, 0, '', 'Hmm, visiteurs inopinés, il faut faire des préparatifs...', '', '', '', 'Hmm, visitantes inesperados, se deben hacer preparativos... ', '', ''),
+('taunt', 'Hostile entities detected. Threat assessment protocol active. Primary target engaged. Time minus thirty seconds to re-evaluation.', 0, 0, '', 'Entités hostiles détectées. Protocole d\'évaluation de la menace actif. Cible principale engagée. Délai de réévaluation moins trente secondes.', '', '', '', 'Entidades hostiles detectadas. Protocolo de evaluación de amenazas activo. Objetivo principal comprometido. Tiempo menos treinta segundos para la reevaluación.', '', ''),
+('taunt', 'New toys? For me? I promise I won\'t break them this time!', 0, 0, '', 'Nouveaux jouets? Pour moi? Promis je ne les casserai pas cette fois !', '', '', '', '¿Juguetes nuevos? ¿Para mi? ¡Te prometo que no los romperé esta vez!', '', ''),
+('taunt', 'I\'m ready to play!', 0, 0, '', 'Je suis prêt à jouer!', '', '', '', '¡Estoy listo para jugar!', '', ''),
+('taunt', 'Shhh... it will all be over soon.', 0, 0, '', 'Chut... tout sera bientôt fini.', '', '', '', 'Shhh... todo terminará pronto.', '', ''),
+('taunt', 'Aaaaaughibbrgubugbugrguburgle!', 0, 0, '', 'Aaaaaughibbrgubugbugrguburgle!', '', '', '', '¡Aaaaaughibbrgubugbugrguburgle!', '', ''),
+('taunt', 'RwlRwlRwlRwl!', 0, 0, '', 'RwlRwlRwlRwl!', '', '', '', 'RwlRwlRwlRwl!', '', ''),
+('taunt', 'You too, shall serve!', 0, 0, '', 'Toi aussi, tu serviras!', '', '', '', '¡Tú también, debes servir!', '', ''),
+('taunt', 'Tell me... tell me everything!  Naughty secrets! I\'ll rip the secrets from your flesh!', 0, 0, '', 'Dis-moi... dis-moi tout ! Secrets coquins ! J\'arracherai les secrets de ta chair!', '', '', '', 'Cuéntame... ¡cuéntame todo! ¡Secretos traviesos! ¡Arrancaré los secretos de tu carne!', '', ''),
+('taunt', 'Prepare yourselves, the bells have tolled! Shelter your weak, your young and your old! Each of you shall pay the final sum! Cry for mercy, the reckoning has come!', 0, 0, '', 'Préparez-vous, les cloches ont sonné ! Mettez à l\'abri vos faibles, vos jeunes et vos vieux ! Chacun de vous paiera la somme finale ! Implorez la miséricorde , le jugement est venu!', '', '', '', '¡Prepárense, las campanas han doblado! ¡Abriga a tus débiles, a tus jóvenes ya tus viejos! ¡Cada uno de ustedes pagará la suma final! Clama por misericordia, el ajuste de cuentas ha llegado!', '', ''),
+('taunt', 'Where in Bonzo\'s brass buttons am I?', 0, 0, '', 'Où suis-je dans les boutons en laiton de Bonzo?', '', '', '', '¿Dónde estoy en los botones de latón de Bonzo?', '', ''),
+('taunt', 'I can bear it no longer! Goblin King! Goblin King! Wherever you may be! Take this <target> far away from me!', 0, 0, '', 'Je ne peux plus le supporter ! Roi Gobelin ! Roi Gobelin ! Où que vous soyez ! Emmenez cette <target> loin de moi!', '', '', '', '¡No puedo soportarlo más! ¡Rey de los duendes! ¡Rey de los duendes! ¡WHERE quiera que estés! ¡Lleva a este <target> lejos de mí!', '', ''),
+('taunt', 'You have thirteen hours in which to solve the labyrinth, before your baby brother becomes one of us... forever.', 0, 0, '', 'Vous avez treize heures pour résoudre le labyrinthe, avant que ton petit frère ne devienne l\'un des nôtres... pour toujours.', '', '', '', 'Tienes trece horas para resolver el laberinto, antes de que tu hermanito se convierta en uno de nosotros... para siempre', '', ''),
+('taunt', 'So, the <subzone> is a piece of cake, is it? Well, let\'s see how you deal with this little slice... ', 0, 0, '', 'Donc, la <subzone> est un jeu d\'enfant, n\'est-ce pas ? Eh bien, voyons comment tu gères cette petite tranche...', '', '', '', 'Entonces, la <subzone> es pan comido, ¿verdad? Bueno, veamos cómo lidias con esta pequeña porción... ', '', ''),
+('taunt', 'Back off, I\'ll take you on, headstrong to take on anyone, I know that you are wrong, and this is not where you belong', 0, 0, '', 'Reculez, je vais vous attaquer, têtu à affronter n\'importe qui, je sais que vous vous trompez, et ce n\'est pas votre place', '', '', '', 'Atrás, te enfrentaré, testarudo para enfrentar a cualquiera, sé que estás equivocado, y este no es el lugar al que perteneces', '', ''),
+('taunt', 'Show me whatcha got!', 0, 0, '', 'Montre-moi ce que tu as!', '', '', '', '¡Muéstrame lo que tienes!', '', ''),
+('taunt', 'To the death!', 0, 0, '', 'A la mort!', '', '', '', '¡Hasta la muerte!', '', ''),
+('taunt', 'Twin blade action, for a clean close shave every time.', 0, 0, '', 'Action à double lame, pour un rasage de près propre à chaque fois.', '', '', '', 'Acción de cuchilla doble, para un afeitado limpio y apurado en todo momento.', '', ''),
+('taunt', 'Bring it on!', 0, 0, '', 'Allez-y!', '', '', '', '¡Adelante!', '', ''),
+('taunt', 'You\'re goin\' down!', 0, 0, '', 'Tu descends!', '', '', '', '¡Vas a caer!', '', ''),
+('taunt', 'Stabby stab stab!', 0, 0, '', 'Coup de poignard poignardé!', '', '', '', '¡Puñalada puñalada puñalada!', '', ''),
+('taunt', 'Let\'s get this over quick, time is mana.', 0, 0, '', 'Finissons-en vite , le temps c\'est du mana.', '', '', '', 'Terminemos con esto rápido, el tiempo es maná.', '', ''),
+('taunt', 'I do not think you realise the gravity of your situation.', 0, 0, '', 'Je ne pense pas que tu te rendes compte de la gravité de ta situation.', '', '', '', 'No creo que te des cuenta de la gravedad de tu situación.', '', ''),
+('taunt', 'I will bring honor to my family and my kingdom!', 0, 0, '', 'Je ferai honneur à ma famille et à mon royaume!', '', '', '', '¡Llevaré honor a mi familia y mi reino!', '', ''),
+('taunt', 'Light, give me strength!', 0, 0, '', 'Lumière, donne-moi la force!', '', '', '', '¡Luz, dame fuerza!', '', ''),
+('taunt', 'My church is the field of battle - time to worship...', 0, 0, '', 'Mon église est le champ de bataille - il est temps d\'adorer...', '', '', '', 'Mi iglesia es el campo de batalla - hora de adorar...', '', ''),
+('taunt', 'I hold you in contempt...', 0, 0, '', 'Je te méprise...', '', '', '', 'Te tengo en desacato...', '', ''),
+('taunt', 'Face the hammer of justice!', 0, 0, '', 'Affrontez le marteau de la justice!', '', '', '', '¡Enfréntate al martillo de la justicia!', '', ''),
+('taunt', 'Prove your worth in the test of arms under the Light!', 0, 0, '', 'Prouvez votre valeur dans l\'épreuve des armes sous la Lumière!', '', '', '', '¡Demuestra tu valía en la prueba de las armas bajo la Luz!', '', ''),
+('taunt', 'All must fall before the might and right of my cause, you shall be next!', 0, 0, '', 'Tout doit tomber devant la force et le droit de ma cause, vous serez le prochain!', '', '', '', 'Todo debe caer ante el poder y el derecho de mi causa, ¡tú serás el próximo!', '', ''),
+('taunt', 'Prepare to die!', 0, 0, '', 'Préparez-vous à mourir!', '', '', '', '¡Prepárate para morir!', '', ''),
+('taunt', 'The beast with me is nothing compared to the beast within...', 0, 0, '', 'La bête avec moi n\'est rien comparée à la bête à l\'intérieur...', '', '', '', 'La bestia conmigo no es nada comparada con la bestia interior...', '', ''),
+('taunt', 'Witness the firepower of this fully armed huntsman!', 0, 0, '', 'Soyez témoin de la puissance de feu de ce chasseur entièrement armé!', '', '', '', '¡Sea testigo de la potencia de fuego de este cazador completamente armado!', '', ''),
+
+
+
+-- combat events
+('critical health', 'Heal me! Quick!', 0, 0, '', 'Soigne moi! Vite!', '', '', '', '¡Cúrame! ¡Rápido!', '', ''),
+('critical health', 'Almost dead! Heal me!', 0, 0, '', 'Presque mort! Soigne moi!', '', '', '', '¡Estoy casi muerto! ¡Cúrame!', '', ''),
+('critical health', 'Help! Heal me!', 0, 0, '', 'Aider! Soigne moi!', '', '', '', '¡Ayuda! ¡Cúrame!', '', ''),
+('critical health', 'Somebody! Heal me!', 0, 0, '', 'Quelqu\'un! Soigne moi!', '', '', '', '¡Alguien! ¡Cúrame!', '', ''),
+('critical health', 'Heal! Heal! Heal!', 0, 0, '', 'Soigner! Soigner! Soigner!', '', '', '', '¡Curame! ¡Saname! ¡Socorro!', '', ''),
+('critical health', 'I am dying! Heal! Aaaaarhg!', 0, 0, '', 'Je meurs! Soigner! Aaaaarhg!', '', '', '', '¡Me estoy muriendo! ¡Saname! ¡Aaaaarhg!', '', ''),
+('critical health', 'Heal me!', 0, 0, '', 'Soigne moi!', '', '', '', '¡Cúrame!', '', ''),
+('critical health', 'I will die. I will die. I will die. Heal!', 0, 0, '', 'Je vais mourir. Je vais mourir. Je vais mourir. Soigner!', '', '', '', 'Voy a morir. Voy a morir. Voy a morir. ¡Saname!', '', ''),
+('critical health', 'Healers, where are you? I am dying!', 0, 0, '', 'Guérisseurs, où êtes-vous ? Je meurs!', '', '', '', 'Sanadores, ¿dónde estais? ¡Me estoy muriendo!', '', ''),
+('critical health', 'Oh the pain. Heal me quick!', 0, 0, '', 'Ah la douleur. Guéris-moi vite!', '', '', '', 'Ouch, qué dolor. ¡Cúrame rápido!', '', ''),
+
+
+
+('low health', 'Need heal', 0, 0, '', 'Besoin de guérir', '', '', '', 'Necesito una cura', '', ''),
+('low health', 'Low health', 0, 0, '', 'Santé faible', '', '', '', 'Salud baja', '', ''),
+('low health', 'Drop a heal. Please.', 0, 0, '', 'Dépose un soin. S\'il te plaît.', '', '', '', 'Una sanación por favor.', '', ''),
+('low health', 'Could somebody drop a heal on me?', 0, 0, '', 'Quelqu\'un pourrait-il me soigner?', '', '', '', '¿Alguien podría curarme?', '', ''),
+('low health', 'Hey! Better heal me now than rez later', 0, 0, '', 'Hey! Mieux vaut me soigner maintenant que rez plus tard', '', '', '', '¡Oye! Mejor curarme ahora que resucitarme después', '', ''),
+('low health', 'I am sorry. Need another heal', 0, 0, '', 'Je suis désolé. J\'ai besoin d\'un autre soin', '', '', '', 'Lo siento. Necesito otra curación', '', ''),
+('low health', 'Damn mobs. Heal me please', 0, 0, '', 'Maudits mobs. Guéris moi s\'il te plait', '', '', '', '¡Malditos bichos! ¡Una curita por favor!', '', ''),
+('low health', 'One more hit and I am done for. Heal please', 0, 0, '', 'Un coup de plus et c\'est fini. Guéris moi s\'il te plait', '', '', '', 'Un golpe más y estoy acabado. Cura por favor', '', ''),
+('low health', 'Are there any healers?', 0, 0, '', 'Y a-t-il des guérisseurs?', '', '', '', '¿Hay sanadores?', '', ''),
+('low health', 'Why do they always punch me in the face? Need heal', 0, 0, '', 'Pourquoi me frappent-ils toujours au visage? Besoin de soins', '', '', '', '¿Por qué siempre me golpean en la cara? Necesito sanacion', '', ''),
+('low health', 'Can anybody heal me a bit?', 0, 0, '', 'Quelqu\'un peut-il me guérir un peu?', '', '', '', '¿Alguien puede curarme un poco?', '', ''),
+
+
+
+('low mana', 'OOM', 0, 0, '', 'MOO', '', '', '', 'No tengo mana!', '', ''),
+('low mana', 'I am out of mana', 0, 0, '', 'je n\'ai plus de mana', '', '', '', 'No tengo maná', '', ''),
+('low mana', 'Damn I wasted all my mana on this', 0, 0, '', 'Putain j\'ai gaspillé tout mon mana sur ça', '', '', '', 'Me cago en todo! Malgasté todo mi maná enseguida', '', ''),
+('low mana', 'You should wait until I drink or regenerate my mana', 0, 0, '', 'Vous devriez attendre que je boive ou que je régénère mon mana', '', '', '', 'Deberías esperar hasta que beba o regenere mi maná', '', ''),
+('low mana', 'Low mana', 0, 0, '', 'Mana faible', '', '', '', 'Maná bajo', '', ''),
+('low mana', 'No mana. Again?', 0, 0, '', 'Pas de mana. De nouveau?', '', '', '', 'Sin maná. ¿Otra vez?', '', ''),
+('low mana', 'Low mana. Wanna drink', 0, 0, '', 'Mana faible. Je veux boire', '', '', '', 'Maná bajo. Quiero beber', '', ''),
+('low mana', 'Do we have a vending machine? Out of mana again', 0, 0, '', 'Avons-nous un distributeur automatique? Plus de mana à nouveau', '', '', '', '¿Tenemos una máquina expendedora? Sin maná otra vez', '', ''),
+('low mana', 'My mana is history', 0, 0, '', 'Mon mana appartient à l\'histoire', '', '', '', 'Mi maná es historia', '', ''),
+('low mana', 'I\'d get some drinks next time. Out of mana', 0, 0, '', 'Je prendrais quelques verres la prochaine fois. Manque de mana', '', '', '', '¡No tengo maná! Tengo que comprar bebidas la próxima vez...', '', ''),
+('low mana', 'Where is my mana?', 0, 0, '', 'Où est mon mana?', '', '', '', '¿Dónde está mi maná?', '', ''),
+
+
+
+('low ammo', 'I have few <ammo> left!', 0, 0, '', 'Il me reste peu de <ammo>!', '', '', '', '¡Me quedan pocas <ammo>!', '', ''),
+('low ammo', 'I need more <ammo>!', 0, 0, '', 'J\'ai besoin de plus de <ammo>!', '', '', '', '¡Necesito más <ammo>!', '', ''),
+('low ammo', '100 <ammo> left!', 0, 0, '', 'Il reste 100 <ammo>!', '', '', '', '¡Quedan 100 <ammo>!', '', ''),
+
+
+
+('no ammo', 'That\'s it! No <ammo>!', 0, 0, '', 'C\'est ça! Pas de <ammo>!', '', '', '', '¡Eso es todo! ¡Sin <ammo>!', '', ''),
+('no ammo', 'And you have my bow... Oops, no <ammo>!', 0, 0, '', 'Et vous avez mon arc... Oups, pas de <ammo>!', '', '', '', 'Y tú tienes mi arco... ¡Uy, sin <ammo>!', '', ''),
+('no ammo', 'Need ammo!', 0, 0, '', 'Besoin de munitions!', '', '', '', '¡Necesito munición!', '', ''),
+
+
+
+('aoe', 'Oh god!', 0, 0, '', 'Oh mon Dieu!', '', '', '', '¡Oh, Dios!', '', ''),
+('aoe', 'I am scared', 0, 0, '', 'j\'ai peur', '', '', '', 'Tengo miedo', '', ''),
+('aoe', 'We are done for', 0, 0, '', 'Nous avons fini pour', '', '', '', 'Hemos terminado', '', ''),
+('aoe', 'This is over', 0, 0, '', 'C\'est terminé', '', '', '', 'Esto se acabó', '', ''),
+('aoe', 'This ends now', 0, 0, '', 'Cela se termine maintenant', '', '', '', 'Esto termina ahora', '', ''),
+('aoe', 'Could somebody cast blizzard or something?', 0, 0, '', 'Quelqu\'un pourrait-il lancer le blizzard ou quelque chose comme ça?', '', '', '', '¿Alguien podría lanzar ventisca o algo así?', '', ''),
+('aoe', 'Damn. The tank aggroed all the mobs around', 0, 0, '', 'Mince. Le tank a agro toutes les mobs autour', '', '', '', '¡Me cago en todo! El tanque atrajo a todos los mobs...', '', ''),
+('aoe', 'We gonna die. We gonna die. We gonna die.', 0, 0, '', 'Nous allons mourir. Nous allons mourir. Nous allons mourir.', '', '', '', 'Vamos a morir. Vamos a morir. Vamos a morir.', '', ''),
+('aoe', 'Whoa! So many toys to play with', 0, 0, '', 'Ouah ! Tant de jouets avec lesquels jouer', '', '', '', '¡Vaya! Tantos juguetes con los que jugar', '', ''),
+('aoe', 'I gonna kill them all!', 0, 0, '', 'Je vais tous les tuer!', '', '', '', '¡Voy a matarlos a todos!', '', ''),
+('aoe', 'If the tank dies we are history', 0, 0, '', 'Si le tank meurt, nous appartenons à l\'histoire', '', '', '', 'Si el tanque muere somos historia', '', ''),
+('aoe', 'Aaaaaargh!', 0, 0, '', 'Aaaaaargh!', '', '', '', '¡Aaaaaargh!', '', ''),
+('aoe', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', 0, 0, '', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', '', '', '', 'LEEEEERROOOYYYYYYYYYYYY JENNKINNNSSSSSS!!!!!!!', '', ''),
+('aoe', 'Right. What do we have in AOE?', 0, 0, '', 'D\'accord. Qu\'avons-nous en dégats de zone?', '', '', '', 'Claro. ¿Qué tenemos en AOE?', '', ''),
+('aoe', 'This gets interesting', 0, 0, '', 'Cela devient intéressant', '', '', '', 'Esto se pone interesante', '', ''),
+('aoe', 'Cool. Get them in one place for a good flamestrike', 0, 0, '', 'Cool. Rassemblez-les au même endroit pour un bon coup de flamme', '', '', '', 'Genial! Ponlos todos juntos para un buen ataque en area', '', ''),
+('aoe', 'Kill! Kill! Kill!', 0, 0, '', 'Tuer! Tuer! Tuer!', '', '', '', '¡Matar! ¡Matar! ¡Matar!', '', ''),
+('aoe', 'I think my pants are wet', 0, 0, '', 'Je pense que mon pantalon est mouillé', '', '', '', 'Creo que mis pantalones están mojados', '', ''),
+('aoe', 'We are history', 0, 0, '', 'Nous sommes l\'histoire', '', '', '', 'Somos historia', '', ''),
+('aoe', 'I hope healers are ready. Leeeeroy!', 0, 0, '', 'J\'espère que les guérisseurs sont prêts. Leeeeeroy!', '', '', '', 'Espero que los sanadores estén listos. ¡Leeeroy!', '', ''),
+('aoe', 'I hope they won\'t come for me', 0, 0, '', 'j\'espère qu\'ils ont gagné, qu\'ils ne viendront pas pour moi', '', '', '', 'Espero que no vengan por mí', '', ''),
+('aoe', 'Oh no. I can\'t see at this slaugther', 0, 0, '', 'Oh non. Je ne peux pas voir à ce massacre', '', '', '', 'Oh, no. No puedo ver esta matanza', '', ''),
+
+
+
+-- on looting
+('loot', 'I hope there will be some money', 0, 0, '', 'j\'espère qu\'il y aura de l\'argent', '', '', '', 'Espero que haya algo de dinero...', '', ''),
+('loot', 'Loot! Loot!', 0, 0, '', 'Butin! Butin!', '', '', '', '¡Botín! ¡Botín!', '', ''),
+('loot', 'My precious', 0, 0, '', 'Mon précieux', '', '', '', 'Mi tesoro...', '', ''),
+('loot', 'I hope there is a shiny epic item waiting for me there', 0, 0, '', 'J\'espère qu\'il y a un objet épique brillant qui m\'attend ici', '', '', '', 'Espero que haya un objeto épico brillante esperándome allí', '', ''),
+('loot', 'I have deep pockets and bags', 0, 0, '', 'J\'ai des poches et des sacs profonds', '', '', '', 'Tengo bolsillos profundos y infinitos', '', ''),
+('loot', 'All is mine!', 0, 0, '', 'Tout est à moi!', '', '', '', '¡Todo es mío!', '', ''),
+('loot', 'Hope no gray shit today', 0, 0, '', 'J\'espère pas de merde grise aujourd\'hui', '', '', '', 'Espero que hoy no haya mierda gris', '', ''),
+('loot', 'This loot is MINE!', 0, 0, '', 'Ce butin est à MOI!', '', '', '', '¡Este botín es MÍO!', '', ''),
+('loot', 'Looting is disgusting but I need money', 0, 0, '', 'Le pillage est dégoûtant mais j\'ai besoin d\'argent', '', '', '', 'El saqueo es repugnante pero necesito dinero...', '', ''),
+('loot', 'Gold!', 0, 0, '', 'Or!', '', '', '', '¡Oro!', '', ''),
+('loot', 'OK. Let\'s see what they\'ve got', 0, 0, '', 'D\'ACCORD. Voyons ce qu\'ils ont', '', '', '', 'OK. Veamos qué tienen', '', ''),
+('loot', 'Do not worry. I will loot eveything', 0, 0, '', 'Ne t\'inquiète pas. je vais tout piller', '', '', '', 'No te preocupes. Saquearé todo', '', ''),
+('loot', 'I am loot ninja', 0, 0, '', 'je suis un ninja de butin', '', '', '', 'Soy un ladron de tesoros', '', ''),
+('loot', 'Do I neeed to roll?', 0, 0, '', 'Dois-je recommencer?', '', '', '', '¿Necesito lanzar dados?', '', ''),
+('loot', 'Somebody explain me, where they did put all this stuff?', 0, 0, '', 'Quelqu\'un m\'explique, où ils ont mis tout ça?', '', '', '', 'Alguien me explica, ¿dónde pusieron todas estas cosas?', '', ''),
+('loot', 'No, I won\'t loot gray shit', 0, 0, '', 'Non, je ne pillerai pas la merde grise', '', '', '', 'No, no saquearé mierda gris', '', ''),
+('loot', 'I\'m first. I\'m first. I\'m first.', 0, 0, '', 'Je suis le premier. Je suis le premier. Je suis le premier.', '', '', '', '¡Es mio! ¡Es mio! ¡Es mio!', '', ''),
+('loot', 'Give me your money!', 0, 0, '', 'Donne-moi ton argent!', '', '', '', '¡Dame todo tu dinero!', '', ''),
+('loot', 'My pockets are empty, I need to fill them', 0, 0, '', 'Mes poches sont vides, j\'ai besoin de les remplir', '', '', '', 'Mis bolsillos están vacíos y necesitan llenarse!', '', ''),
+('loot', 'I\'ve got a new bag for this', 0, 0, '', 'J\'ai un nouveau sac pour ça', '', '', '', 'Tengo una nueva bolsa para esto', '', ''),
+('loot', 'I hope I won\'t aggro anybody while looting', 0, 0, '', 'J\'espère que je n\'agresserai personne pendant le pillage', '', '', '', 'Espero no ofender a nadie mientras saqueo', '', ''),
+('loot', 'Please don\'t watch. I am looting', 0, 0, '', 'S\'il vous plaît, ne regardez pas. je pille', '', '', '', 'Por favor, no mires. Estoy saqueando', '', ''),
+('loot', 'Ha! You won\'t get any piece of it!', 0, 0, '', 'Ha! Vous n\'en aurez aucun morceau!', '', '', '', '¡Ja! ¡No obtendrás nada de eso!', '', ''),
+('loot', 'Looting is cool', 0, 0, '', 'Le pillage c\'est cool', '', '', '', 'Saquear es genial', '', ''),
+('loot', 'I like new gear', 0, 0, '', 'j\'aime le nouveau matos', '', '', '', 'Me gusta el equipo nuevo', '', ''),
+('loot', 'I\'l quit if there is nothing valuable again', 0, 0, '', 'J\'arrêterai s\'il n\'y a plus rien de précieux', '', '', '', 'Me doy por vencido si no hay nada util', '', ''),
+('loot', 'I hope it is be a pretty ring', 0, 0, '', 'j\'espère que c\'est une jolie bague', '', '', '', 'Espero que sea un anillo bonito', '', ''),
+('loot', 'I\'l rip the loot from you', 0, 0, '', 'Je t\'arracherai le butin', '', '', '', 'Te arrancaré el botín', '', ''),
+('loot', 'Everybody stay off. I\'m going to loot', 0, 0, '', 'Tout le monde reste à l\'écart. je vais piller', '', '', '', '¡Alejaos todos! Voy a lootear', '', ''),
+('loot', 'Sweet loot', 0, 0, '', 'Doux butin', '', '', '', 'Dulce botín', '', ''),
+('loot', 'The Roll God! Give me an epic today', 0, 0, '', 'Le Dieu du rouleau ! Donnez-moi de l\'épique aujourd\'hui', '', '', '', '¡El Dios de los dados! Dame un epico hoy', '', ''),
+('loot', 'Please give me new toys', 0, 0, '', 'S\'il te plaît, donne-moi de nouveaux jouets', '', '', '', 'Por favor, dame nuevos juguetes', '', ''),
+('loot', 'I hope they carry tasties', 0, 0, '', 'J\'espère qu\'ils portent des saveurs', '', '', '', 'Espero que caiga algo sabrosos', '', ''),
+('loot', 'The gold is mine. I\'l leave everyting, I promise', 0, 0, '', 'L\'or est à moi. Je laisse tout, je promets', '', '', '', 'El oro es mío. Dejaré todo lo demas, lo prometo!', '', ''),
+('loot', 'No, I can\'t resist', 0, 0, '', 'Non, je ne peux pas résister', '', '', '', 'No, no puedo resistir', '', ''),
+('loot', 'I want more!', 0, 0, '', 'Je veux plus!', '', '', '', '¡Quiero más!', '', ''),
+
+
+
+-- wait signals
+('wait_travel_close', 'I am close, wait for me!', 0, 0, '', '', '', '', '', '¡Estoy cerca, espérame!', '', 'Я тут рядом, подожди!'),
+('wait_travel_close', 'I\'m not far, please wait!', 0, 0, '', '', '', '', '', 'No estoy lejos, ¡esperame por favor!', '', 'Я недалеко, погодите!'),
+
+
+
+('wait_travel_medium', 'I\'m heading to your location', 0, 0, '', '', '', '', '', 'Me dirijo a tu ubicación', '', 'Двигаюсь к тебе'),
+('wait_travel_medium', 'I\'m coming to you', 0, 0, '', '', '', '', '', 'Voy hacia ti', '', 'Иду к тебе'),
+
+
+
+('wait_travel_far', 'I\'m traveling to your location', 0, 0, '', '', '', '', '', 'Voy a viajar a tu ubicación', '', 'Направляюсь к тебе'),
+('wait_travel_far', 'I\'m trying to get to you', 0, 0, '', '', '', '', '', 'Estoy tratando de llegar a ti', '', 'Пытаюсь до тебя добраться'),
+
+
+
+
+-- commands
+('equip_command', 'Equipping %item', 0, 0, '', '', '', '', '', 'Me he equipado %item', '', ''),
+
+
+
+('unequip_command', '%item unequipped', 0, 0, '', '', '', '', '', 'Me he quitado %item', '', ''),
+
+
+
+('auto_learn_spell', 'I have learned the spells: %spells', 0, 0, '', '', '', '', '', 'He aprendido los hechizos: %spells', '', ''),
+
+
+
+('use_command_item_cooldown', '%item is in cooldown', 0, 0, '', '', '', '', '', '%item esta recargandose', '', ''),
+
+
+
+('use_command_item_not_owned', 'I don''t have %item in my inventory', 0, 0, '', '', '', '', '', 'No tengo %item en mi inventario', '', ''),
+
+
+
+('use_command_invalid_item', 'The item with the id %item does not exist', 0, 0, '', '', '', '', '', 'El objeto con el id %item no existe', '', ''),
+
+
+
+('use_command_socket', 'Socketing %gem into %item', 0, 0, '', '', '', '', '', 'Insertando %gem en %item', '', ''),
+
+
+
+('use_command_item_error', 'I can''t use %item', 0, 0, '', '', '', '', '', 'No puedo usar %item', '', ''),
+
+
+
+('following', 'Following', 0, 0, '', '', '', '', '', 'Te sigo', '', 'Следую'),
+
+
+
+('staying', 'Staying', 0, 0, '', '', '', '', '', 'Me quedo aqui', '', 'Стою'),
+
+
+
+('fleeing', 'Fleeing', 0, 0, '', '', '', '', '', 'Huyendo', '', 'Убегаю'),
+
+
+
+('fleeing_far', 'I won\'t flee with you, you are too far away', 0, 0, '', '', '', '', '', 'No huiré contigo, estás demasiado lejos', '', 'Я с тобой не побегу, ты слишком далеко'),
+
+
+
+('grinding', 'Grinding', 0, 0, '', '', '', '', '', 'Farmeando', '', 'Гриндю'),
+
+
+
+('attacking', 'Attacking', 0, 0, '', '', '', '', '', 'Atacando', '', 'Атакую'),
+
+
+
+('error_far', 'It is too far away', 0, 0, '', '', '', '', '', 'Estas demasiado lejos', '', 'Слишком далеко'),
+
+
+
+('error_water', 'It is under water', 0, 0, '', '', '', '', '', 'Estas debajo del agua', '', 'Это под водой'),
+
+
+
+('error_cant_go', 'I can\'t go there', 0, 0, '', '', '', '', '', 'No puedo ir allí', '', 'Я не могу туда пройти'),
+
+
+
+('error_guild', 'I\'m not in your guild!', 0, 0, '', '', '', '', '', '¡No estoy en tu hermandad!', '', 'Я не в твоей гильдии'),
+
+
+
+('error_gbank_found', 'Can not find a guild bank nearby', 0, 0, '', '', '', '', '', 'No se puede encontrar un banco de hermandad cercano', '', 'Не могу найти гильд банк рядом'),
+
+
+
+('error_cant_put', 'I can\'t put ', 0, 0, '', '', '', '', '', 'No puedo depositar ', '', 'Я не могу положить'),
+
+
+
+('error_gbank_rights', 'I have no rights to put items in the first guild bank tab', 0, 0, '', '', '', '', '', 'No tengo derechos para depositar objetos en la primera pestaña del banco de hermandad', '', 'Нет прав чтобы класть вещи в первую вкладку гильд банка'),
+
+
+
+('gbank_put', ' put to guild bank', 0, 0, '', '', '', '', '', ' depositado en el banco de hermandad', '', ' теперь в гильд банке'),
+
+
+
+('free_moving', 'Free moving', 0, 0, '', '', '', '', '', 'Moviendome libremente', '', ''),
+
+
+
+('guarding', 'Guarding', 0, 0, '', '', '', '', '', 'Protegiendo la posición', '', ''),
+
+
+
+('use_command', 'Using %target', 0, 0, '', '', '', '', '', 'Usando %target', '', ''),
+
+
+
+('command_target_unit', 'on %unit', 0, 0, '', '', '', '', '', 'en %unit', '', ''),
+
+
+
+('use_command_remaining', '(%amount available)', 0, 0, '', '', '', '', '', '(%amount restante)', '', ''),
+
+
+
+('use_command_last', '(the last one)', 0, 0, '', '', '', '', '', '(el último)', '', ''),
+
+
+
+('use_command_socket_error', 'The socket does not fit', 0, 0, '', '', '', '', '', 'La ranura no sirve', '', ''),
+
+
+
+('command_target_trade', 'on trade item', 0, 0, '', '', '', '', '', 'en objeto comerciado', '', ''),
+
+
+
+('command_target_self', 'on myself', 0, 0, '', '', '', '', '', 'en mi', '', ''),
+
+
+
+('command_target_item', 'on %item', 0, 0, '', '', '', '', '', 'en %item', '', ''),
+
+
+
+('command_target_go', 'on %gameobject', 0, 0, '', '', '', '', '', 'en %gameobject', '', ''),
+
+
+
+('loot_command', 'Looting %item', 0, 0, '', '', '', '', '', 'Despojando %item', '', ''),
+
+
+
+('cast_spell_command_summon', 'Summoning %target', 0, 0, '', '', '', '', '', 'Invocando a %target', '', ''),
+('cast_spell_command_summon_error_members', 'I don\'t have enough party members around to cast a summon', 0, 0, '', '', '', '', '', 'No tengo suficientes miembros de grupo alrededor para invocar', '', ''),
+('cast_spell_command_summon_error_target', 'Failed to find the summon target', 0, 0, '', '', '', '', '', 'No he podido encontrar al objetivo de la invocación', '', ''),
+('cast_spell_command_summon_error_combat', 'I can\'t summon while I\'m in combat', 0, 0, '', '', '', '', '', 'No puedo invocar durante un combate', '', ''),
+
+
+
+('cast_spell_command_error_unknown_spell', 'I don\'t know the spell %spell', 0, 0, '', '', '', '', '', 'No conozco el hechizo %spell', '', ''),
+
+
+
+('cast_spell_command_spell', 'Casting %spell', 0, 0, '', '', '', '', '', 'Lanzando %spell', '', ''),
+
+
+
+('cast_spell_command_craft', 'Crafting %spell', 0, 0, '', '', '', '', '', 'Creando %spell', '', ''),
+
+
+
+('cast_spell_command_error', 'Cannot cast %spell', 0, 0, '', '', '', '', '', 'No puedo lanzar %spell', '', ''),
+('cast_spell_command_error_failed', 'Failed to cast %spell', 0, 0, '', '', '', '', '', 'Fallo al lanzar %spell', '', ''),
+
+
+
+('cast_spell_command_amount', ' |cffffff00(x%amount left)|r', 0, 0, '', '', '', '', '', ' |cffffff00(x%amount restante)|r', '', ''),
+
+
+
+
+('dummy_end', 'dummy', 0, 0, '', '', '', '', '', '', '', '');
+
+
 
 DROP TABLE IF EXISTS `ai_playerbot_texts_chance`;
 CREATE TABLE IF NOT EXISTS `ai_playerbot_texts_chance` (

--- a/sql/world/ai_playerbot_texts.sql
+++ b/sql/world/ai_playerbot_texts.sql
@@ -3043,6 +3043,7 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 
 -- random generic toxic item links
 -- usable placeholders:
+-- %prefix
 -- %random_taken_quest_or_item_link
 -- %random_inventory_item_link
 -- %my_role
@@ -3051,8 +3052,29 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 -- %my_class
 -- %my_race
 -- %my_level
-('suggest_toxic_links', 'gnomes %random_taken_quest_or_item_link', 0, 0, '', '', '', '', '', '', '', ''),
-('suggest_toxic_links', 'gnomes %random_inventory_item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_toxic_links', '%prefix %random_taken_quest_or_item_link', 0, 0, '', '', '', '', '', '', '', ''),
+('suggest_toxic_links', '%prefix %random_inventory_item_link', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- thunderfury spam
+-- usable placeholders:
+-- %thunderfury_link
+('thunderfury_spam', '%thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', '%thunderfury_link%thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', '%thunderfury_link%thunderfury_link%thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'I think I just heard %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'I think I heard %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'I definitely heard %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'I dunno but I\'m pretty sure I heard %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'Did you just say %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'did someone say %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'Did someone say %thunderfury_link ?', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'Someone said %thunderfury_link', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', '%thunderfury_link is coming out of the closet', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'could swear it was a %thunderfury_link, might have been %thunderfury_link tho', 0, 0, '', '', '', '', '', '', '', ''),
+('thunderfury_spam', 'Why use %thunderfury_link when %thunderfury_link is clearly way more OP', 0, 0, '', '', '', '', '', '', '', ''),
+
 
 
 -- random WTS
@@ -3106,6 +3128,82 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 ('suggest_sell', 'I am going to post %item_formatted_link on the AH but you can buy it now cheaper just for %cost_gold.', 0, 0, '', 'Je vais poster %item_formatted_link à l\'hôtel des ventes mais vous pouvez l\'acheter maintenant moins cher juste pour %cost_gold', '', '', '', 'Voy a poner %item_formatted_link en la casa de subastas pero puedes comprarlo ahora más barato solo por %cost_gold.', '', ''),
 ('suggest_sell', 'Why the #!@ have I bought %item_formatted_link? Anyone needs it for %cost_gold?', 0, 0, '', 'Pourquoi ai-je acheté le #!@ %item_formatted_link ? Quelqu\'un en a besoin pour %cost_gold ?', '', '', '', '¿Por qué #!@ he comprado %item_formatted_link? ¿Alguien lo necesita por %cost_gold?', '', ''),
 
+
+-- response LFG/LFM channel
+-- usable placeholders:
+-- %quest_links
+-- %other_name
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('response_lfg_quests_channel', 'I have %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', 'I also have %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', 'I also have %quest_links, I am in %zone_name right now', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', '%other_name, I also have %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', '%other_name, I also have %quest_links, I am in %zone_name right now', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', 'I am up for %quest_links, I am in %zone_name right now', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', 'I am up for %quest_links, I am %my_role', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', '%other_name, I am up for %quest_links, I am in %zone_name right now', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_channel', '%other_name, I am up for %quest_links, I am %my_role', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+-- response LFG/LFM whisper
+-- usable placeholders:
+-- %quest_links
+-- %other_name
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('response_lfg_quests_whisper', 'Hey, I\'m up for %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'Hey, I could do %quest_links with you', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'Hey, I also have %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'Hey %other_name, I\'m up for %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'Hey %other_name, I could do %quest_links with you', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'Hey %other_name, I also have %quest_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'wanna group up for %quest_links ?', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'I am up for %quest_links, I am in %zone_name right now', 0, 0, '', '', '', '', '', '', '', ''),
+('response_lfg_quests_whisper', 'I am up for %quest_links, I am %my_role', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+-- response WTB channel
+-- usable placeholders:
+-- %formatted_item_links
+-- %other_name
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('response_wtb_items_channel', '%other_name, I could sell you %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_channel', 'I could potentially sell %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_channel', 'Think I could sell %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_channel', '%other_name, I could potentially sell %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_channel', '%other_name, Think I could sell %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+
+
+
+
+-- response WTB channel
+-- usable placeholders:
+-- %formatted_item_links
+-- %other_name
+-- %my_role
+-- %zone_name
+-- %area_name
+-- %my_class
+-- %my_race
+-- %my_level
+('response_wtb_items_whisper', 'I could sell you %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_whisper', 'Hey, I got %formatted_item_links for sale', 0, 0, '', '', '', '', '', '', '', ''),
+('response_wtb_items_whisper', 'Hey, I could potentially sell %formatted_item_links', 0, 0, '', '', '', '', '', '', '', ''),
 
 
 
@@ -3254,7 +3352,6 @@ INSERT INTO `ai_playerbot_texts` (`name`, `text`, `say_type`, `reply_type`, `tex
 ('reply', 'wtf are you all talking about', 0, 0, '', '', '', '', '', '', '', ''),
 ('reply', 'fr fr no cap on a stack', 0, 0, '', '', '', '', '', '', '', ''),
 ('reply', 'your not getting jack shit', 0, 0, '', '', '', '', '', '', '', ''),
-('reply', 'are you begging for head ?', 0, 0, '', '', '', '', '', '', '', ''),
 ('reply', 'swag', 0, 0, '', '', '', '', '', '', '', ''),
 ('reply', 'ty!', 0, 0, '', '', '', '', '', '', '', ''),
 ('reply', 'no', 0, 0, '', '', '', '', '', '', '', ''),


### PR DESCRIPTION
added say() methods for all chats to PlayerbotAI
implemented a broadcast system for bots to broadcast events 
fixed ai_playerbot_texts.sql syntax
added more texts, text types and comments to ai_playerbot_texts.sql

added configurable guild max member limit (was hardcoded) 
added configs for broadcast chances

removed guildFeedbackRate, guildSuggestRate

changed guildRepliesRate from float to uint (0-100)

added all questupdate events handlers, broadcasts, config values

separated reply logic for easy future additions
added multiple helper methods to PlayerbotAI, ChatHelper
added thunderfury spam capabilities
added configurable word for "<word> [item link]"
added LFG/LFM, WTB commands
added new texts
added configs for thunderfury and toxic link replies chance