### PR TITLE
workaround - AnyUnfriendlyUnitInObjectRangeCheck rarely returns friendly players and even self as a hostile to the bot, remove players from calculations for now

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -6837,7 +6837,23 @@ std::list<Unit*> PlayerbotAI::GetAllHostileUnitsAroundWO(WorldObject* wo, float 
     MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(hostileUnits, u_check);
     Cell::VisitAllObjects(wo, searcher, distanceAround);
 
+    //bugs out with players very rarely - returns friendly as hostile to bots
+
     return hostileUnits;
+}
+
+std::list<Unit*> PlayerbotAI::GetAllHostileNonPlayerUnitsAroundWO(WorldObject* wo, float distanceAround)
+{
+    std::list<Unit*> hostileUnitsNonPlayers;
+    for (auto hostileUnit : GetAllHostileUnitsAroundWO(wo, distanceAround))
+    {
+        if (!hostileUnit->IsPlayer())
+        {
+            hostileUnitsNonPlayers.push_back(hostileUnit);
+        }
+    }
+
+    return hostileUnitsNonPlayers;
 }
 
 std::string PlayerbotAI::InventoryParseOutfitName(std::string outfit)

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -508,6 +508,7 @@ public:
     void AccelerateRespawn(ObjectGuid guid, float accelMod = 0) { Creature* creature = GetCreature(guid); if (creature) AccelerateRespawn(creature,accelMod); }
 
     std::list<Unit*> GetAllHostileUnitsAroundWO(WorldObject* wo, float distanceAround);
+    std::list<Unit*> GetAllHostileNonPlayerUnitsAroundWO(WorldObject* wo, float distanceAround);
 
 public:
     std::vector<Item*> GetInventoryAndEquippedItems();

--- a/playerbot/strategy/actions/AddLootAction.cpp
+++ b/playerbot/strategy/actions/AddLootAction.cpp
@@ -113,7 +113,7 @@ bool AddAllLootAction::AddLoot(Player* requester, ObjectGuid guid)
     if (isInGroup && !isGroupLeader)
     {
         float MOB_AGGRO_DISTANCE = 30.0f;
-        std::list<Unit*> hostiles = ai->GetAllHostileUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
+        std::list<Unit*> hostiles = ai->GetAllHostileNonPlayerUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
 
         if (hostiles.size() > 0)
         {
@@ -208,7 +208,7 @@ bool AddGatheringLootAction::AddLoot(Player* requester, ObjectGuid guid)
     //check hostile units after distance checks, to avoid unnecessary calculations
 
     float MOB_AGGRO_DISTANCE = 30.0f;
-    std::list<Unit*> hostiles = ai->GetAllHostileUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
+    std::list<Unit*> hostiles = ai->GetAllHostileNonPlayerUnitsAroundWO(wo, MOB_AGGRO_DISTANCE);
     std::list<Unit*> strongHostiles;
     for (auto hostile : hostiles)
     {


### PR DESCRIPTION
workaround - AnyUnfriendlyUnitInObjectRangeCheck rarely returns friendly players and even self as a hostile to the bot, remove players from calculations for now