### PR TITLE
DisableBotOptimizations will put all bots under the same highest priority

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -5221,8 +5221,8 @@ enum ActivityType
 
 ActivePiorityType PlayerbotAI::GetPriorityType()
 {
-    //Has player master. Always active.
-    if (HasRealPlayerMaster())
+    //First priority - priorities disabled or has player master. Always active.
+    if (sPlayerbotAIConfig.disableActivityPriorities || HasRealPlayerMaster())
         return ActivePiorityType::HAS_REAL_PLAYER_MASTER;
 
     //Self bot in a group with a bot master.

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -425,6 +425,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotRandomPassword = config.GetBoolDefault("AiPlayerbot.RandomBotRandomPassword", true);
     playerbotsXPrate = config.GetFloatDefault("AiPlayerbot.XPRate", 1.0f);
     disableBotOptimizations = config.GetBoolDefault("AiPlayerbot.DisableBotOptimizations", false);
+    disableActivityPriorities = config.GetBoolDefault("AiPlayerbot.DisableActivityPriorities", false);
     botActiveAlone = config.GetIntDefault("AiPlayerbot.botActiveAlone", 10);
     diffWithPlayer = config.GetIntDefault("AiPlayerbot.DiffWithPlayer", 100);
     diffEmpty = config.GetIntDefault("AiPlayerbot.DiffEmpty", 200);

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -154,6 +154,7 @@ public:
 	bool randomBotPreQuests;
     float playerbotsXPrate;
     bool disableBotOptimizations;
+    bool disableActivityPriorities;
     uint32 botActiveAlone;
     uint32 diffWithPlayer;
     uint32 diffEmpty;

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -57,9 +57,19 @@ AiPlayerbot.RandomBotMaxLevel = 60
 AiPlayerbot.RandomBotAccountPrefix = rndbot
 AiPlayerbot.RandomBotAccountCount = 200
 
-# Disable bot optimization, to make all bots ACTUALLY active without player in the zones or server
+# Disable core mangos map/bot optimizations which hinders bot activity
+# Works best together with AiPlayerbot.DisableActivityPriorities = 1
 # (0-1), default 0
 # AiPlayerbot.DisableBotOptimizations = 0
+
+# Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
+# This setting is added for the sake of having all bots always active regardless of anything
+# With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
+# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
+# This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
+# Works best together with AiPlayerbot.DisableBotOptimizations = 1
+# (0-1), default 0
+# AiPlayerbot.DisableActivityPriorities = 0
 
 # Percentage of fully active bots. Default is 10, higher numbers may affect performance
 # AiPlayerbot.botActiveAlone = 10

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -57,9 +57,19 @@ AiPlayerbot.RandomBotMaxLevel = 70
 AiPlayerbot.RandomBotAccountPrefix = rndbot
 AiPlayerbot.RandomBotAccountCount = 200
 
-# Disable bot optimization, to make all bots ACTUALLY active without player in the zones or server
+# Disable core mangos map/bot optimizations which hinders bot activity
+# Works best together with AiPlayerbot.DisableActivityPriorities = 1
 # (0-1), default 0
 # AiPlayerbot.DisableBotOptimizations = 0
+
+# Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
+# This setting is added for the sake of having all bots always active regardless of anything
+# With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
+# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
+# This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
+# Works best together with AiPlayerbot.DisableBotOptimizations = 1
+# (0-1), default 0
+# AiPlayerbot.DisableActivityPriorities = 0
 
 # Percentage of fully active bots. Default is 10, higher numbers may affect performance
 # AiPlayerbot.botActiveAlone = 10

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -57,9 +57,19 @@ AiPlayerbot.RandomBotMaxLevel = 80
 AiPlayerbot.RandomBotAccountPrefix = rndbot
 AiPlayerbot.RandomBotAccountCount = 200
 
-# Disable bot optimization, to make all bots ACTUALLY active without player in the zones or server
+# Disable core mangos map/bot optimizations which hinders bot activity
+# Works best together with AiPlayerbot.DisableActivityPriorities = 1
 # (0-1), default 0
 # AiPlayerbot.DisableBotOptimizations = 0
+
+# Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
+# This setting is added for the sake of having all bots always active regardless of anything
+# With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
+# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
+# This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
+# Works best together with AiPlayerbot.DisableBotOptimizations = 1
+# (0-1), default 0
+# AiPlayerbot.DisableActivityPriorities = 0
 
 # Percentage of fully active bots. Default is 10, higher numbers may affect performance
 # AiPlayerbot.botActiveAlone = 10


### PR DESCRIPTION
DisableBotOptimizations will put all bots under the same highest priority, to disable this behavior (because botActiveAlone = 100 is not sufficient)