### PR TITLE
Imbue Weapon: Add <=70 level check for weapon stones and oils

### DIFF
--- a/playerbot/strategy/actions/ImbueAction.cpp
+++ b/playerbot/strategy/actions/ImbueAction.cpp
@@ -50,7 +50,7 @@ bool ImbueWithStoneAction::Execute(Event& event)
     if (allowMainhand)
     {
         Item* mainWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-        if (mainWeapon && mainWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+        if (mainWeapon && mainWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
         {
             Item* stone = ai->FindStoneFor(mainWeapon);
             if (stone)
@@ -60,7 +60,7 @@ bool ImbueWithStoneAction::Execute(Event& event)
 
     // Offhand
     Item* secondaryWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    if (secondaryWeapon && secondaryWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+    if (secondaryWeapon && secondaryWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
     {
         Item* stone = ai->FindStoneFor(secondaryWeapon);
         if (stone)
@@ -99,7 +99,7 @@ bool ImbueWithStoneAction::isUseful()
 
     // Check Offhand always
     Item* secondaryWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    if (secondaryWeapon && secondaryWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+    if (secondaryWeapon && secondaryWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
     {
         if (ai->FindStoneFor(secondaryWeapon))
             return true;
@@ -109,7 +109,7 @@ bool ImbueWithStoneAction::isUseful()
     if (allowMainhand)
     {
         Item* mainWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-        if (mainWeapon && mainWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+        if (mainWeapon && mainWeapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
         {
             if (ai->FindStoneFor(mainWeapon))
                 return true;
@@ -135,7 +135,7 @@ bool ImbueWithOilAction::Execute(Event& event)
 
     // Search and apply oil to weapons
     Item* weapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+    if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
     {
         Item* oil = ai->FindOilFor(weapon);
         if (oil)
@@ -150,7 +150,7 @@ bool ImbueWithOilAction::Execute(Event& event)
 bool ImbueWithOilAction::isUseful()
 {
     Item* weapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0)
+    if (weapon && weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) == 0 && bot->GetLevel() <= 70)
     {
         if (ai->FindOilFor(weapon))
         {


### PR DESCRIPTION
Above level 70 weapon stones and oils are no more relevant, as WotLK didn't introduce +70lvl stones/oils and cannot be applied on weapons above 165ilvl.