### PR TITLE
looting fixes

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -6194,51 +6194,10 @@ bool PlayerbotAI::HasItemInInventory(uint32 itemId)
     return false;
 }
 
-void PlayerbotAI::DestroyAllGrayItemsInBags(Player* requester)
-{
-    for (int i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
-    {
-        if (Bag* pBag = (Bag*)bot->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
-        {
-            for (uint32 j = 0; j < pBag->GetBagSize(); ++j)
-            {
-                if (Item* pItem = pBag->GetItemByPos(j))
-                {
-                    if (const ItemPrototype* proto = pItem->GetProto())
-                    {
-                        if (proto->Quality == ITEM_QUALITY_POOR)
-                        {
-                            bot->DestroyItem(pItem->GetBagSlot(), pItem->GetSlot(), true);
-                            std::ostringstream out; out << GetChatHelper()->formatItem(pItem) << " destroyed";
-                            TellPlayer(requester, out, PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    for (int i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
-    {
-        if (Item* pItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
-        {
-            if (const ItemPrototype* proto = pItem->GetProto())
-            {
-                if (proto->Quality == ITEM_QUALITY_POOR)
-                {
-                    bot->DestroyItem(pItem->GetBagSlot(), pItem->GetSlot(), true);
-                    std::ostringstream out; out << GetChatHelper()->formatItem(pItem) << " destroyed";
-                    TellPlayer(requester, out, PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
-                }
-            }
-        }
-    }
-}
-
 /*
 * @return true if has stacks which are not full for these items
 */
-bool PlayerbotAI::HasNotFullStacksInBagsForLootItems(LootItemList lootItemList)
+bool PlayerbotAI::HasNotFullStacksInBagsForLootItems(LootItemList &lootItemList)
 {
     for (auto lootItem : lootItemList)
     {
@@ -6278,8 +6237,13 @@ bool PlayerbotAI::HasNotFullStacksInBagsForLootItems(LootItemList lootItemList)
 
 bool PlayerbotAI::HasQuestItemsInWOLootList(WorldObject* wo)
 {
-    LootItemList lootItemList;
-    wo->m_loot->GetLootItemsListFor(bot, lootItemList);
+    if (!wo)
+        return false;
+
+    LootItemList lootItemList = {};
+
+    if (wo->m_loot)
+        wo->m_loot->GetLootItemsListFor(bot, lootItemList);
 
     if (HasQuestItemsInLootList(lootItemList))
     {
@@ -6289,7 +6253,7 @@ bool PlayerbotAI::HasQuestItemsInWOLootList(WorldObject* wo)
     return false;
 }
 
-bool PlayerbotAI::HasQuestItemsInLootList(LootItemList lootItemList)
+bool PlayerbotAI::HasQuestItemsInLootList(LootItemList &lootItemList)
 {
     for (auto lootItem : lootItemList)
     {
@@ -6304,6 +6268,9 @@ bool PlayerbotAI::HasQuestItemsInLootList(LootItemList lootItemList)
 
 bool PlayerbotAI::CanLootSomethingFromWO(WorldObject* wo)
 {
+    if (!wo)
+        return false;
+
     ObjectGuid guid = wo->GetObjectGuid();
     if (guid.IsCreature())
     {
@@ -6314,8 +6281,11 @@ bool PlayerbotAI::CanLootSomethingFromWO(WorldObject* wo)
             {
                 return true;
             }
-            LootItemList lootItemList;
-            creature->m_loot->GetLootItemsListFor(bot, lootItemList);
+            LootItemList lootItemList = {};
+
+            if (creature->m_loot)
+                creature->m_loot->GetLootItemsListFor(bot, lootItemList);
+
             if (HasNotFullStacksInBagsForLootItems(lootItemList))
             {
                 return true;
@@ -6327,8 +6297,11 @@ bool PlayerbotAI::CanLootSomethingFromWO(WorldObject* wo)
         GameObject* go = GetGameObject(guid);
         if (go)
         {
-            LootItemList lootItemList;
-            go->m_loot->GetLootItemsListFor(bot, lootItemList);
+            LootItemList lootItemList = {};
+
+            if (go->m_loot)
+                go->m_loot->GetLootItemsListFor(bot, lootItemList);
+
             if (HasNotFullStacksInBagsForLootItems(lootItemList))
             {
                 return true;

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -517,9 +517,8 @@ public:
     std::vector<Item*> GetInventoryItems();
     uint32 GetInventoryItemsCountWithId(uint32 itemId);
     bool HasItemInInventory(uint32 itemId);
-    void DestroyAllGrayItemsInBags(Player* requester);
-    bool HasNotFullStacksInBagsForLootItems(LootItemList questLootItemList);
-    bool HasQuestItemsInLootList(LootItemList questLootItemList);
+    bool HasNotFullStacksInBagsForLootItems(LootItemList &questLootItemList);
+    bool HasQuestItemsInLootList(LootItemList &questLootItemList);
     bool HasQuestItemsInWOLootList(WorldObject* wo);
     bool CanLootSomethingFromWO(WorldObject* wo);
 

--- a/playerbot/strategy/actions/AddLootAction.cpp
+++ b/playerbot/strategy/actions/AddLootAction.cpp
@@ -10,6 +10,8 @@
 #include "Grids/GridNotifiersImpl.h"
 #include "Grids/CellImpl.h"
 
+#include "playerbot/strategy/actions/DestroyItemAction.h"
+
 using namespace ai;
 using namespace MaNGOS;
 
@@ -148,21 +150,23 @@ bool AddAllLootAction::AddLoot(Player* requester, ObjectGuid guid)
         }
     }
 
-    uint8 freeBagSpace = AI_VALUE(uint8, "bag space");
+    uint8 usedBagSpacePercent = AI_VALUE(uint8, "bag space");
 
-    if (freeBagSpace < 1 && !ai->CanLootSomethingFromWO(wo))
+    if (usedBagSpacePercent > 99 && !ai->CanLootSomethingFromWO(wo))
     {
         if (ai->HasQuestItemsInWOLootList(wo))
         {
-            if (freeBagSpace < 1)
+            if (usedBagSpacePercent > 99 && ai->DoSpecificAction("destroy all gray"))
             {
-                ai->TellDebug(requester, "Destroying items to make room.", "debug loot");
-                ai->DestroyAllGrayItemsInBags(requester);
-                //recount freeBagSpace
-                freeBagSpace = AI_VALUE(uint8, "bag space");
+                usedBagSpacePercent = AI_VALUE(uint8, "bag space");
             }
 
-            if (freeBagSpace < 1)
+            if (usedBagSpacePercent > 99 && ai->DoSpecificAction("smart destroy"))
+            {
+                usedBagSpacePercent = AI_VALUE(uint8, "bag space");
+            }
+
+            if (usedBagSpacePercent > 99)
             {
                 ai->TellPlayer(requester, "Can not loot quest item, my bags are full", PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
                 return false;
@@ -170,7 +174,7 @@ bool AddAllLootAction::AddLoot(Player* requester, ObjectGuid guid)
 
         }
 
-        if (freeBagSpace < 1)
+        if (usedBagSpacePercent > 99)
         {
             ai->TellError(requester, "There is some loot but I do not have free bag space, so not looting");
             return false;
@@ -264,20 +268,23 @@ bool AddGatheringLootAction::AddLoot(Player* requester, ObjectGuid guid)
         }
     }
 
-    uint8 freeBagSpace = AI_VALUE(uint8, "bag space");
+    uint8 usedBagSpacePercent = AI_VALUE(uint8, "bag space");
 
-    if (freeBagSpace < 1 && !ai->CanLootSomethingFromWO(wo))
+    if (usedBagSpacePercent > 99 && !ai->CanLootSomethingFromWO(wo))
     {
         if (ai->HasQuestItemsInWOLootList(wo))
         {
-            if (freeBagSpace < 1)
+            if (usedBagSpacePercent > 99 && ai->DoSpecificAction("destroy all gray"))
             {
-                ai->DestroyAllGrayItemsInBags(requester);
-                //recount freeBagSpace
-                freeBagSpace = AI_VALUE(uint8, "bag space");
+                usedBagSpacePercent = AI_VALUE(uint8, "bag space");
             }
 
-            if (freeBagSpace < 1)
+            if (usedBagSpacePercent > 99 && ai->DoSpecificAction("smart destroy"))
+            {
+                usedBagSpacePercent = AI_VALUE(uint8, "bag space");
+            }
+
+            if (usedBagSpacePercent > 99)
             {
                 ai->TellPlayer(requester, "Can not loot quest item, my bags are full", PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
                 return false;
@@ -285,7 +292,7 @@ bool AddGatheringLootAction::AddLoot(Player* requester, ObjectGuid guid)
 
         }
 
-        if (freeBagSpace < 1)
+        if (usedBagSpacePercent > 99)
         {
             ai->TellError(requester, "There is some loot but I do not have free bag space, so not looting");
             return false;

--- a/playerbot/strategy/actions/DestroyItemAction.cpp
+++ b/playerbot/strategy/actions/DestroyItemAction.cpp
@@ -105,3 +105,56 @@ bool SmartDestroyItemAction::Execute(Event& event)
 
     return false;
 }
+
+bool DestroyAllGrayItemsAction::Execute(Event& event)
+{
+    Player* requester = event.getOwner() ? event.getOwner() : GetMaster();
+
+    bool hasDestroyedAnyItems = false;
+
+    for (int i = INVENTORY_SLOT_BAG_START; i < INVENTORY_SLOT_BAG_END; ++i)
+    {
+        if (Bag* pBag = (Bag*)bot->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+        {
+            for (uint32 j = 0; j < pBag->GetBagSize(); ++j)
+            {
+                if (Item* pItem = pBag->GetItemByPos(j))
+                {
+                    if (const ItemPrototype* proto = pItem->GetProto())
+                    {
+                        if (proto->Quality == ITEM_QUALITY_POOR)
+                        {
+                            std::ostringstream out; out << ai->GetChatHelper()->formatItem(pItem->GetProto()) << " destroyed";
+                            sLog.outBasic("%s via DestroyAllGrayItemsAction", out.str());
+                            bot->DestroyItem(pItem->GetBagSlot(), pItem->GetSlot(), true);
+                            ai->TellPlayer(requester, out, PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+                            hasDestroyedAnyItems = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (int i = INVENTORY_SLOT_ITEM_START; i < INVENTORY_SLOT_ITEM_END; ++i)
+    {
+        if (Item* pItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, i))
+        {
+            if (const ItemPrototype* proto = pItem->GetProto())
+            {
+                if (proto->Quality == ITEM_QUALITY_POOR)
+                {
+                    std::ostringstream out; out << ai->GetChatHelper()->formatItem(pItem->GetProto()) << " destroyed";
+                    sLog.outBasic("%s via DestroyAllGrayItemsAction", out.str());
+                    bot->DestroyItem(pItem->GetBagSlot(), pItem->GetSlot(), true);
+                    ai->TellPlayer(requester, out, PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+
+                    hasDestroyedAnyItems = true;
+                }
+            }
+        }
+    }
+
+    return hasDestroyedAnyItems;
+}

--- a/playerbot/strategy/actions/DestroyItemAction.h
+++ b/playerbot/strategy/actions/DestroyItemAction.h
@@ -42,4 +42,23 @@ namespace ai
         virtual std::vector<std::string> GetUsedValues() { return { "bag space", "force item usage" }; }
 #endif
     };
+
+    class DestroyAllGrayItemsAction : public DestroyItemAction
+    {
+    public:
+        DestroyAllGrayItemsAction(PlayerbotAI* ai) : DestroyItemAction(ai, "destroy all gray") {}
+        virtual bool Execute(Event& event) override;
+        virtual bool isUseful() { return true; }
+
+#ifdef GenerateBotHelp
+        virtual std::string GetHelpName() { return "destroy all gray"; } //Must equal iternal name
+        virtual std::string GetHelpDescription()
+        {
+            return "This command will make the bot destroy all gray items.\n"
+                "Usage: destroy all gray\n";
+        }
+        virtual std::vector<std::string> GetUsedActions() { return {}; }
+        virtual std::vector<std::string> GetUsedValues() { return {}; }
+#endif
+    };
 }


### PR DESCRIPTION
fix crash when m_items in nullptr
moved DestroyAllGrayItemsInBags to DestroyAllGrayItemsAction 
fix incorrect usage of "bag space" in AddLootAction 
added DoSpecificAction("smart destroy") call for clearing bot inventory when it could loot quest items