### PR TITLE
Alt bots learn dropped book spells

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -612,7 +612,8 @@ bool PlayerbotAIConfig::Initialize()
     autoPickTalents = config.GetStringDefault("AiPlayerbot.AutoPickTalents", "no");
     autoLearnTrainerSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnTrainerSpells", false);
     autoLearnQuestSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnQuestSpells", false);
-    autoDoQuests = config.GetBoolDefault("AiPlayerbot.AutoDoQuests", true);
+    autoLearnDroppedSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnDroppedSpells", false);
+    autoDoQuests = config.GetBoolDefault("AiPlayerbot.AutoDoQuests", false);
     syncLevelWithPlayers = config.GetBoolDefault("AiPlayerbot.SyncLevelWithPlayers", false);
     syncLevelMaxAbove = config.GetIntDefault("AiPlayerbot.SyncLevelMaxAbove", 5);
     syncLevelNoPlayer = config.GetIntDefault("AiPlayerbot.SyncLevelNoPlayer", randombotStartingLevel);

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -296,6 +296,7 @@ public:
     std::string autoPickTalents;
     bool autoLearnTrainerSpells;
     bool autoLearnQuestSpells;
+    bool autoLearnDroppedSpells;
     bool autoDoQuests;
     bool syncLevelWithPlayers;
     uint32 syncLevelMaxAbove, syncLevelNoPlayer;

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -333,6 +333,10 @@ AiPlayerbot.AutoLearnTrainerSpells = 0
 # Default: 0 (disabled)
 AiPlayerbot.AutoLearnQuestSpells = 0
 
+# Alt Bots automatically learn spells learned from drops at the required level.
+# Default: 0 (disabled)
+AiPlayerbot.AutoLearnDroppedSpells = 0
+
 # Random Bots will pick quests on their own and try to complete
 # Default: 0 (disabled)
 # AiPlayerbot.AutoDoQuests = 1

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -333,7 +333,7 @@ AiPlayerbot.AutoLearnTrainerSpells = 0
 # Default: 0 (disabled)
 AiPlayerbot.AutoLearnQuestSpells = 0
 
-# Alt Bots automatically learn spells learned from drops at the required level.
+# Alt Bots automatically learn class spells from books dropped from dungeons and raids when leveled and they reached the required level of the book.
 # Default: 0 (disabled)
 AiPlayerbot.AutoLearnDroppedSpells = 0
 

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -315,6 +315,10 @@ AiPlayerbot.AutoLearnTrainerSpells = 0
 # Default: 0 (disabled)
 AiPlayerbot.AutoLearnQuestSpells = 0
 
+# Alt Bots automatically learn class spells from books dropped from dungeons and raids when leveled and they reached the required level of the book. Classic Only.
+# Default: 0 (disabled)
+AiPlayerbot.AutoLearnDroppedSpells = 0
+
 # Random Bots will pick quests on their own and try to complete
 # Default: 0 (disabled)
 # AiPlayerbot.AutoDoQuests = 1

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -321,6 +321,10 @@ AiPlayerbot.AutoLearnTrainerSpells = 0
 # Default: 0 (disabled)
 AiPlayerbot.AutoLearnQuestSpells = 0
 
+# Alt Bots automatically learn class spells from books dropped from dungeons and raids when leveled and they reached the required level of the book. Classic Only.
+# Default: 0 (disabled)
+AiPlayerbot.AutoLearnDroppedSpells = 0
+
 # Random Bots will pick quests on their own and try to complete
 # Default: 0 (disabled)
 # AiPlayerbot.AutoDoQuests = 1

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -229,11 +229,17 @@ void AutoLearnSpellAction::LearnDroppedSpells(std::ostringstream* out)
     spellList[CLASS_DRUID][50] = { 21849 };
     spellList[CLASS_DRUID][60] = { 31018, 25297, 25299, 25298, 21850 };
     
-    for (uint32 spellId : spellList[bot->getClass()][bot->GetLevel()])
+    for (const auto& levelSpells : spellList[bot->getClass()])
     {
-        if (!bot->HasSpell(spellId))
+        if (bot->GetLevel() >= levelSpells.first)
         {
-            bot->learnSpell(spellId, false);
+            for (uint32 spellId : levelSpells.second)
+            {
+                if (!bot->HasSpell(spellId))
+                {
+                    bot->learnSpell(spellId, false);
+                }
+            }
         }
     }
 }

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -42,8 +42,10 @@ void AutoLearnSpellAction::LearnSpells(std::ostringstream* out)
     if (sPlayerbotAIConfig.autoLearnTrainerSpells)
         LearnTrainerSpells(out);
 
+#ifdef MANGOSBOT_ZERO
     if (sPlayerbotAIConfig.autoLearnDroppedSpells)
         LearnDroppedSpells(out);
+#endif
 
     if (!ai->HasActivePlayerMaster()) //Hunter spells for pets.
     {

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -207,6 +207,7 @@ void AutoLearnSpellAction::LearnQuestSpells(std::ostringstream* out)
         }
     }
 }
+
 void AutoLearnSpellAction::LearnDroppedSpells(std::ostringstream* out)
 {   //       Class       Level      // Spells
     std::map<uint8, std::map<uint8, std::vector<uint32>>> spellList;
@@ -227,7 +228,16 @@ void AutoLearnSpellAction::LearnDroppedSpells(std::ostringstream* out)
     spellList[CLASS_WARLOCK][60] = { 18540, 25311, 25309, 25307, 28610 };
     spellList[CLASS_DRUID][50] = { 21849 };
     spellList[CLASS_DRUID][60] = { 31018, 25297, 25299, 25298, 21850 };
+    
+    for (uint32 spellId : spellList[bot->getClass()][bot->GetLevel()])
+    {
+        if (!bot->HasSpell(spellId))
+        {
+            bot->learnSpell(spellId, false);
+        }
+    }
 }
+
 /**
 * Attempts to add the quest item
 * If the bot's bag is full report to player.

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -42,6 +42,9 @@ void AutoLearnSpellAction::LearnSpells(std::ostringstream* out)
     if (sPlayerbotAIConfig.autoLearnTrainerSpells)
         LearnTrainerSpells(out);
 
+    if (sPlayerbotAIConfig.autoLearnDroppedSpells)
+        LearnDroppedSpells(out);
+
     if (!ai->HasActivePlayerMaster()) //Hunter spells for pets.
     {
         if (bot->getClass() == CLASS_HUNTER && bot->GetLevel() >= 10)
@@ -203,6 +206,27 @@ void AutoLearnSpellAction::LearnQuestSpells(std::ostringstream* out)
             }
         }
     }
+}
+void AutoLearnSpellAction::LearnDroppedSpells(std::ostringstream* out)
+{   //       Class       Level      // Spells
+    std::map<uint8, std::map<uint8, std::vector<uint32>>> spellList;
+    spellList[CLASS_WARRIOR][60] = { 25289, 25288, 25286 };
+    spellList[CLASS_PALADIN][60] = { 25291, 25290, 25292 };
+    spellList[CLASS_HUNTER][60] = { 19801, 25296, 25294, 25295 };
+    spellList[CLASS_ROGUE][60] = { 25300, 25347, 25302, 31016 };
+    spellList[CLASS_PRIEST][48] = { 21562 };
+    // Spell 27683 Prayer of Shadow Protection https://www.wowhead.com/classic/spell=27683/prayer-of-shadow-protection book requires level 60, spell requires 56. 
+    // Went with the book requirement.
+    spellList[CLASS_PRIEST][60] = { 25314, 25315, 25316,21564,27683 };
+    spellList[CLASS_SHAMAN][60] = { 29228, 25359, 25357, 25361 };
+    spellList[CLASS_MAGE][56] = { 23028 };
+    // Spell 25345 Arcane Missiles https://www.wowhead.com/classic/spell=25345/arcane-missiles book requires level 60, spell requires 56.
+    // Went with the book requirement.
+    spellList[CLASS_MAGE][60] = { 28612, 28609, 25345, 25306, 25304, 28271 };
+    spellList[CLASS_WARLOCK][50] = { 1122 };
+    spellList[CLASS_WARLOCK][60] = { 18540, 25311, 25309, 25307, 28610 };
+    spellList[CLASS_DRUID][50] = { 21849 };
+    spellList[CLASS_DRUID][60] = { 31018, 25297, 25299, 25298, 21850 };
 }
 /**
 * Attempts to add the quest item

--- a/playerbot/strategy/actions/AutoLearnSpellAction.h
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.h
@@ -17,6 +17,7 @@ namespace ai
         void LearnSpells(std::ostringstream* out);
         void LearnTrainerSpells(std::ostringstream* out);
         void LearnQuestSpells(std::ostringstream* out);
+        void LearnDroppedSpells(std::ostringstream* out);
         void GetClassQuestItem(Quest const* quest, std::ostringstream* out);
         bool LearnSpell(uint32 spellId, std::ostringstream* out);
         bool LearnSpellFromSpell(uint32 spellId, std::ostringstream* out);


### PR DESCRIPTION
Allows alt bots to learn dropped book spells at the earliest level allowed by the book.