### PR TITLE
revive logic improvements

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -2665,6 +2665,39 @@ std::vector<std::pair<const Quest*, uint32>> PlayerbotAI::GetCurrentQuestsRequir
     return result;
 }
 
+//this is something analogous to /unstuck, but forced, for bad situations
+void PlayerbotAI::Evacuate()
+{
+    sLog.outBasic("Evacuating bot #%d %s:%d <%s>", bot->GetGUIDLow(), bot->GetTeam() == ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
+
+    aiObjectContext->GetValue<uint32>("death count")->Set(0);
+
+    if (bot->IsDead())
+    {
+        bot->ResurrectPlayer(1.0f, false);
+        bot->SpawnCorpseBones();
+        bot->SaveToDB();
+    }
+
+    sLog.outBasic("Evacuating: Removing bot #%d %s:%d <%s> from group", bot->GetGUIDLow(), bot->GetTeam() == ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
+    if (Group* group = bot->GetGroup())
+        group->RemoveMember(bot->GetObjectGuid(), GROUP_LEAVE);
+
+    PlayerInfo const* defaultPlayerInfo = sObjectMgr.GetPlayerInfo(bot->getRace(), bot->getClass());
+    if (defaultPlayerInfo)
+    {
+        sLog.outBasic("Evacuating: Teleporting bot #%d %s:%d <%s> to spawn", bot->GetGUIDLow(), bot->GetTeam() == ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
+        //teleport bot to spawn
+        bot->TeleportTo(defaultPlayerInfo->mapId, defaultPlayerInfo->positionX, defaultPlayerInfo->positionY, defaultPlayerInfo->positionZ, defaultPlayerInfo->orientation);
+    }
+    else
+    {
+        sLog.outBasic("Evacuating: Teleporting bot #%d %s:%d <%s> to homebind", bot->GetGUIDLow(), bot->GetTeam() == ALLIANCE ? "A" : "H", bot->GetLevel(), bot->GetName());
+        //teleport bot to homebind
+        bot->TeleportToHomebind();
+    }
+}
+
 const AreaTableEntry* PlayerbotAI::GetCurrentArea()
 {
     return GetAreaEntryByAreaID(sServerFacade.GetAreaId(bot));

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -385,6 +385,7 @@ public:
     const Quest* GetCurrentIncompleteQuestWithId(uint32 questId);
     bool HasCurrentIncompleteQuestWithId(uint32 questId);
     std::vector<std::pair<const Quest*, uint32>> GetCurrentQuestsRequiringItemId(uint32 itemId);
+    void Evacuate();
     const AreaTableEntry* GetCurrentArea();
     const AreaTableEntry* GetCurrentZone();
     std::string GetLocalizedAreaName(const AreaTableEntry* entry);

--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -196,7 +196,6 @@ bool PlayerbotAIConfig::Initialize()
     minRandomBotReviveTime = config.GetIntDefault("AiPlayerbot.MinRandomBotReviveTime", 60);
     maxRandomBotReviveTime = config.GetIntDefault("AiPlayerbot.MaxRandomReviveTime", 300);
     enableRandomTeleports = config.GetBoolDefault("AiPlayerbot.EnableRandomTeleports", true);
-    realisticRevives = config.GetBoolDefault("AiPlayerbot.RealisticRevives", false);
     randomBotTeleportDistance = config.GetIntDefault("AiPlayerbot.RandomBotTeleportDistance", 1000);
     randomBotTeleportNearPlayer = config.GetBoolDefault("AiPlayerbot.RandomBotTeleportNearPlayer", false);
     randomBotTeleportNearPlayerMaxAmount = config.GetIntDefault("AiPlayerbot.RandomBotTeleportNearPlayerMaxAmount", 0);

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -83,7 +83,6 @@ public:
     std::list<std::string> toggleAlwaysOnlineAccounts;
     std::list<std::string> toggleAlwaysOnlineChars;
     bool enableRandomTeleports;
-    bool realisticRevives;
     uint32 randomBotTeleportDistance;
     bool randomBotTeleportNearPlayer;
     uint32 randomBotTeleportNearPlayerMaxAmount;

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -823,9 +823,6 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #(0-1) enable or disable random teleports
 # AiPlayerbot.EnableRandomTeleports = 1
 
-#(0-1) 1 - revives will respect game rules (no teleports, revive at nearest graveyard)
-# AiPlayerbot.RealisticRevives = 0
-
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -863,9 +863,6 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #(0-1) enable or disable random teleports
 # AiPlayerbot.EnableRandomTeleports = 1
 
-#(0-1) 1 - revives will respect game rules (no teleports, revive at nearest graveyard)
-# AiPlayerbot.RealisticRevives = 0
-
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -804,9 +804,6 @@ AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 #(0-1) enable or disable random teleports
 # AiPlayerbot.EnableRandomTeleports = 1
 
-#(0-1) 1 - revives will respect game rules (no teleports, revive at nearest graveyard)
-# AiPlayerbot.RealisticRevives = 0
-
 # How far random bots are teleported after death
 AiPlayerbot.RandomBotTeleportDistance = 100
 

--- a/playerbot/strategy/values/DeadValues.h
+++ b/playerbot/strategy/values/DeadValues.h
@@ -3,6 +3,13 @@
 
 namespace ai
 {
+    enum DeadValueConstants
+    {
+        DEATH_COUNT_BEFORE_EVAC = 10,
+        DEATH_COUNT_BEFORE_TRYING_ANOTHER_GRAVEYARD = 5,
+        DEATH_COUNT_BEFORE_REVIVING_AT_SPIRIT_HEALER = 3
+    };
+
     class GraveyardValue : public GuidPositionCalculatedValue, public Qualified
     {
     public:
@@ -10,6 +17,7 @@ namespace ai
 
     public:
         GuidPosition Calculate();
+        WorldSafeLocsEntry const* GetAnotherAppropriateClosestGraveyard() const;
     };
 
     class BestGraveyardValue : public GuidPositionCalculatedValue


### PR DESCRIPTION
added "another closest appropriate" graveyard value which gives coordinates to another nearest non-hostile appropriate for level zone graveyard
removed "start" and "home bind" from dead values - no need removed AiPlayerbot.RealisticRevives option - no need anymore revised revive conditions
moved death count constants to DeadValueConstants
added PlayerbotAI::Evacuate() to evacuate bots from difficult situations (like death loops, maybe something else in the future)