### PR TITLE
Alt bots learn dropped book spells (Correction)

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -613,7 +613,7 @@ bool PlayerbotAIConfig::Initialize()
     autoLearnTrainerSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnTrainerSpells", false);
     autoLearnQuestSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnQuestSpells", false);
     autoLearnDroppedSpells = config.GetBoolDefault("AiPlayerbot.AutoLearnDroppedSpells", false);
-    autoDoQuests = config.GetBoolDefault("AiPlayerbot.AutoDoQuests", false);
+    autoDoQuests = config.GetBoolDefault("AiPlayerbot.AutoDoQuests", true);
     syncLevelWithPlayers = config.GetBoolDefault("AiPlayerbot.SyncLevelWithPlayers", false);
     syncLevelMaxAbove = config.GetIntDefault("AiPlayerbot.SyncLevelMaxAbove", 5);
     syncLevelNoPlayer = config.GetIntDefault("AiPlayerbot.SyncLevelNoPlayer", randombotStartingLevel);

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -338,7 +338,7 @@ AiPlayerbot.AutoLearnQuestSpells = 0
 AiPlayerbot.AutoLearnDroppedSpells = 0
 
 # Random Bots will pick quests on their own and try to complete
-# Default: 0 (disabled)
+# Default: 1 (enabled)
 # AiPlayerbot.AutoDoQuests = 1
 
 ##################################################################################

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -320,7 +320,7 @@ AiPlayerbot.AutoLearnQuestSpells = 0
 AiPlayerbot.AutoLearnDroppedSpells = 0
 
 # Random Bots will pick quests on their own and try to complete
-# Default: 0 (disabled)
+# Default: 1 (enabled)
 # AiPlayerbot.AutoDoQuests = 1
 
 ##################################################################################

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -326,7 +326,7 @@ AiPlayerbot.AutoLearnQuestSpells = 0
 AiPlayerbot.AutoLearnDroppedSpells = 0
 
 # Random Bots will pick quests on their own and try to complete
-# Default: 0 (disabled)
+# Default: 1 (enabled)
 # AiPlayerbot.AutoDoQuests = 1
 
 ##################################################################################


### PR DESCRIPTION
Corrected accidental reversion of `PlayerbotAIConfig.cpp` `autoDoQuest` default. Was true, changed to false on accident, reverted back to true.

Updated `aiplayerbot.conf.dist.in`, `aiplayerbot.conf.dist.in.tbc`, and `aiplayerbot.conf.dist.in.wotlk` `AiPlayerbot.AutoDoQuests` descriptor to # Default: 1 (enabled)