### PR TITLE
added check for warlocks to keep at least 10 soul shards (previously they would not want to keep any at all)

### DIFF
--- a/playerbot/strategy/values/ItemUsageValue.cpp
+++ b/playerbot/strategy/values/ItemUsageValue.cpp
@@ -110,6 +110,10 @@ ItemUsage ItemUsageValue::Calculate()
     if (proto->ItemId == 6948)
         return ItemUsage::ITEM_USAGE_KEEP;
 
+    //WARLOCKS GOT TO KEEP SOULSHARDS (keep at least 10)
+    if (bot->getClass() == CLASS_WARLOCK && proto->ItemId == 6265 && CurrentStacks(ai, proto) <= 10)
+        return ItemUsage::ITEM_USAGE_KEEP;
+
     //SKILL
     if (ai->HasActivePlayerMaster())
     {


### PR DESCRIPTION
added check for warlocks to keep at least 10 soul shards (previously they would not want to keep any at all)