### PR TITLE
Looting logic improvements/fixes, Disabled BG join lag checks if priorities disabled, added AiPlayerbot.BotAcceptDuelMinimumLevel

### DIFF
--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -507,11 +507,18 @@ public:
     void AccelerateRespawn(Creature* creature, float accelMod = 0);
     void AccelerateRespawn(ObjectGuid guid, float accelMod = 0) { Creature* creature = GetCreature(guid); if (creature) AccelerateRespawn(creature,accelMod); }
 
+    std::list<Unit*> GetAllHostileUnitsAroundWO(WorldObject* wo, float distanceAround);
+
 public:
     std::vector<Item*> GetInventoryAndEquippedItems();
     std::vector<Item*> GetInventoryItems();
     uint32 GetInventoryItemsCountWithId(uint32 itemId);
     bool HasItemInInventory(uint32 itemId);
+    void DestroyAllGrayItemsInBags(Player* requester);
+    bool HasNotFullStacksInBagsForLootItems(LootItemList questLootItemList);
+    bool HasQuestItemsInLootList(LootItemList questLootItemList);
+    bool HasQuestItemsInWOLootList(WorldObject* wo);
+    bool CanLootSomethingFromWO(WorldObject* wo);
 
 private:
     void InventoryIterateItemsInBags(IterateItemsVisitor* visitor);

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -108,7 +108,12 @@ bool PlayerbotAIConfig::Initialize()
     reactDistance = config.GetFloatDefault("AiPlayerbot.ReactDistance", 150.0f);
     grindDistance = config.GetFloatDefault("AiPlayerbot.GrindDistance", 75.0f);
     aggroDistance = config.GetFloatDefault("AiPlayerbot.AggroDistance", 22.0f);
-    lootDistance = config.GetFloatDefault("AiPlayerbot.LootDistance", 15.0f);
+    lootDistance = config.GetFloatDefault("AiPlayerbot.LootDistance", 25.0f);
+    groupMemberLootDistance = config.GetFloatDefault("AiPlayerbot.GroupMemberLootDistance", 15.0f);
+    groupMemberLootDistanceWithRealMaster = config.GetFloatDefault("AiPlayerbot.GroupMemberLootDistanceWithRealMaster", 10.0f);
+    gatheringDistance = config.GetFloatDefault("AiPlayerbot.GatheringDistance", 15.0f);
+    groupMemberGatheringDistance = config.GetFloatDefault("AiPlayerbot.GroupMemberGatheringDistance", 10.0f);
+    groupMemberGatheringDistanceWithRealMaster = config.GetFloatDefault("AiPlayerbot.GroupMemberGatheringDistanceWithRealMaster", 5.0f);
     fleeDistance = config.GetFloatDefault("AiPlayerbot.FleeDistance", 8.0f);
     tooCloseDistance = config.GetFloatDefault("AiPlayerbot.TooCloseDistance", 5.0f);
     meleeDistance = config.GetFloatDefault("AiPlayerbot.MeleeDistance", 1.5f);
@@ -118,6 +123,12 @@ bool PlayerbotAIConfig::Initialize()
     contactDistance = config.GetFloatDefault("AiPlayerbot.ContactDistance", 0.5f);
     aoeRadius = config.GetFloatDefault("AiPlayerbot.AoeRadius", 5.0f);
     rpgDistance = config.GetFloatDefault("AiPlayerbot.RpgDistance", 80.0f);
+    proximityDistance = config.GetFloatDefault("AiPlayerbot.ProximityDistance", 20.0f);
+
+    destroyAllGrayItemsBeforeLooting = config.GetBoolDefault("AiPlayerbot.DestroyAllGrayItemsBeforeLooting", false);
+    destroyAllGrayItemsBeforeGathering = config.GetBoolDefault("AiPlayerbot.DestroyAllGrayItemsBeforeGathering", false);
+
+    destroyAllGrayItemsBeforeLootingIfLootHasQuestItems = config.GetBoolDefault("AiPlayerbot.DestroyAllGrayItemsBeforeLootingIfLootHasQuestItems", true);
 
     criticalHealth = config.GetIntDefault("AiPlayerbot.CriticalHealth", 20);
     lowHealth = config.GetIntDefault("AiPlayerbot.LowHealth", 50);
@@ -190,6 +201,7 @@ bool PlayerbotAIConfig::Initialize()
     maxRandomBotChangeStrategyTime = config.GetIntDefault("AiPlayerbot.MaxRandomBotChangeStrategyTime", 2 * 3600);
     minRandomBotReviveTime = config.GetIntDefault("AiPlayerbot.MinRandomBotReviveTime", 60);
     maxRandomBotReviveTime = config.GetIntDefault("AiPlayerbot.MaxRandomReviveTime", 300);
+    enableRandomTeleportOnRevive = config.GetBoolDefault("AiPlayerbot.EnableRandomTeleportOnRevive", true);
     randomBotTeleportDistance = config.GetIntDefault("AiPlayerbot.RandomBotTeleportDistance", 1000);
     randomBotTeleportNearPlayer = config.GetBoolDefault("AiPlayerbot.RandomBotTeleportNearPlayer", false);
     randomBotTeleportNearPlayerMaxAmount = config.GetIntDefault("AiPlayerbot.RandomBotTeleportNearPlayerMaxAmount", 0);
@@ -510,9 +522,11 @@ bool PlayerbotAIConfig::Initialize()
     broadcastChanceGuildManagement = config.GetIntDefault("AiPlayerbot.BroadcastChanceGuildManagement", 30000);
     ////////////////////////////
 
-    toxicLinksRepliesChance = config.GetIntDefault("AiPlayerbot.ToxicLinksRepliesChance", 100); //0-100
-    thunderfuryRepliesChance = config.GetIntDefault("AiPlayerbot.ThunderfuryRepliesChance", 100); //0-100
+    toxicLinksRepliesChance = config.GetIntDefault("AiPlayerbot.ToxicLinksRepliesChance", 30); //0-100
+    thunderfuryRepliesChance = config.GetIntDefault("AiPlayerbot.ThunderfuryRepliesChance", 40); //0-100
     guildRepliesRate = config.GetIntDefault("AiPlayerbot.GuildRepliesRate", 100); //0-100
+
+    botAcceptDuelMinimumLevel = config.GetIntDefault("AiPlayerbot.BotAcceptDuelMinimumLevel", 10);
 
     randomBotFormGuild = config.GetBoolDefault("AiPlayerbot.RandomBotFormGuild", true);
 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -62,9 +62,13 @@ public:
     bool allowMultiAccountAltBots;
     uint32 globalCoolDown, reactDelay, maxWaitForMove, expireActionTime, dispelAuraDuration, passiveDelay, repeatDelay,
         errorDelay, rpgDelay, sitDelay, returnDelay, lootDelay;
-    float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, shootDistance,
+    float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, groupMemberLootDistance, groupMemberLootDistanceWithRealMaster,
+        gatheringDistance, groupMemberGatheringDistance, groupMemberGatheringDistanceWithRealMaster, shootDistance,
         fleeDistance, tooCloseDistance, meleeDistance, followDistance, raidFollowDistance, whisperDistance, contactDistance,
-        aoeRadius, rpgDistance, targetPosRecalcDistance, farDistance, healDistance, aggroDistance;
+        aoeRadius, rpgDistance, targetPosRecalcDistance, farDistance, healDistance, aggroDistance, proximityDistance;
+    bool destroyAllGrayItemsBeforeLooting;
+    bool destroyAllGrayItemsBeforeGathering;
+    bool destroyAllGrayItemsBeforeLootingIfLootHasQuestItems;
     uint32 criticalHealth, lowHealth, mediumHealth, almostFullHealth;
     uint32 lowMana, mediumMana;
 
@@ -81,6 +85,7 @@ public:
     std::list<std::pair<uint32, uint32>> freeAltBots;
     std::list<std::string> toggleAlwaysOnlineAccounts;
     std::list<std::string> toggleAlwaysOnlineChars;
+    bool enableRandomTeleportOnRevive;
     uint32 randomBotTeleportDistance;
     bool randomBotTeleportNearPlayer;
     uint32 randomBotTeleportNearPlayerMaxAmount;
@@ -230,6 +235,8 @@ public:
     uint32 broadcastChanceGuildManagement;
 
     uint32 guildRepliesRate;
+
+    uint32 botAcceptDuelMinimumLevel;
 
     bool talentsInPublicNote;
     bool nonGmFreeSummon;

--- a/playerbot/RandomPlayerbotMgr.cpp
+++ b/playerbot/RandomPlayerbotMgr.cpp
@@ -1928,13 +1928,16 @@ void RandomPlayerbotMgr::Revive(Player* player)
     SetEventValue(bot, "dead", 0, 0);
     SetEventValue(bot, "revive", 0, 0);
 
-    if (sServerFacade.GetDeathState(player) == CORPSE)
+    if (sPlayerbotAIConfig.enableRandomTeleportOnRevive)
     {
-        RandomTeleport(player);
-    }
-    else
-    {
-        RandomTeleportForLevel(player, false);
+        if (sServerFacade.GetDeathState(player) == CORPSE)
+        {
+            RandomTeleport(player);
+        }
+        else
+        {
+            RandomTeleportForLevel(player, false);
+        }
     }
 }
 

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -65,7 +65,6 @@ AiPlayerbot.RandomBotAccountCount = 200
 # Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
 # This setting is added for the sake of having all bots always active regardless of anything
 # With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
-# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
 # This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
 # Works best together with AiPlayerbot.DisableBotOptimizations = 1
 # (0-1), default 0
@@ -287,14 +286,17 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761,9378
 ##################################################################################
 
 # Chance to reply to toxic links with toxic links (0-100)
-# AiPlayerbot.ToxicLinksRepliesChance = 100
+# AiPlayerbot.ToxicLinksRepliesChance = 30
 # Chance to reply to thunderfury with thunderfury (0-100)
-# AiPlayerbot.ThunderfuryRepliesChance = 100
+# AiPlayerbot.ThunderfuryRepliesChance = 40
 # Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.
 # AiPlayerbot.RandomBotSayWithoutMaster = 0
+
+# Minimum level at which bots will start accepting duels
+# AiPlayerbot.BotAcceptDuelMinimumLevel = 10
 
 # Speeds up respawn of mobs after being killed by a bot. This only affects the delays after being fully looted.
 # AiPlayerbot.RespawnModNeutral = 10.0    # Each nearby player will decrease the respawn time by 10% for neutral mobs.
@@ -727,7 +729,18 @@ AiPlayerbot.SpellDistance = 26.0
 AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ReactDistance = 150.0
 #AiPlayerbot.GrindDistance = 75.0
-#AiPlayerbot.LootDistance = 15.0
+#overall loot distance
+#AiPlayerbot.LootDistance = 25.0
+#loot distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberLootDistance = 15.0
+#loot distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberLootDistanceWithRealMaster = 10.0
+#overall gathering distance
+#AiPlayerbot.GatheringDistance = 15.0
+#gathering distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberGatheringDistance = 10.0
+#gathering distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberGatheringDistanceWithRealMaster = 5.0
 #AiPlayerbot.FleeDistance = 8.0
 #AiPlayerbot.TooCloseDistance = 5.0
 #AiPlayerbot.MeleeDistance = 1.5
@@ -737,6 +750,16 @@ AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ContactDistance = 0.5
 #AiPlayerbot.AoeRadius = 10
 AiPlayerbot.RpgDistance = 200
+#AiPlayerbot.ProximityDistance = 20.0
+
+#bots will destroy all gray items in bags before looting (if bags are full and loot has no money or doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeLooting = 0
+#bots will destroy all gray items in bags before gathering (if bags are full and loot doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeGathering = 0
+
+# Destroy all gray items in bags if has no free bag space for quest items in bags, and if item stacks are full
+# applies to both looting and gathering
+# AiPlayerbot.DestroyAllGrayItemsBeforeLootingIfLootHasQuestItems = 1
 
 # Bot can flee for enemy
 AiPlayerbot.FleeingEnabled = 1
@@ -785,6 +808,9 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #AiPlayerbot.RandomBotsMaxLoginsPerInterval = 30
 #AiPlayerbot.MinRandomBotsPriceChangeInterval = 7200
 #AiPlayerbot.MaxRandomBotsPriceChangeInterval = 172800
+
+#(0-1) enable or disable random teleports on revive
+# AiPlayerbot.EnableRandomTeleportOnRevive = 1
 
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -65,7 +65,6 @@ AiPlayerbot.RandomBotAccountCount = 200
 # Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
 # This setting is added for the sake of having all bots always active regardless of anything
 # With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
-# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
 # This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
 # Works best together with AiPlayerbot.DisableBotOptimizations = 1
 # (0-1), default 0
@@ -269,14 +268,17 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 ##################################################################################
 
 # Chance to reply to toxic links with toxic links (0-100)
-# AiPlayerbot.ToxicLinksRepliesChance = 100
+# AiPlayerbot.ToxicLinksRepliesChance = 30
 # Chance to reply to thunderfury with thunderfury (0-100)
-# AiPlayerbot.ThunderfuryRepliesChance = 100
+# AiPlayerbot.ThunderfuryRepliesChance = 40
 # Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
 # Bots without a master will say things they normally tell their master.
 # AiPlayerbot.RandomBotSayWithoutMaster = 0
+
+# Minimum level at which bots will start accepting duels
+# AiPlayerbot.BotAcceptDuelMinimumLevel = 10
 
 # Speeds up respawn of mobs after being killed by a bot. This only affects the delays after being fully looted.
 # AiPlayerbot.RespawnModNeutral = 10.0    # Each nearby player will decrease the respawn time by 10% for neutral mobs.
@@ -767,7 +769,18 @@ AiPlayerbot.SpellDistance = 26.0
 AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ReactDistance = 150.0
 #AiPlayerbot.GrindDistance = 75.0
-#AiPlayerbot.LootDistance = 15.0
+#overall loot distance
+#AiPlayerbot.LootDistance = 25.0
+#loot distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberLootDistance = 15.0
+#loot distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberLootDistanceWithRealMaster = 10.0
+#overall gathering distance
+#AiPlayerbot.GatheringDistance = 15.0
+#gathering distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberGatheringDistance = 10.0
+#gathering distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberGatheringDistanceWithRealMaster = 5.0
 #AiPlayerbot.FleeDistance = 15.0
 #AiPlayerbot.TooCloseDistance = 5.0
 #AiPlayerbot.MeleeDistance = 1.5
@@ -777,6 +790,16 @@ AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ContactDistance = 0.5
 #AiPlayerbot.AoeRadius = 10
 AiPlayerbot.RpgDistance = 200
+#AiPlayerbot.ProximityDistance = 20.0
+
+#bots will destroy all gray items in bags before looting (if bags are full and loot has no money or doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeLooting = 0
+#bots will destroy all gray items in bags before gathering (if bags are full and loot doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeGathering = 0
+
+# Destroy all gray items in bags if has no free bag space for quest items in bags, and if item stacks are full
+# applies to both looting and gathering
+# AiPlayerbot.DestroyAllGrayItemsBeforeLootingIfLootHasQuestItems = 1
 
 # Bot can flee for enemy
 AiPlayerbot.FleeingEnabled = 1
@@ -825,6 +848,9 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #AiPlayerbot.RandomBotsMaxLoginsPerInterval = 30
 #AiPlayerbot.MinRandomBotsPriceChangeInterval = 7200
 #AiPlayerbot.MaxRandomBotsPriceChangeInterval = 172800
+
+#(0-1) enable or disable random teleports on revive
+# AiPlayerbot.EnableRandomTeleportOnRevive = 1
 
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -65,7 +65,6 @@ AiPlayerbot.RandomBotAccountCount = 200
 # Disable bot activity priorities, to make all bots ACTUALLY active without player in the zones or server (unless AiPlayerbot.DisableBotOptimizations = 0)
 # This setting is added for the sake of having all bots always active regardless of anything
 # With this enabled, if you get lags - then you need to reduce amount of online bots, rather than relying on optimizations
-# You may also want to set AiPlayerbot.DiffWithPlayer and AiPlayerbot.DiffEmpty to about 2x your avg diff, otherwise bots will not be joining BG
 # This will ingore the AiPlayerbot.botActiveAlone setting, all bots will be active regardless
 # Works best together with AiPlayerbot.DisableBotOptimizations = 1
 # (0-1), default 0
@@ -272,9 +271,9 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 ##################################################################################
 
 # Chance to reply to toxic links with toxic links (0-100)
-# AiPlayerbot.ToxicLinksRepliesChance = 100
+# AiPlayerbot.ToxicLinksRepliesChance = 30
 # Chance to reply to thunderfury with thunderfury (0-100)
-# AiPlayerbot.ThunderfuryRepliesChance = 100
+# AiPlayerbot.ThunderfuryRepliesChance = 40
 # Bots will chat in guild about certain events (int) (0-100)
 # AiPlayerbot.GuildRepliesRate = 100         # Reply someone saying something.
 
@@ -283,6 +282,9 @@ AiPlayerbot.RandomBotQuestIds = 7848,3802,5505,6502,7761
 
 # Bots without a master will say things they normally tell their master.
 # AiPlayerbot.RandomBotSayWithoutMaster = 0
+
+# Minimum level at which bots will start accepting duels
+# AiPlayerbot.BotAcceptDuelMinimumLevel = 10
 
 # Speeds up respawn of mobs after being killed by a bot. This only affects the delays after being fully looted.
 # AiPlayerbot.RespawnModNeutral = 10.0    # Each nearby player will decrease the respawn time by 10% for neutral mobs.
@@ -708,7 +710,18 @@ AiPlayerbot.SpellDistance = 26.0
 AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ReactDistance = 150.0
 #AiPlayerbot.GrindDistance = 75.0
-#AiPlayerbot.LootDistance = 15.0
+#overall loot distance
+#AiPlayerbot.LootDistance = 25.0
+#loot distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberLootDistance = 15.0
+#loot distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberLootDistanceWithRealMaster = 10.0
+#overall gathering distance
+#AiPlayerbot.GatheringDistance = 15.0
+#gathering distance when bot is a group member (not leader)
+#AiPlayerbot.GroupMemberGatheringDistance = 10.0
+#gathering distance when bot is a group member (not leader) and has real player master (if player is group leader)
+#AiPlayerbot.GroupMemberGatheringDistanceWithRealMaster = 5.0
 #AiPlayerbot.FleeDistance = 15.0
 #AiPlayerbot.TooCloseDistance = 5.0
 #AiPlayerbot.MeleeDistance = 1.5
@@ -718,6 +731,16 @@ AiPlayerbot.ShootDistance = 26.0
 #AiPlayerbot.ContactDistance = 0.5
 #AiPlayerbot.AoeRadius = 10
 AiPlayerbot.RpgDistance = 200
+#AiPlayerbot.ProximityDistance = 20.0
+
+#bots will destroy all gray items in bags before looting (if bags are full and loot has no money or doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeLooting = 0
+#bots will destroy all gray items in bags before gathering (if bags are full and loot doesn't add to stacks in bags)
+# AiPlayerbot.DestroyAllGrayItemsBeforeGathering = 0
+
+# Destroy all gray items in bags if has no free bag space for quest items in bags, and if item stacks are full
+# applies to both looting and gathering
+# AiPlayerbot.DestroyAllGrayItemsBeforeLootingIfLootHasQuestItems = 1
 
 # Bot can flee for enemy
 AiPlayerbot.FleeingEnabled = 1
@@ -766,6 +789,9 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #AiPlayerbot.RandomBotsMaxLoginsPerInterval = 30
 #AiPlayerbot.MinRandomBotsPriceChangeInterval = 7200
 #AiPlayerbot.MaxRandomBotsPriceChangeInterval = 172800
+
+#(0-1) enable or disable random teleports on revive
+# AiPlayerbot.EnableRandomTeleportOnRevive = 1
 
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100

--- a/playerbot/strategy/actions/AcceptDuelAction.h
+++ b/playerbot/strategy/actions/AcceptDuelAction.h
@@ -19,8 +19,9 @@ namespace ai
             ObjectGuid playerGuid;
             p >> playerGuid;
 
-            // do not auto duel with low hp
-            if ((!ai->HasRealPlayerMaster() || (ai->GetMaster() && ai->GetMaster()->GetObjectGuid() != playerGuid)) && AI_VALUE2(uint8, "health", "self target") < 90)
+            // do not auto duel with low hp or below certain level
+            if (bot->GetLevel() < sPlayerbotAIConfig.botAcceptDuelMinimumLevel
+                || ((!ai->HasRealPlayerMaster() || (ai->GetMaster() && ai->GetMaster()->GetObjectGuid() != playerGuid)) && AI_VALUE2(uint8, "health", "self target") < 90))
             {
                 WorldPacket packet(CMSG_DUEL_CANCELLED, 8);
                 packet << flagGuid;

--- a/playerbot/strategy/actions/AddLootAction.cpp
+++ b/playerbot/strategy/actions/AddLootAction.cpp
@@ -61,21 +61,95 @@ bool AddAllLootAction::AddLoot(Player* requester, ObjectGuid guid)
     if (abs(wo->GetPositionZ() - bot->GetPositionZ()) > INTERACTION_DISTANCE)
         return false;
 
-    if (ai->HasRealPlayerMaster())
-    {
-        bool inDungeon = false;
-        if (requester->IsInWorld() &&
-            requester->GetMap()->IsDungeon() &&
-            bot->GetMapId() == requester->GetMapId())
-            inDungeon = true;
+    if (!loot.IsLootPossible(bot))
+        return false;
 
-        if (inDungeon && sServerFacade.IsDistanceGreaterThan(sServerFacade.GetDistance2d(requester, wo), sPlayerbotAIConfig.lootDistance))
+    float lootDistanceToUse = sPlayerbotAIConfig.lootDistance;
+
+    Group* group = bot->GetGroup();
+
+    bool isInGroup = group ? true : false;
+    bool isGroupLeader = isInGroup ? group->GetLeaderGuid() == bot->GetObjectGuid() : false;
+    bool isInDungeon = bot->GetMap()->IsDungeon();
+
+    if (isInGroup)
+    {
+        //if is not master looter (and loot is set to MASTER_LOOT)
+        //NOTE: They are !unable to loot quests items! too if so
+        if (isInDungeon
+            && group->GetLootMethod() == LootMethod::MASTER_LOOT
+            && group->GetMasterLooterGuid()
+            && group->GetMasterLooterGuid() != bot->GetObjectGuid())
             return false;
 
-        if (Group* group = bot->GetGroup())
+        if (isGroupLeader)
         {
-            if (group->GetLootMethod() == LootMethod::MASTER_LOOT && group->GetMasterLooterGuid() && group->GetMasterLooterGuid() != bot->GetObjectGuid())
-                return false;
+            lootDistanceToUse = sPlayerbotAIConfig.lootDistance;
+        }
+        else
+        {
+            if (ai->HasRealPlayerMaster())
+            {
+                lootDistanceToUse = sPlayerbotAIConfig.groupMemberLootDistanceWithRealMaster;
+            }
+            else
+            {
+                lootDistanceToUse = sPlayerbotAIConfig.groupMemberLootDistance;
+            }
+        }
+    }
+    else
+    {
+        lootDistanceToUse = sPlayerbotAIConfig.lootDistance;
+    }
+
+    if (sServerFacade.IsDistanceGreaterThan(sServerFacade.GetDistance2d(requester, wo), lootDistanceToUse))
+    {
+        return false;
+    }
+
+    //check hostile units after distance checks, to avoid unnecessary calculations
+
+    if (isInGroup && !isGroupLeader)
+    {
+        float MOB_AGGRO_DISTANCE = 30.0f;
+        std::list<Unit*> hostiles = ai->GetAllHostileUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
+
+        if (hostiles.size() > 0)
+        {
+            std::ostringstream out;
+            out << hostiles.front()->GetName() << " is blocking " << wo->GetName() << ", need to kill it or I will not loot";
+            ai->TellError(requester, out.str());
+            return false;
+        }
+    }
+
+    uint8 freeBagSpace = AI_VALUE(uint8, "bag space");
+
+    //do not even attempt if has no bag space
+    if (freeBagSpace < 1 && !ai->CanLootSomethingFromWO(wo))
+    {
+        //try to destroy all gray items
+        if (sPlayerbotAIConfig.destroyAllGrayItemsBeforeLooting)
+        {
+            ai->DestroyAllGrayItemsInBags(requester);
+            //recount freeBagSpace
+            freeBagSpace = AI_VALUE(uint8, "bag space");
+        }
+
+        //try to destroy all gray items
+        if (sPlayerbotAIConfig.destroyAllGrayItemsBeforeLootingIfLootHasQuestItems && freeBagSpace < 1 && ai->HasQuestItemsInWOLootList(wo))
+        {
+            ai->DestroyAllGrayItemsInBags(requester);
+            //recount freeBagSpace
+            freeBagSpace = AI_VALUE(uint8, "bag space");
+        }
+
+        //if after trying to destroy - still no bag space
+        if (freeBagSpace < 1)
+        {
+            ai->TellError(requester, "There is some loot but I do not have free bag space, so not looting");
+            return false;
         }
     }
 
@@ -99,17 +173,98 @@ bool AddGatheringLootAction::AddLoot(Player* requester, ObjectGuid guid)
     if (!loot.IsLootPossible(bot))
         return false;
 
-    if (sServerFacade.IsDistanceGreaterThan(sServerFacade.GetDistance2d(bot, wo), INTERACTION_DISTANCE) && sServerFacade.IsDistanceLessThan(sServerFacade.GetDistance2d(bot, requester), sPlayerbotAIConfig.reactDistance))
+    float gatheringDistanceToUse = sPlayerbotAIConfig.gatheringDistance;
+
+    Group* group = bot->GetGroup();
+
+    bool isInGroup = group ? true : false;
+    bool isGroupLeader = isInGroup ? group->GetLeaderGuid() == bot->GetObjectGuid() : false;
+    bool isInDungeon = bot->GetMap()->IsDungeon();
+
+    if (isInGroup && !isGroupLeader)
     {
-        std::list<Unit*> targets;
-        MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(bot, sPlayerbotAIConfig.lootDistance);
-        MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
-        Cell::VisitAllObjects(wo, searcher, sPlayerbotAIConfig.spellDistance * 1.5);
-        if (!targets.empty())
+        if (ai->HasRealPlayerMaster())
+        {
+            gatheringDistanceToUse = sPlayerbotAIConfig.groupMemberGatheringDistanceWithRealMaster;
+        }
+        else
+        {
+            gatheringDistanceToUse = sPlayerbotAIConfig.groupMemberGatheringDistance;
+        }
+    }
+    else if (isInGroup && isGroupLeader)
+    {
+        gatheringDistanceToUse = sPlayerbotAIConfig.gatheringDistance;
+    }
+    else
+    {
+        gatheringDistanceToUse = sPlayerbotAIConfig.gatheringDistance;
+    }
+
+    if (sServerFacade.IsDistanceGreaterThan(sServerFacade.GetDistance2d(requester, wo), gatheringDistanceToUse))
+    {
+        return false;
+    }
+
+    //check hostile units after distance checks, to avoid unnecessary calculations
+
+    float MOB_AGGRO_DISTANCE = 30.0f;
+    std::list<Unit*> hostiles = ai->GetAllHostileUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
+    std::list<Unit*> strongHostiles;
+    for (auto hostile : hostiles)
+    {
+        if (!(bot->GetLevel() > hostile->GetLevel() + 7))
+        {
+            strongHostiles.push_back(hostile);
+        }
+    }
+
+    if (isInGroup && !isGroupLeader)
+    {
+        if (hostiles.size() > 0)
         {
             std::ostringstream out;
-            out << "Kill that " << targets.front()->GetName() << " so I can loot freely";
+            out << hostiles.front()->GetName() << " is blocking " << wo->GetName() << ", need to kill it or I will not gather";
             ai->TellError(requester, out.str());
+            return false;
+        }
+    }
+    else
+    {
+        if (strongHostiles.size() > 1)
+        {
+            std::ostringstream out;
+            out << strongHostiles.front()->GetName() << " is blocking " << wo->GetName() << ", need to kill it or I will not gather";
+            ai->TellError(requester, out.str());
+            return false;
+        }
+    }
+
+    uint8 freeBagSpace = AI_VALUE(uint8, "bag space");
+
+    //do not even attempt if has no bag space
+    if (freeBagSpace < 1 && !ai->CanLootSomethingFromWO(wo))
+    {
+        //try to destroy all gray items
+        if (sPlayerbotAIConfig.destroyAllGrayItemsBeforeGathering)
+        {
+            ai->DestroyAllGrayItemsInBags(requester);
+            //recount freeBagSpace
+            freeBagSpace = AI_VALUE(uint8, "bag space");
+        }
+
+        //try to destroy all gray items
+        if (sPlayerbotAIConfig.destroyAllGrayItemsBeforeLootingIfLootHasQuestItems && freeBagSpace < 1 && ai->HasQuestItemsInWOLootList(wo))
+        {
+            ai->DestroyAllGrayItemsInBags(requester);
+            //recount freeBagSpace
+            freeBagSpace = AI_VALUE(uint8, "bag space");
+        }
+
+        //if after trying to destroy - still no bag space
+        if (freeBagSpace < 1)
+        {
+            ai->TellError(requester, "There is some loot but I do not have free bag space, so not looting");
             return false;
         }
     }

--- a/playerbot/strategy/actions/BattleGroundJoinAction.cpp
+++ b/playerbot/strategy/actions/BattleGroundJoinAction.cpp
@@ -365,6 +365,11 @@ bool BGJoinAction::shouldJoinBg(BattleGroundQueueTypeId queueTypeId, BattleGroun
     bool isTeamLead = false;
     bool noLag = sWorld.GetAverageDiff() < (sRandomPlayerbotMgr.GetPlayers().empty() ? sPlayerbotAIConfig.diffEmpty : sPlayerbotAIConfig.diffWithPlayer) * 1.1;
 
+    if (sPlayerbotAIConfig.disableActivityPriorities)
+    {
+        noLag = true;
+    }
+
 #ifndef MANGOSBOT_ZERO
     ArenaType type = sServerFacade.BgArenaType(queueTypeId);
     if (type != ARENA_TYPE_NONE)
@@ -405,7 +410,7 @@ bool BGJoinAction::shouldJoinBg(BattleGroundQueueTypeId queueTypeId, BattleGroun
         return false;
 
     if (!hasPlayers && bgTypeId == BATTLEGROUND_SA)
-        return false;    
+        return false;
 #endif
 
     uint32 BracketSize = bg->GetMaxPlayers();
@@ -827,6 +832,11 @@ bool FreeBGJoinAction::shouldJoinBg(BattleGroundQueueTypeId queueTypeId, BattleG
     bool isRated = false;
     bool hasTeam = false;
     bool noLag = sWorld.GetAverageDiff() < (sRandomPlayerbotMgr.GetPlayers().empty() ? sPlayerbotAIConfig.diffEmpty : sPlayerbotAIConfig.diffWithPlayer) * 1.5;
+
+    if (sPlayerbotAIConfig.disableActivityPriorities)
+    {
+        noLag = true;
+    }
 
 #ifndef MANGOSBOT_ZERO
     ArenaType type = sServerFacade.BgArenaType(queueTypeId);

--- a/playerbot/strategy/actions/RevealGatheringItemAction.cpp
+++ b/playerbot/strategy/actions/RevealGatheringItemAction.cpp
@@ -45,7 +45,7 @@ bool RevealGatheringItemAction::Execute(Event& event)
     {
         GameObject* go = *tIter;
         if (!go || !sServerFacade.isSpawned(go) ||
-                sServerFacade.IsDistanceLessOrEqualThan(sServerFacade.GetDistance2d(bot, go), sPlayerbotAIConfig.lootDistance))
+                sServerFacade.IsDistanceLessOrEqualThan(sServerFacade.GetDistance2d(bot, go), sPlayerbotAIConfig.gatheringDistance))
             continue;
 
         if (LockEntry const *lockInfo = sLockStore.LookupEntry(go->GetGOInfo()->GetLockId()))

--- a/playerbot/strategy/values/FreeMoveValues.cpp
+++ b/playerbot/strategy/values/FreeMoveValues.cpp
@@ -82,7 +82,7 @@ float FreeMoveRangeValue::Calculate()
         return 0;
 
     if (hasFree || hasGuard)//Free and guard start with a base 20y range.
-        maxDist += sPlayerbotAIConfig.lootDistance;
+        maxDist += sPlayerbotAIConfig.proximityDistance;
 
     uint32 lastMasterMove = MEM_AI_VALUE(WorldPosition, "master position")->LastChangeDelay();
 

--- a/playerbot/strategy/values/GrindTargetValue.cpp
+++ b/playerbot/strategy/values/GrindTargetValue.cpp
@@ -87,7 +87,7 @@ Unit* GrindTargetValue::FindTargetForGrinding(int assistCount)
             continue;
         }
 
-        if (!bot->InBattleGround() && master && ai->HasStrategy("follow", BotState::BOT_STATE_NON_COMBAT) && sServerFacade.GetDistance2d(master, unit) > sPlayerbotAIConfig.lootDistance)
+        if (!bot->InBattleGround() && master && ai->HasStrategy("follow", BotState::BOT_STATE_NON_COMBAT) && sServerFacade.GetDistance2d(master, unit) > sPlayerbotAIConfig.proximityDistance)
         {
             if (ai->HasStrategy("debug grind", BotState::BOT_STATE_NON_COMBAT))
                 ai->TellPlayer(GetMaster(), chat->formatWorldobject(unit) + " ignored (far from master).");

--- a/playerbot/strategy/values/PositionValue.h
+++ b/playerbot/strategy/values/PositionValue.h
@@ -56,7 +56,7 @@ namespace ai
     {
     public:
         MasterPositionValue(PlayerbotAI* ai, std::string name = "master position", uint32 checkInterval = 1) : MemoryCalculatedValue<WorldPosition>(ai, name, checkInterval) { minChangeInterval = 1; };
-        virtual bool EqualToLast(WorldPosition value) { return value.fDist(lastValue) < sPlayerbotAIConfig.lootDistance; }
+        virtual bool EqualToLast(WorldPosition value) { return value.fDist(lastValue) < sPlayerbotAIConfig.proximityDistance; }
         virtual WorldPosition Calculate() { Player* master = GetMaster();  if (master) return WorldPosition(master); return WorldPosition(); };
     };
 


### PR DESCRIPTION
added disable "nolag" check for BG joins if sPlayerbotAIConfig.disableActivityPriorities as per @mostlikelyfr suggestion
added AiPlayerbot.BotAcceptDuelMinimumLevel to limit at which level bots will start accepting duels
changed/fixed/improved AddLootAction logic for looting and gathering
added configs for different looting scenarios
changed out-of-place usages of lootDistance to use AiPlayerbot.ProximityDistance instead (judging by their logic, 20.0 default value fits more than 15.0 value of lootDistance)
tweaked default AiPlayerbot.ToxicLinksRepliesChance and AiPlayerbot.ThunderfuryRepliesChance values