### PR TITLE
Add configuration to Allow/deny multi-account alt bots

### DIFF
--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -758,6 +758,9 @@ AiPlayerbot.PremadeSpecLink.11.12.70 = 01-500232130322125331251-05503001
 # Allow/deny bots from your guild
 AiPlayerbot.AllowGuildBots = 1
 
+# Allow/deny bots from other player accounts (must have AiPlayerbot.AllowGuildBots activated and character on same guild)
+AiPlayerbot.AllowMultiAccountAltBots = 1
+
 # Delay between two short-time spells cast (Default 500)
 AiPlayerbot.GlobalCooldown = 1500
 

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -696,6 +696,9 @@ AiPlayerbot.PremadeSpecLink.11.8.80 = 05320001--230033312031512531153313051
 # Allow/deny bots from your guild
 AiPlayerbot.AllowGuildBots = 1
 
+# Allow/deny bots from other player accounts (must have AiPlayerbot.AllowGuildBots activated and character on same guild)
+AiPlayerbot.AllowMultiAccountAltBots = 1
+
 # Delay between two short-time spells cast (Default 500)
 AiPlayerbot.GlobalCooldown = 1500
 


### PR DESCRIPTION
This commit adds the missing configuration (tbc and wotlk config) `AiPlayerbot.AllowMultiAccountAltBots` to allow or deny the use of bots from multi-account or alternate characters. This was overlooked in the previous commit: https://github.com/cmangos/playerbots/commit/907f8d2bf78a50408bddf95fef30727c76808724.