### PR TITLE
feat: Initial structure for Playerbot AI RPC refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ set(LIBRARY_SRCS
     ${AHbot_Source}
     ${bots_PCH}
     ${CMAKE_CURRENT_SOURCE_DIR}/botpch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/playerbot/PlayerbotAI_rpc.cpp # Added RPC implementation file
+    ${CMAKE_CURRENT_SOURCE_DIR}/playerbot/PlayerbotRpcClientMgr.cpp # Added RPC Client Manager
 )
 
 #Strategy files
@@ -154,6 +156,64 @@ endif()
 
 add_library(${LIBRARY_NAME} STATIC ${LIBRARY_SRCS})
 
+# ==== Playerbot RPC Integration START ====
+if (BUILD_PLAYERBOTS)
+  find_package(Protobuf REQUIRED)
+  find_package(gRPC REQUIRED)
+
+  set(PLAYERBOT_PROTO_FILE ${CMAKE_CURRENT_SOURCE_DIR}/playerbot/rpc/playerbot_rpc.proto)
+  set(PLAYERBOT_PROTO_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/playerbot_rpc_generated)
+
+  add_custom_command(
+      OUTPUT
+          ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.pb.h
+          ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+          ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.h
+          ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${PLAYERBOT_PROTO_GENERATED_DIR}
+      COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+          --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/playerbot/rpc
+          --cpp_out=${PLAYERBOT_PROTO_GENERATED_DIR}
+          --grpc_out=${PLAYERBOT_PROTO_GENERATED_DIR}
+          --plugin=protoc-gen-grpc=`which grpc_cpp_plugin`
+          ${PLAYERBOT_PROTO_FILE}
+      DEPENDS ${PLAYERBOT_PROTO_FILE}
+      COMMENT "Generating Playerbot RPC C++ files from ${PLAYERBOT_PROTO_FILE}"
+  )
+
+  # Add generated source files to the library
+  target_sources(${LIBRARY_NAME} PRIVATE
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+  )
+
+  # Create a custom target for generating files to manage dependencies correctly
+  # This target will be depended upon by the main library.
+  add_custom_target(generate_playerbot_rpc_files ALL DEPENDS
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.pb.h
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.h
+      ${PLAYERBOT_PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+  )
+
+  # Ensure the library depends on the generation of these files
+  add_dependencies(${LIBRARY_NAME} generate_playerbot_rpc_files)
+
+  # Add include directory for generated headers to the library
+  target_include_directories(${LIBRARY_NAME}
+    PRIVATE ${PLAYERBOT_PROTO_GENERATED_DIR}
+  )
+
+  # Link gRPC and Protobuf libraries to the playerbots library
+  target_link_libraries(${LIBRARY_NAME}
+    PRIVATE
+      ${Protobuf_LIBRARIES}
+      gRPC::grpc++
+      gRPC::grpc++_reflection # Optional, but useful for debugging
+  )
+endif()
+# ==== Playerbot RPC Integration END ====
+
 target_link_libraries(${LIBRARY_NAME}
   PRIVATE shared
   PRIVATE Detour
@@ -168,10 +228,10 @@ target_include_directories(${LIBRARY_NAME}
 # Install config files
 if ( ${CMAKE_PROJECT_NAME} MATCHES "Classic")
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/playerbot/aiplayerbot.conf.dist.in ${CMAKE_CURRENT_BINARY_DIR}/aiplayerbot.conf.dist)
-endif()	
+endif()
 if ( ${CMAKE_PROJECT_NAME} MATCHES "TBC")
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/playerbot/aiplayerbot.conf.dist.in.tbc ${CMAKE_CURRENT_BINARY_DIR}/aiplayerbot.conf.dist)
-endif()	
+endif()
 if ( ${CMAKE_PROJECT_NAME} MATCHES "WoTLK")
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/playerbot/aiplayerbot.conf.dist.in.wotlk ${CMAKE_CURRENT_BINARY_DIR}/aiplayerbot.conf.dist)
 endif()

--- a/action_server/CMakeLists.txt
+++ b/action_server/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.10)
+project(ActionServer CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Protobuf
+find_package(Protobuf REQUIRED)
+
+# Find gRPC
+find_package(gRPC REQUIRED)
+
+# Add action_server executable
+add_executable(action_server src/main.cpp src/action_service_impl.cpp)
+
+# Include directories for Protobuf and gRPC generated files
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# Link libraries
+target_link_libraries(action_server
+    PRIVATE
+    ${Protobuf_LIBRARIES}
+    gRPC::grpc++
+    gRPC::grpc++_reflection # Optional, but useful for debugging
+)
+
+# Custom command to generate protobuf and gRPC C++ files
+# This assumes playerbot_rpc.proto is in the same directory as this CMakeLists.txt
+set(PROTO_FILE ${CMAKE_CURRENT_SOURCE_DIR}/playerbot_rpc.proto)
+set(PROTO_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(
+    OUTPUT
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.h
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.h
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROTO_GENERATED_DIR}
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+        --proto_path=${CMAKE_CURRENT_SOURCE_DIR}
+        --cpp_out=${PROTO_GENERATED_DIR}
+        --grpc_out=${PROTO_GENERATED_DIR}
+        --plugin=protoc-gen-grpc=`which grpc_cpp_plugin`
+        ${PROTO_FILE}
+    DEPENDS ${PROTO_FILE}
+    COMMENT "Generating Protobuf and gRPC C++ files from ${PROTO_FILE}"
+)
+
+# Add generated files to the action_server target sources
+target_sources(action_server
+    PRIVATE
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.h
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.h
+        ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+)
+
+# Ensure generated files are created before compiling action_server
+add_custom_target(generate_proto_files ALL DEPENDS
+    ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.h
+    ${PROTO_GENERATED_DIR}/playerbot_rpc.pb.cc
+    ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.h
+    ${PROTO_GENERATED_DIR}/playerbot_rpc.grpc.pb.cc
+)
+
+add_dependencies(action_server generate_proto_files)
+
+install(TARGETS action_server DESTINATION bin)

--- a/action_server/playerbot_rpc.proto
+++ b/action_server/playerbot_rpc.proto
@@ -1,0 +1,145 @@
+syntax = "proto3";
+
+package playerbot_rpc;
+
+// -------- Enums and Common Structures --------
+
+enum BotClass {
+  CLASS_UNKNOWN = 0;
+  WARRIOR = 1;
+  PALADIN = 2;
+  HUNTER = 3;
+  ROGUE = 4;
+  PRIEST = 5;
+  DEATH_KNIGHT = 6; // If applicable
+  SHAMAN = 7;
+  MAGE = 8;
+  WARLOCK = 9;
+  DRUID = 11;
+}
+
+enum BotRace {
+  RACE_UNKNOWN = 0;
+  HUMAN = 1;
+  ORC = 2;
+  DWARF = 3;
+  NIGHT_ELF = 4;
+  UNDEAD = 5;
+  TAUREN = 6;
+  GNOME = 7;
+  TROLL = 8;
+  GOBLIN = 9; // If applicable
+  BLOOD_ELF = 10; // If applicable
+  DRAENEI = 11; // If applicable
+}
+
+message Position {
+  float x = 1;
+  float y = 2;
+  float z = 3;
+  float orientation = 4;
+  uint32 map_id = 5;
+}
+
+message BotStats {
+  uint32 health = 1;
+  uint32 max_health = 2;
+  uint32 mana = 3; // Or other power type
+  uint32 max_mana = 4;
+  uint32 level = 5;
+  // Add other relevant stats like rage, energy, etc.
+}
+
+message Entity {
+  uint64 guid = 1;
+  string name = 2;
+  Position position = 3;
+  bool is_hostile = 4;
+  uint32 health_percent = 5;
+  // Add more entity details as needed (e.g., type, class for players)
+}
+
+message QuestObjective {
+  uint32 objective_id = 1;
+  string description = 2;
+  uint32 current_count = 3;
+  uint32 required_count = 4;
+  bool completed = 5;
+}
+
+message Quest {
+  uint32 quest_id = 1;
+  string title = 2;
+  string description = 3; // Short summary
+  uint32 level = 4;
+  repeated QuestObjective objectives = 5;
+  bool completed = 6;
+  bool is_active = 7; // Is it in the bot's quest log?
+}
+
+
+// -------- Action Server Service --------
+
+// Service for the Game Server to call the Action Server
+service ActionService {
+  // Requests a macro decision for a bot
+  rpc GetMacroDecision (MacroDecisionRequest) returns (MacroDecisionResponse);
+}
+
+message BotStateSnapshot {
+  uint64 bot_guid = 1;
+  BotClass bot_class = 2;
+  BotRace bot_race = 3;
+  Position current_position = 4;
+  BotStats current_stats = 5;
+  repeated Entity nearby_entities = 6; // Players, NPCs, objects
+  repeated Quest active_quests = 7;
+  // Add other relevant state: inventory highlights, current target, group members, etc.
+  bool is_in_combat = 8;
+  string current_strategy_non_combat = 9; // e.g. "grind", "quest", "travel"
+  string current_strategy_combat = 10;
+}
+
+message MacroDecisionRequest {
+  BotStateSnapshot bot_state = 1;
+}
+
+message MacroDecisionResponse {
+  enum DecisionType {
+    DECIDE_UNKNOWN = 0;
+    CONTINUE_CURRENT = 1; // Continue with whatever the game server is already doing
+    SET_STRATEGY = 2;     // Suggests a new high-level strategy
+    EXECUTE_COMMAND = 3;  // Suggests a specific command string for the bot
+    TRAVEL_TO = 4;        // Suggests traveling to a specific location
+    TARGET_ENTITY = 5;    // Suggests targeting a specific entity
+  }
+  DecisionType decision_type = 1;
+  string strategy_name = 2;     // if decision_type is SET_STRATEGY
+  string command_string = 3;    // if decision_type is EXECUTE_COMMAND
+  Position travel_position = 4; // if decision_type is TRAVEL_TO
+  uint64 target_guid = 5;       // if decision_type is TARGET_ENTITY
+  string justification = 6;     // Optional: why this decision was made
+}
+
+
+// -------- Game Server Service --------
+
+// Service for the Action Server (or other clients) to call the Game Server
+service GameControlService {
+  // Sends a command to a specific bot
+  rpc SendBotCommand (BotCommandRequest) returns (BotCommandResponse);
+
+  // Future: Could add methods to request specific information from the game server
+  // rpc GetBotDetails (GetBotDetailsRequest) returns (GetBotDetailsResponse);
+}
+
+message BotCommandRequest {
+  uint64 bot_guid = 1;
+  string command = 2; // The command string, similar to what's used in chat
+  // Potentially add an originator_id or auth_token for security/logging
+}
+
+message BotCommandResponse {
+  bool success = 1;
+  string message = 2; // e.g., "Command executed", "Bot not found", "Invalid command"
+}

--- a/action_server/src/action_service_impl.cpp
+++ b/action_server/src/action_service_impl.cpp
@@ -1,0 +1,32 @@
+#include "action_service_impl.h"
+#include <iostream> // For logging/debugging
+
+grpc::Status ActionServiceImpl::GetMacroDecision(
+    grpc::ServerContext* context,
+    const playerbot_rpc::MacroDecisionRequest* request,
+    playerbot_rpc::MacroDecisionResponse* response) {
+
+    // Log the request (basic example)
+    std::cout << "Received GetMacroDecision request for bot GUID: " << request->bot_state().bot_guid() << std::endl;
+    if (request->has_bot_state() && request->bot_state().has_current_position()) {
+        std::cout << "  Bot Position: map_id=" << request->bot_state().current_position().map_id()
+                  << ", x=" << request->bot_state().current_position().x()
+                  << ", y=" << request->bot_state().current_position().y()
+                  << ", z=" << request->bot_state().current_position().z() << std::endl;
+    }
+
+    // Placeholder logic: Always tell the bot to continue its current action.
+    // In a real implementation, this is where the AI decision-making would happen.
+    response->set_decision_type(playerbot_rpc::MacroDecisionResponse::CONTINUE_CURRENT);
+    response->set_justification("Action server received request, placeholder: continue.");
+
+    // Example of how to set a different decision:
+    /*
+    response->set_decision_type(playerbot_rpc::MacroDecisionResponse::SET_STRATEGY);
+    response->set_strategy_name("grind");
+    response->set_justification("Action server suggests grinding.");
+    */
+
+    std::cout << "Sending MacroDecisionResponse: CONTINUE_CURRENT" << std::endl;
+    return grpc::Status::OK;
+}

--- a/action_server/src/action_service_impl.h
+++ b/action_server/src/action_service_impl.h
@@ -1,0 +1,15 @@
+#ifndef ACTION_SERVICE_IMPL_H
+#define ACTION_SERVICE_IMPL_H
+
+#include "playerbot_rpc.grpc.pb.h" // Generated from playerbot_rpc.proto
+#include <grpcpp/grpcpp.h>
+
+class ActionServiceImpl final : public playerbot_rpc::ActionService::Service {
+public:
+    grpc::Status GetMacroDecision(
+        grpc::ServerContext* context,
+        const playerbot_rpc::MacroDecisionRequest* request,
+        playerbot_rpc::MacroDecisionResponse* response) override;
+};
+
+#endif // ACTION_SERVICE_IMPL_H

--- a/action_server/src/main.cpp
+++ b/action_server/src/main.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include <string>
+#include <grpcpp/grpcpp.h>
+#include "action_service_impl.h" // Our service implementation
+
+void RunServer() {
+    std::string server_address("0.0.0.0:50051"); // Listen on all interfaces, port 50051
+    ActionServiceImpl service;
+
+    grpc::ServerBuilder builder;
+    // Listen on the given address without any authentication mechanism.
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    // Register "service" as the instance through which we'll communicate with
+    // clients. In this case it corresponds to an *synchronous* service.
+    builder.RegisterService(&service);
+
+    // Finally assemble the server.
+    std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+    std::cout << "Action Server listening on " << server_address << std::endl;
+
+    // Wait for the server to shutdown. Note that some other thread must be
+    // responsible for shutting down the server for this call to ever return.
+    server->Wait();
+}
+
+int main(int argc, char** argv) {
+    // Initialize any global state or configurations here if needed
+    // For example, connecting to Redis, loading AI models, etc.
+
+    RunServer();
+    return 0;
+}

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -17,6 +17,8 @@
 #include "LootObjectStack.h"
 #include "playerbot/PlayerbotAIConfig.h"
 #include "PlayerbotAI.h"
+#include "PlayerbotRpcClient.h"     // Added for RPC client
+#include "rpc/playerbot_rpc.pb.h"   // Added for protobuf message types
 #include "playerbot/PlayerbotFactory.h"
 #include "PlayerbotSecurity.h"
 #include "Groups/Group.h"
@@ -125,6 +127,8 @@ PlayerbotAI::PlayerbotAI() : PlayerbotAIBase(), bot(NULL), aiObjectContext(NULL)
 PlayerbotAI::PlayerbotAI(Player* bot) :
     PlayerbotAIBase(), chatHelper(this), chatFilter(this), security(bot), master(NULL), faceTargetUpdateDelay(0), jumpTime(0), fallAfterJump(false)
 {
+    InitRpcClient(); // Ensure RPC Client is initialized
+
     this->bot = bot;
     if (!bot->isTaxiCheater() && HasCheat(BotCheatMask::taxi))
         bot->SetTaxiCheater(true);

--- a/playerbot/PlayerbotAI.h
+++ b/playerbot/PlayerbotAI.h
@@ -13,8 +13,13 @@
 #include "strategy/IterateItemsMask.h"
 #include "RandomPlayerbotMgr.h"
 
+#include <memory> // For std::unique_ptr
+
+// Forward declarations
 class Player;
 class PlayerbotMgr;
+class PlayerbotRpcClient;
+namespace playerbot_rpc { class BotStateSnapshot; class MacroDecisionResponse; } // Forward declare protobuf messages
 class ChatHandler;
 
 using namespace ai;
@@ -712,6 +717,22 @@ protected:
 #ifdef BUILD_ELUNA
     MaNGOS::unique_weak_ptr<PlayerbotAI> m_weakRef;
 #endif
+
+    // RPC Client
+    std::unique_ptr<PlayerbotRpcClient> rpcClient;
+
+private:
+    void InitRpcClient();
+    bool ShouldUseRpcForDecision();
+    bool ProcessRpcDecision(); // Returns true if RPC provided a new action that was taken
+    void PopulateBotStateSnapshot(playerbot_rpc::BotStateSnapshot* snapshot); // Helper to fill snapshot
+
+    // GameControlService (RPC Server on Game Server) related
+    void StartRpcService(); // To start the gRPC server for GameControlService
+    void StopRpcService();  // To stop it
+    // Placeholder for the gRPC server instance for GameControlService
+    // std::unique_ptr<grpc::Server> gameControlServer;
+    // Actual implementation of GameControlServiceImpl would also be needed.
 };
 
 template<typename T>

--- a/playerbot/PlayerbotAI_rpc.cpp
+++ b/playerbot/PlayerbotAI_rpc.cpp
@@ -1,0 +1,260 @@
+#include "PlayerbotAI.h"
+#include "PlayerbotRpcClient.h"
+#include "PlayerbotRpcClientMgr.h" // Added for the manager
+#include "playerbot/PlayerbotAIConfig.h"
+#include "playerbot/ServerFacade.h"
+#include "Entities/Player.h"
+#include "Entities/Unit.h"
+#include "QuestDef.h"
+#include "ObjectGuid.h"
+#include "rpc/playerbot_rpc.pb.h"
+#include "Logging/Log.h"
+#include "strategy/AiObjectContext.h"
+#include "strategy/values/ValueContext.h"
+
+// RPC related methods
+void PlayerbotAI::InitRpcClient()
+{
+    // The PlayerbotRpcClientMgr should be initialized globally once,
+    // for example, when the PlayerbotAIConfig is loaded or the server starts.
+    // We ensure it's initialized here if needed, but this might log repeatedly if called per bot
+    // without a proper global initialization point.
+    if (!sPlayerbotRpcClientMgr.IsInitialized() && !sPlayerbotAIConfig.actionServerAddress.empty()) {
+        sPlayerbotRpcClientMgr.Initialize(sPlayerbotAIConfig.actionServerAddress);
+    }
+
+    if (sPlayerbotRpcClientMgr.IsInitialized())
+    {
+        playerbot_rpc::ActionService::StubInterface* stub = sPlayerbotRpcClientMgr.GetClientStub();
+        if (stub)
+        {
+            try
+            {
+                // Note: rpcClient is std::unique_ptr<PlayerbotRpcClient>
+                rpcClient = std::make_unique<PlayerbotRpcClient>(this, stub);
+                if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+                    std::ostringstream out;
+                    out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+                    out << GetBot()->GetName() << ",INFO,PlayerbotAI,InitRpcClient: PlayerbotRpcClient wrapper created using shared stub for bot.";
+                    sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+                }
+            }
+            catch (const std::exception& e)
+            {
+                 if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+                    std::ostringstream out;
+                    out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+                    out << GetBot()->GetName() << ",ERROR,PlayerbotAI,InitRpcClient: Exception while creating PlayerbotRpcClient wrapper: " << e.what();
+                    sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+                }
+                rpcClient.reset();
+            }
+        }
+        else
+        {
+            if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+                std::ostringstream out;
+                out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+                out << GetBot()->GetName() << ",ERROR,PlayerbotAI,InitRpcClient: Failed to get client stub from PlayerbotRpcClientMgr for bot.";
+                sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+            }
+            rpcClient.reset();
+        }
+    }
+    else
+    {
+        if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+            std::ostringstream out;
+            out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+            out << GetBot()->GetName() << ",INFO,PlayerbotAI,InitRpcClient: PlayerbotRpcClientMgr not initialized. RPC client not created for bot.";
+            sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+        }
+        rpcClient.reset();
+    }
+}
+
+bool PlayerbotAI::ShouldUseRpcForDecision()
+{
+    return rpcClient != nullptr && sPlayerbotAIConfig.enableActionServerDecisionMaking;
+}
+
+void PlayerbotAI::PopulateBotStateSnapshot(playerbot_rpc::BotStateSnapshot* snapshot)
+{
+    if (!snapshot || !bot) return;
+
+    snapshot->set_bot_guid(bot->GetObjectGuid().GetRawValue());
+
+    snapshot->set_bot_class(static_cast<playerbot_rpc::BotClass>(bot->getClass()));
+    snapshot->set_bot_race(static_cast<playerbot_rpc::BotRace>(bot->getRace()));
+
+    playerbot_rpc::Position* current_pos = snapshot->mutable_current_position();
+    current_pos->set_x(bot->GetPositionX());
+    current_pos->set_y(bot->GetPositionY());
+    current_pos->set_z(bot->GetPositionZ());
+    current_pos->set_orientation(bot->GetOrientation());
+    current_pos->set_map_id(bot->GetMapId());
+
+    playerbot_rpc::BotStats* stats = snapshot->mutable_current_stats();
+    stats->set_health(bot->GetHealth());
+    stats->set_max_health(bot->GetMaxHealth());
+    stats->set_mana(bot->GetPower(POWER_MANA));
+    stats->set_max_mana(bot->GetMaxPower(POWER_MANA));
+    stats->set_level(bot->GetLevel());
+
+    snapshot->set_is_in_combat(sServerFacade.IsInCombat(bot));
+
+    if (Unit* currentTarget = GetAiObjectContext()->GetValue<Unit*>("current target")->Get()) {
+        playerbot_rpc::Entity* entity_proto = snapshot->add_nearby_entities();
+        entity_proto->set_guid(currentTarget->GetObjectGuid().GetRawValue());
+        entity_proto->set_name(currentTarget->GetName());
+        entity_proto->mutable_position()->set_x(currentTarget->GetPositionX());
+        entity_proto->mutable_position()->set_y(currentTarget->GetPositionY());
+        entity_proto->mutable_position()->set_z(currentTarget->GetPositionZ());
+        entity_proto->mutable_position()->set_map_id(currentTarget->GetMapId());
+        entity_proto->set_is_hostile(sServerFacade.IsHostileTo(bot, currentTarget));
+        entity_proto->set_health_percent(GetHealthPercent(*currentTarget));
+    }
+
+    for (uint16 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot) {
+        uint32 questId = bot->GetQuestSlotQuestId(slot);
+        if (!questId) continue;
+
+        const Quest* qTemplate = sObjectMgr.GetQuestTemplate(questId);
+        if (!qTemplate) continue;
+
+        playerbot_rpc::Quest* quest_proto = snapshot->add_active_quests();
+        quest_proto->set_quest_id(qTemplate->GetQuestId());
+        quest_proto->set_title(qTemplate->GetTitle());
+        quest_proto->set_level(qTemplate->GetQuestLevel());
+        quest_proto->set_is_active(true);
+        quest_proto->set_completed(bot->GetQuestStatus(questId) == QUEST_STATUS_COMPLETE);
+
+        QuestStatusData qStatus = bot->getQuestStatusMap()[questId];
+        for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i) {
+            if (qTemplate->ReqCreatureOrGOId[i] != 0 || qTemplate->ReqItemId[i] != 0) {
+                 playerbot_rpc::QuestObjective* obj_proto = quest_proto->add_objectives();
+                 obj_proto->set_description(qTemplate->ObjectiveText[i]);
+
+                if (qTemplate->ReqCreatureOrGOId[i] != 0) {
+                    obj_proto->set_current_count(qStatus.m_creatureOrGOcount[i]);
+                    obj_proto->set_required_count(qTemplate->ReqCreatureOrGOCount[i]);
+                    obj_proto->set_completed(qStatus.m_creatureOrGOcount[i] >= qTemplate->ReqCreatureOrGOCount[i]);
+                } else if (qTemplate->ReqItemId[i] != 0) {
+                    obj_proto->set_current_count(qStatus.m_itemcount[i]);
+                    obj_proto->set_required_count(qTemplate->ReqItemCount[i]);
+                    obj_proto->set_completed(qStatus.m_itemcount[i] >= qTemplate->ReqItemCount[i]);
+                }
+            }
+        }
+    }
+
+    if (engines[(uint8)BotState::BOT_STATE_NON_COMBAT]) {
+        std::list<std::string_view> strats = engines[(uint8)BotState::BOT_STATE_NON_COMBAT]->GetStrategies();
+        if (!strats.empty()) snapshot->set_current_strategy_non_combat(std::string(strats.front()));
+    }
+    if (engines[(uint8)BotState::BOT_STATE_COMBAT]) {
+         std::list<std::string_view> strats = engines[(uint8)BotState::BOT_STATE_COMBAT]->GetStrategies();
+        if (!strats.empty()) snapshot->set_current_strategy_combat(std::string(strats.front()));
+    }
+
+    if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+        std::ostringstream out;
+        out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+        out << GetBot()->GetName() << ",DEBUG,PlayerbotAI,PopulateBotStateSnapshot: Snapshot populated for bot.";
+        sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+    }
+}
+
+bool PlayerbotAI::ProcessRpcDecision()
+{
+    if (!ShouldUseRpcForDecision()) return false;
+
+    playerbot_rpc::BotStateSnapshot snapshot;
+    PopulateBotStateSnapshot(&snapshot);
+
+    playerbot_rpc::MacroDecisionResponse response;
+    if (rpcClient && rpcClient->GetMacroDecision(snapshot, &response))
+    {
+        if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+            std::ostringstream out;
+            out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+            out << GetBot()->GetName() << ",INFO,PlayerbotAI,ProcessRpcDecision: Received decision type " << response.decision_type()
+                << ". Justification: " << response.justification();
+            sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+        }
+
+        if (sPlayerbotAIConfig.enableDebugWhispers && master && bot) {
+            std::string decision_text = "RPC Decision (" + bot->GetName() + "): " + std::to_string(response.decision_type()) + " - " + response.justification();
+            TellPlayer(master, decision_text , PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false, true);
+        }
+
+        switch (response.decision_type())
+        {
+            case playerbot_rpc::MacroDecisionResponse::SET_STRATEGY:
+                if (!response.strategy_name().empty())
+                {
+                    BotState stateToApply = sServerFacade.IsInCombat(bot) ? BotState::BOT_STATE_COMBAT : BotState::BOT_STATE_NON_COMBAT;
+                    ChangeStrategy(response.strategy_name(), stateToApply);
+                    ResetAIInternalUpdateDelay();
+                    return true;
+                }
+                break;
+            case playerbot_rpc::MacroDecisionResponse::EXECUTE_COMMAND:
+                if (!response.command_string().empty())
+                {
+                    HandleCommand(CHAT_MSG_WHISPER , response.command_string(), *master);
+                    ResetAIInternalUpdateDelay();
+                    return true;
+                }
+                break;
+            case playerbot_rpc::MacroDecisionResponse::TRAVEL_TO:
+                if (response.has_travel_position()) {
+                    const auto& pos = response.travel_position();
+                    std::ostringstream travelCmd;
+                    travelCmd << "travel " << pos.x() << " " << pos.y() << " " << pos.z();
+                    // Map ID handling for travel needs to be robust in the actual "travel" action.
+                    // For now, we assume current map if map_id in response is 0 or matches current.
+                    // If map_id is different, the travel action needs to handle cross-map travel (e.g. using teleporter or flight paths).
+                    HandleCommand(CHAT_MSG_WHISPER , travelCmd.str(), *master);
+                    ResetAIInternalUpdateDelay();
+                    return true;
+                }
+                break;
+            case playerbot_rpc::MacroDecisionResponse::TARGET_ENTITY:
+                if (response.target_guid() != 0)
+                {
+                    ObjectGuid newTargetGuid(response.target_guid());
+                    Unit* newTarget = GetUnit(newTargetGuid);
+                    if (newTarget) {
+                        bot->SetSelectionGuid(newTargetGuid);
+                        GetAiObjectContext()->GetValue<Unit*>("current target")->Set(newTarget);
+                        ResetAIInternalUpdateDelay();
+                    }
+                    return true;
+                }
+                break;
+            case playerbot_rpc::MacroDecisionResponse::CONTINUE_CURRENT:
+            case playerbot_rpc::MacroDecisionResponse::DECIDE_UNKNOWN:
+            default:
+                return false;
+        }
+    }
+    else if (rpcClient)
+    {
+        if (bot && master && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+             std::ostringstream out;
+             out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+             out << GetBot()->GetName() << ",ERROR,PlayerbotAI,ProcessRpcDecision: GetMacroDecision RPC call failed to " << sPlayerbotAIConfig.actionServerAddress;
+             sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+        }
+    }
+    return false;
+}
+
+void PlayerbotAI::StartRpcService() {
+    sLog.outBasic("PlayerbotAI %s: StartRpcService stub called. GameControlService server not implemented in this step.", bot ? bot->GetName() : "UNKNOWN_BOT");
+}
+
+void PlayerbotAI::StopRpcService() {
+    sLog.outBasic("PlayerbotAI %s: StopRpcService stub called.", bot ? bot->GetName() : "UNKNOWN_BOT");
+}

--- a/playerbot/PlayerbotRpcClient.cpp
+++ b/playerbot/PlayerbotRpcClient.cpp
@@ -1,0 +1,72 @@
+#include "PlayerbotRpcClient.h"
+#include "PlayerbotAI.h"       // For PlayerbotAI context, logging
+#include "PlayerbotAIConfig.h" // For potential config values like server address
+
+// Constructor
+PlayerbotRpcClient::PlayerbotRpcClient(ai::PlayerbotAI* ai, playerbot_rpc::ActionService::StubInterface* stub)
+    : botAI(ai), stub_(stub) {
+    // The stub is now passed in, presumably from PlayerbotRpcClientMgr
+    if (botAI && botAI->GetMaster() && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+        std::ostringstream out;
+        out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+        out << botAI->GetBot()->GetName() << ",INFO,PlayerbotRpcClient,PlayerbotRpcClient wrapper created, using shared stub.";
+        sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+    }
+}
+
+// Method to request a macro decision from the action server
+bool PlayerbotRpcClient::GetMacroDecision(
+    const playerbot_rpc::BotStateSnapshot& snapshot,
+    playerbot_rpc::MacroDecisionResponse* rpc_response) {
+
+    if (!stub_) { // Check if the provided stub is valid
+        if (botAI && botAI->GetMaster() && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+            std::ostringstream out;
+            out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+            out << botAI->GetBot()->GetName() << ",ERROR,PlayerbotRpcClient,GetMacroDecision: RPC stub is NULL.";
+            sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+        }
+        return false;
+    }
+
+    playerbot_rpc::MacroDecisionRequest request;
+    request.mutable_bot_state()->CopyFrom(snapshot);
+
+    grpc::ClientContext context;
+    // Set a deadline for the RPC call (e.g., 500 milliseconds)
+    std::chrono::system_clock::time_point deadline =
+        std::chrono::system_clock::now() + std::chrono::milliseconds(sPlayerbotAIConfig.actionServerRpcTimeoutMs); // Configurable timeout
+    context.set_deadline(deadline);
+
+    grpc::Status status = stub_->GetMacroDecision(&context, request, rpc_response);
+
+    if (status.ok()) {
+        if (botAI && botAI->GetMaster() && sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+            std::ostringstream out;
+            out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+            out << botAI->GetBot()->GetName() << ",INFO,PlayerbotRpcClient,GetMacroDecision: Success. Decision: " << rpc_response->decision_type();
+            if (!rpc_response->justification().empty()) {
+                out << " Justification: " << rpc_response->justification();
+            }
+            sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+        }
+        return true;
+    } else {
+        if (botAI && botAI->GetMaster()) { // Check botAI and master to prevent crashes if they are null
+             if (sPlayerbotAIConfig.hasLog("bot_rpc_client.csv")) {
+                std::ostringstream out;
+                out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
+                out << botAI->GetBot()->GetName() << ",ERROR,PlayerbotRpcClient,GetMacroDecision: RPC failed. Error code: " << status.error_code()
+                    << ", message: " << status.error_message();
+                sPlayerbotAIConfig.log("bot_rpc_client.csv", out.str().c_str());
+            }
+            // Optionally, tell the player master about the error if debugging is enabled
+            if (sPlayerbotAIConfig.enableDebugWhispers) {
+                 std::ostringstream debugMsg;
+                 debugMsg << "RPC Error: " << status.error_message() << " (Code: " << status.error_code() << ")";
+                 botAI->TellPlayer(botAI->GetMaster(), debugMsg.str(), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false, true);
+            }
+        }
+        return false;
+    }
+}

--- a/playerbot/PlayerbotRpcClient.h
+++ b/playerbot/PlayerbotRpcClient.h
@@ -1,0 +1,25 @@
+#ifndef PLAYERBOTRPCCLIENT_H
+#define PLAYERBOTRPCCLIENT_H
+
+#include "rpc/playerbot_rpc.grpc.pb.h" // Generated gRPC file
+#include <grpcpp/grpcpp.h>
+#include <memory>
+#include <string>
+
+// Forward declaration
+namespace ai { class PlayerbotAI; }
+
+class PlayerbotRpcClient {
+public:
+    // Constructor now takes the existing stub from the manager
+    PlayerbotRpcClient(ai::PlayerbotAI* ai, playerbot_rpc::ActionService::StubInterface* stub);
+
+    // Method to request a macro decision from the action server
+    bool GetMacroDecision(const playerbot_rpc::BotStateSnapshot& snapshot, playerbot_rpc::MacroDecisionResponse* response);
+
+private:
+    ai::PlayerbotAI* botAI; // Reference to the bot's AI instance for context
+    playerbot_rpc::ActionService::StubInterface* stub_; // Now a raw pointer to the shared stub
+};
+
+#endif // PLAYERBOTRPCCLIENT_H

--- a/playerbot/PlayerbotRpcClientMgr.cpp
+++ b/playerbot/PlayerbotRpcClientMgr.cpp
@@ -1,0 +1,101 @@
+#include "PlayerbotRpcClientMgr.h"
+#include "playerbot/PlayerbotAIConfig.h" // For sLog and config access
+#include "Logging/Log.h"                 // For sLog access (if not in PlayerbotAIConfig.h)
+
+PlayerbotRpcClientMgr::PlayerbotRpcClientMgr() : initialized_(false) {
+    // Constructor can be light, initialization happens in Initialize()
+}
+
+PlayerbotRpcClientMgr::~PlayerbotRpcClientMgr() {
+    // Cleanup if necessary, though shared_ptr and unique_ptr handle memory.
+    // If channel needed explicit shutdown, it would go here.
+}
+
+PlayerbotRpcClientMgr& PlayerbotRpcClientMgr::instance() {
+    static PlayerbotRpcClientMgr instance;
+    return instance;
+}
+
+void PlayerbotRpcClientMgr::Initialize(const std::string& server_address) {
+    std::lock_guard<std::mutex> lock(init_mutex_);
+    if (initialized_) {
+        // Already initialized, perhaps log or decide if re-initialization is allowed/needed
+        if (server_address_ != server_address) {
+            sLog.outString("PlayerbotRpcClientMgr: Attempting to re-initialize with a new address. Current: %s, New: %s",
+                           server_address_.c_str(), server_address.c_str());
+            // Potentially tear down old channel/stub and recreate
+            // For now, let's just log and prevent re-init with different address easily
+             stub_.reset();
+             channel_.reset();
+             initialized_ = false;
+        } else {
+            sLog.outString("PlayerbotRpcClientMgr: Already initialized with address %s.", server_address.c_str());
+            return;
+        }
+    }
+
+    if (server_address.empty()) {
+        sLog.outString("PlayerbotRpcClientMgr: Server address is empty. RPC client will not be initialized.");
+        server_address_ = "";
+        initialized_ = false; // Mark as not successfully initialized
+        stub_.reset();
+        channel_.reset();
+        return;
+    }
+
+    server_address_ = server_address;
+    sLog.outString("PlayerbotRpcClientMgr: Initializing RPC client for Action Server at %s", server_address_.c_str());
+
+    try {
+        channel_ = grpc::CreateChannel(server_address_, grpc::InsecureChannelCredentials());
+        if (!channel_) {
+            sLog.outError("PlayerbotRpcClientMgr: Failed to create gRPC channel to %s.", server_address_.c_str());
+            initialized_ = false;
+            return;
+        }
+
+        // You might want to check channel connectivity here, e.g., channel_->GetState(true)
+        // or wait for ready with a timeout, though stub creation itself doesn't guarantee connection.
+        // grpc::ClientContext context;
+        // std::chrono::system_clock::time_point deadline = std::chrono::system_clock::now() + std::chrono::seconds(5);
+        // channel_->WaitForConnected(deadline);
+
+
+        stub_ = playerbot_rpc::ActionService::NewStub(channel_);
+        if (!stub_) {
+            sLog.outError("PlayerbotRpcClientMgr: Failed to create gRPC stub for ActionService.");
+            channel_.reset();
+            initialized_ = false;
+            return;
+        }
+        initialized_ = true;
+        sLog.outString("PlayerbotRpcClientMgr: Successfully initialized and created stub for Action Server at %s", server_address_.c_str());
+    } catch (const std::exception& e) {
+        sLog.outError("PlayerbotRpcClientMgr: Exception during initialization for %s: %s", server_address_.c_str(), e.what());
+        stub_.reset();
+        channel_.reset();
+        initialized_ = false;
+    }
+}
+
+bool PlayerbotRpcClientMgr::IsInitialized() const {
+    return initialized_ && stub_ != nullptr;
+}
+
+playerbot_rpc::ActionService::StubInterface* PlayerbotRpcClientMgr::GetClientStub() {
+    if (!IsInitialized()) {
+        // Attempt to re-initialize if not already initialized and address is known
+        if (!server_address_.empty()) {
+            sLog.outString("PlayerbotRpcClientMgr::GetClientStub: Stub not ready, attempting to re-initialize to %s", server_address_.c_str());
+            Initialize(server_address_); // This will re-check initialized_ flag internally
+            if(!IsInitialized()) {
+                 sLog.outError("PlayerbotRpcClientMgr::GetClientStub: Re-initialization failed.");
+                 return nullptr;
+            }
+        } else {
+            sLog.outError("PlayerbotRpcClientMgr::GetClientStub: Manager not initialized and no server address known.");
+            return nullptr;
+        }
+    }
+    return stub_.get();
+}

--- a/playerbot/PlayerbotRpcClientMgr.h
+++ b/playerbot/PlayerbotRpcClientMgr.h
@@ -1,0 +1,41 @@
+#ifndef PLAYERBOTRPCCLIENTMGR_H
+#define PLAYERBOTRPCCLIENTMGR_H
+
+#include "rpc/playerbot_rpc.grpc.pb.h" // Generated gRPC file
+#include <grpcpp/grpcpp.h>
+#include <memory>
+#include <string>
+#include <mutex>
+
+// Singleton class to manage the gRPC channel and stub for the ActionService
+class PlayerbotRpcClientMgr {
+public:
+    static PlayerbotRpcClientMgr& instance();
+
+    // Call this during server startup or when config is loaded
+    void Initialize(const std::string& server_address);
+    bool IsInitialized() const;
+
+    // Provides access to the client stub
+    // Returns nullptr if not initialized or connection failed
+    playerbot_rpc::ActionService::StubInterface* GetClientStub();
+
+private:
+    PlayerbotRpcClientMgr(); // Private constructor for singleton
+    ~PlayerbotRpcClientMgr();
+
+    // Delete copy constructor and assignment operator
+    PlayerbotRpcClientMgr(const PlayerbotRpcClientMgr&) = delete;
+    PlayerbotRpcClientMgr& operator=(const PlayerbotRpcClientMgr&) = delete;
+
+    std::shared_ptr<grpc::Channel> channel_;
+    std::unique_ptr<playerbot_rpc::ActionService::StubInterface> stub_;
+
+    bool initialized_ = false;
+    std::string server_address_;
+    std::mutex init_mutex_;
+};
+
+#define sPlayerbotRpcClientMgr PlayerbotRpcClientMgr::instance()
+
+#endif // PLAYERBOTRPCCLIENTMGR_H

--- a/playerbot/rpc/playerbot_rpc.proto
+++ b/playerbot/rpc/playerbot_rpc.proto
@@ -1,0 +1,145 @@
+syntax = "proto3";
+
+package playerbot_rpc;
+
+// -------- Enums and Common Structures --------
+
+enum BotClass {
+  CLASS_UNKNOWN = 0;
+  WARRIOR = 1;
+  PALADIN = 2;
+  HUNTER = 3;
+  ROGUE = 4;
+  PRIEST = 5;
+  DEATH_KNIGHT = 6; // If applicable
+  SHAMAN = 7;
+  MAGE = 8;
+  WARLOCK = 9;
+  DRUID = 11;
+}
+
+enum BotRace {
+  RACE_UNKNOWN = 0;
+  HUMAN = 1;
+  ORC = 2;
+  DWARF = 3;
+  NIGHT_ELF = 4;
+  UNDEAD = 5;
+  TAUREN = 6;
+  GNOME = 7;
+  TROLL = 8;
+  GOBLIN = 9; // If applicable
+  BLOOD_ELF = 10; // If applicable
+  DRAENEI = 11; // If applicable
+}
+
+message Position {
+  float x = 1;
+  float y = 2;
+  float z = 3;
+  float orientation = 4;
+  uint32 map_id = 5;
+}
+
+message BotStats {
+  uint32 health = 1;
+  uint32 max_health = 2;
+  uint32 mana = 3; // Or other power type
+  uint32 max_mana = 4;
+  uint32 level = 5;
+  // Add other relevant stats like rage, energy, etc.
+}
+
+message Entity {
+  uint64 guid = 1;
+  string name = 2;
+  Position position = 3;
+  bool is_hostile = 4;
+  uint32 health_percent = 5;
+  // Add more entity details as needed (e.g., type, class for players)
+}
+
+message QuestObjective {
+  uint32 objective_id = 1;
+  string description = 2;
+  uint32 current_count = 3;
+  uint32 required_count = 4;
+  bool completed = 5;
+}
+
+message Quest {
+  uint32 quest_id = 1;
+  string title = 2;
+  string description = 3; // Short summary
+  uint32 level = 4;
+  repeated QuestObjective objectives = 5;
+  bool completed = 6;
+  bool is_active = 7; // Is it in the bot's quest log?
+}
+
+
+// -------- Action Server Service --------
+
+// Service for the Game Server to call the Action Server
+service ActionService {
+  // Requests a macro decision for a bot
+  rpc GetMacroDecision (MacroDecisionRequest) returns (MacroDecisionResponse);
+}
+
+message BotStateSnapshot {
+  uint64 bot_guid = 1;
+  BotClass bot_class = 2;
+  BotRace bot_race = 3;
+  Position current_position = 4;
+  BotStats current_stats = 5;
+  repeated Entity nearby_entities = 6; // Players, NPCs, objects
+  repeated Quest active_quests = 7;
+  // Add other relevant state: inventory highlights, current target, group members, etc.
+  bool is_in_combat = 8;
+  string current_strategy_non_combat = 9; // e.g. "grind", "quest", "travel"
+  string current_strategy_combat = 10;
+}
+
+message MacroDecisionRequest {
+  BotStateSnapshot bot_state = 1;
+}
+
+message MacroDecisionResponse {
+  enum DecisionType {
+    DECIDE_UNKNOWN = 0;
+    CONTINUE_CURRENT = 1; // Continue with whatever the game server is already doing
+    SET_STRATEGY = 2;     // Suggests a new high-level strategy
+    EXECUTE_COMMAND = 3;  // Suggests a specific command string for the bot
+    TRAVEL_TO = 4;        // Suggests traveling to a specific location
+    TARGET_ENTITY = 5;    // Suggests targeting a specific entity
+  }
+  DecisionType decision_type = 1;
+  string strategy_name = 2;     // if decision_type is SET_STRATEGY
+  string command_string = 3;    // if decision_type is EXECUTE_COMMAND
+  Position travel_position = 4; // if decision_type is TRAVEL_TO
+  uint64 target_guid = 5;       // if decision_type is TARGET_ENTITY
+  string justification = 6;     // Optional: why this decision was made
+}
+
+
+// -------- Game Server Service --------
+
+// Service for the Action Server (or other clients) to call the Game Server
+service GameControlService {
+  // Sends a command to a specific bot
+  rpc SendBotCommand (BotCommandRequest) returns (BotCommandResponse);
+
+  // Future: Could add methods to request specific information from the game server
+  // rpc GetBotDetails (GetBotDetailsRequest) returns (GetBotDetailsResponse);
+}
+
+message BotCommandRequest {
+  uint64 bot_guid = 1;
+  string command = 2; // The command string, similar to what's used in chat
+  // Potentially add an originator_id or auth_token for security/logging
+}
+
+message BotCommandResponse {
+  bool success = 1;
+  string message = 2; // e.g., "Command executed", "Bot not found", "Invalid command"
+}

--- a/playerbot_rpc.proto
+++ b/playerbot_rpc.proto
@@ -1,0 +1,145 @@
+syntax = "proto3";
+
+package playerbot_rpc;
+
+// -------- Enums and Common Structures --------
+
+enum BotClass {
+  CLASS_UNKNOWN = 0;
+  WARRIOR = 1;
+  PALADIN = 2;
+  HUNTER = 3;
+  ROGUE = 4;
+  PRIEST = 5;
+  DEATH_KNIGHT = 6; // If applicable
+  SHAMAN = 7;
+  MAGE = 8;
+  WARLOCK = 9;
+  DRUID = 11;
+}
+
+enum BotRace {
+  RACE_UNKNOWN = 0;
+  HUMAN = 1;
+  ORC = 2;
+  DWARF = 3;
+  NIGHT_ELF = 4;
+  UNDEAD = 5;
+  TAUREN = 6;
+  GNOME = 7;
+  TROLL = 8;
+  GOBLIN = 9; // If applicable
+  BLOOD_ELF = 10; // If applicable
+  DRAENEI = 11; // If applicable
+}
+
+message Position {
+  float x = 1;
+  float y = 2;
+  float z = 3;
+  float orientation = 4;
+  uint32 map_id = 5;
+}
+
+message BotStats {
+  uint32 health = 1;
+  uint32 max_health = 2;
+  uint32 mana = 3; // Or other power type
+  uint32 max_mana = 4;
+  uint32 level = 5;
+  // Add other relevant stats like rage, energy, etc.
+}
+
+message Entity {
+  uint64 guid = 1;
+  string name = 2;
+  Position position = 3;
+  bool is_hostile = 4;
+  uint32 health_percent = 5;
+  // Add more entity details as needed (e.g., type, class for players)
+}
+
+message QuestObjective {
+  uint32 objective_id = 1;
+  string description = 2;
+  uint32 current_count = 3;
+  uint32 required_count = 4;
+  bool completed = 5;
+}
+
+message Quest {
+  uint32 quest_id = 1;
+  string title = 2;
+  string description = 3; // Short summary
+  uint32 level = 4;
+  repeated QuestObjective objectives = 5;
+  bool completed = 6;
+  bool is_active = 7; // Is it in the bot's quest log?
+}
+
+
+// -------- Action Server Service --------
+
+// Service for the Game Server to call the Action Server
+service ActionService {
+  // Requests a macro decision for a bot
+  rpc GetMacroDecision (MacroDecisionRequest) returns (MacroDecisionResponse);
+}
+
+message BotStateSnapshot {
+  uint64 bot_guid = 1;
+  BotClass bot_class = 2;
+  BotRace bot_race = 3;
+  Position current_position = 4;
+  BotStats current_stats = 5;
+  repeated Entity nearby_entities = 6; // Players, NPCs, objects
+  repeated Quest active_quests = 7;
+  // Add other relevant state: inventory highlights, current target, group members, etc.
+  bool is_in_combat = 8;
+  string current_strategy_non_combat = 9; // e.g. "grind", "quest", "travel"
+  string current_strategy_combat = 10;
+}
+
+message MacroDecisionRequest {
+  BotStateSnapshot bot_state = 1;
+}
+
+message MacroDecisionResponse {
+  enum DecisionType {
+    DECIDE_UNKNOWN = 0;
+    CONTINUE_CURRENT = 1; // Continue with whatever the game server is already doing
+    SET_STRATEGY = 2;     // Suggests a new high-level strategy
+    EXECUTE_COMMAND = 3;  // Suggests a specific command string for the bot
+    TRAVEL_TO = 4;        // Suggests traveling to a specific location
+    TARGET_ENTITY = 5;    // Suggests targeting a specific entity
+  }
+  DecisionType decision_type = 1;
+  string strategy_name = 2;     // if decision_type is SET_STRATEGY
+  string command_string = 3;    // if decision_type is EXECUTE_COMMAND
+  Position travel_position = 4; // if decision_type is TRAVEL_TO
+  uint64 target_guid = 5;       // if decision_type is TARGET_ENTITY
+  string justification = 6;     // Optional: why this decision was made
+}
+
+
+// -------- Game Server Service --------
+
+// Service for the Action Server (or other clients) to call the Game Server
+service GameControlService {
+  // Sends a command to a specific bot
+  rpc SendBotCommand (BotCommandRequest) returns (BotCommandResponse);
+
+  // Future: Could add methods to request specific information from the game server
+  // rpc GetBotDetails (GetBotDetailsRequest) returns (GetBotDetailsResponse);
+}
+
+message BotCommandRequest {
+  uint64 bot_guid = 1;
+  string command = 2; // The command string, similar to what's used in chat
+  // Potentially add an originator_id or auth_token for security/logging
+}
+
+message BotCommandResponse {
+  bool success = 1;
+  string message = 2; // e.g., "Command executed", "Bot not found", "Invalid command"
+}

--- a/rpc-refactor.md
+++ b/rpc-refactor.md
@@ -1,0 +1,230 @@
+# RPC Refactor Checklist for Playerbot AI
+
+This document outlines the steps to refactor the playerbot AI decision-making process to happen outside the main game server through RPC, introducing an "Action Server."
+
+## I. Core RPC Infrastructure Setup
+
+*   [x] **Define RPC Interface (`playerbot_rpc.proto`)**
+    *   [x] Specify services: `ActionService` (GameServer -> ActionServer) and `GameControlService` (ActionServer/External -> GameServer).
+    *   [x] Define request/response messages (e.g., `MacroDecisionRequest`, `MacroDecisionResponse`, `BotCommandRequest`, `BotCommandResponse`).
+    *   [x] Define common data structures (e.g., `Position`, `BotStats`, `Entity`, `Quest`, `BotStateSnapshot`).
+    *   [x] Choose Protocol Buffers as the Interface Definition Language.
+*   [x] **Set up Action Server Project**
+    *   [x] Create `action_server/` directory.
+    *   [x] Implement basic `action_server/CMakeLists.txt` for gRPC/Protobuf.
+    *   [x] Copy `playerbot_rpc.proto` to `action_server/`.
+    *   [x] Create placeholder `action_service_impl.h/cpp` for `ActionService`.
+    *   [x] Create placeholder `main.cpp` for the action server to start the gRPC service.
+    *   [-] Build action server successfully (requires gRPC/Protobuf dev libraries installed in the environment).
+*   [x] **Set up Game Server for RPC Client**
+    *   [x] Copy `playerbot_rpc.proto` to `playerbot/rpc/`.
+    *   [x] Modify root `CMakeLists.txt` to:
+        *   [x] Find gRPC and Protobuf libraries.
+        *   [x] Add custom command to generate gRPC client stubs from `playerbot/rpc/playerbot_rpc.proto`.
+        *   [x] Add generated C++ files to the `playerbots` library sources.
+        *   [x] Add include directories for generated files.
+        *   [x] Link `playerbots` library against gRPC and Protobuf.
+*   [x] **Implement Central RPC Client Manager (`PlayerbotRpcClientMgr`)**
+    *   [x] Create `PlayerbotRpcClientMgr.h/cpp`.
+    *   [x] Implement as a singleton to manage a shared gRPC channel and `ActionService` stub.
+    *   [x] Add `PlayerbotRpcClientMgr.cpp` to game server's `CMakeLists.txt`.
+    *   [ ] Ensure `PlayerbotRpcClientMgr::Initialize(sPlayerbotAIConfig.actionServerAddress)` is called appropriately at game server startup (e.g., within `PlayerbotAIConfig::Initialize()` or a similar global init function after configs are loaded, and before any bot AI is created).
+*   [x] **Refactor `PlayerbotRpcClient`**
+    *   [x] Modify `PlayerbotRpcClient.h/cpp` to use the shared stub from `PlayerbotRpcClientMgr` instead of creating its own channel/stub.
+*   [x] **Integrate RPC Client into `PlayerbotAI`**
+    *   [x] Add `rpcClient` member (std::unique_ptr<PlayerbotRpcClient>) to `PlayerbotAI.h`.
+    *   [x] Add RPC-related method declarations to `PlayerbotAI.h` (`InitRpcClient`, `ShouldUseRpcForDecision`, `ProcessRpcDecision`, `PopulateBotStateSnapshot`).
+    *   [x] Create `playerbot/PlayerbotAI_rpc.cpp` for implementations of these methods.
+    *   [x] Add `PlayerbotAI_rpc.cpp` to game server's `CMakeLists.txt`.
+    *   [x] Implement `PlayerbotAI::InitRpcClient` to use `PlayerbotRpcClientMgr` to initialize its `rpcClient` member.
+    *   [x] Ensure `InitRpcClient()` is called in `PlayerbotAI` constructor.
+    *   [x] Add conceptual call to `ProcessRpcDecision()` in `PlayerbotAI::UpdateAIInternal()`.
+
+## II. Action Server - AI Logic Implementation
+
+*   [ ] **Flesh out `ActionServiceImpl::GetMacroDecision`**
+    *   [ ] Basic parsing of `BotStateSnapshot`.
+    *   [ ] Implement logic for simple decisions (e.g., if low health -> suggest "flee" strategy or "use potion" command).
+    *   [ ] Adapt parts of existing `PlayerbotAI` strategy selection logic to operate on `BotStateSnapshot` data.
+    *   [ ] Gradually expand decision-making capabilities (questing, grinding, travel).
+*   [ ] **Data Storage for Action Server (e.g., Redis)**
+    *   [ ] Choose and integrate a Redis client library for C++.
+    *   [ ] Update `action_server/CMakeLists.txt` for the Redis client.
+    *   [ ] Define data structures to store in Redis (e.g., bot's long-term goals, persistent macro state).
+    *   [ ] Implement logic in `ActionServiceImpl` to read/write from/to Redis as part of decision-making.
+
+## III. Game Server - Detailed RPC Integration
+
+*   [ ] **Complete `PlayerbotAI::PopulateBotStateSnapshot`**
+    *   [ ] Systematically gather all relevant data from `Player* bot` and its environment.
+        *   [ ] Accurate BotClass and BotRace mapping to proto enums.
+        *   [ ] Comprehensive nearby entities (players, NPCs, game objects), including their type, faction, hostility, etc.
+        *   [ ] Detailed active quest information, including progress on all objectives.
+        *   [ ] Relevant inventory items (e.g., quest items, consumables count).
+        *   [ ] Spell cooldowns relevant for macro decisions.
+        *   [ ] Bot's current effective strategies.
+        *   [ ] Reputation with relevant factions.
+        *   [ ] Known flight paths / travel nodes.
+        *   [ ] Group member information.
+    *   [ ] Optimize data collection to minimize performance impact.
+*   [ ] **Complete `PlayerbotAI::ProcessRpcDecision`**
+    *   [ ] Implement handling for all `MacroDecisionResponse::DecisionType` cases:
+        *   [ ] `SET_STRATEGY`: Ensure correct `BotState` is used when applying.
+        *   [ ] `EXECUTE_COMMAND`: Securely handle command execution.
+        *   [ ] `TRAVEL_TO`: Integrate with `TravelMgr` or relevant travel actions. This likely needs a robust "travel <x> <y> <z> [mapid]" command/action.
+        *   [ ] `TARGET_ENTITY`: Correctly set target and potentially interrupt current action.
+    *   [ ] Add logic for error handling and fallbacks if Action Server is unavailable or returns errors.
+*   [ ] **Implement `GameControlService` on Game Server**
+    *   [ ] Create `GameControlServiceImpl.h/cpp` inheriting from `playerbot_rpc::GameControlService::Service`.
+    *   [ ] Implement `SendBotCommand` method:
+        *   [ ] Find target bot by GUID.
+        *   [ ] Pass command string to `PlayerbotAI::HandleCommand`.
+        *   [ ] Return appropriate success/failure response.
+    *   [ ] Set up a gRPC server instance within the game server process.
+        *   [ ] This might run in a separate thread.
+        *   [ ] Configure listening port.
+        *   [ ] Ensure proper startup and shutdown with the main server.
+    *   [ ] Implement security/authentication for `GameControlService` if exposed externally.
+
+## IV. Data Synchronization and State Management
+
+*   [ ] **Game Server -> Action Server Flow**
+    *   [ ] Ensure `BotStateSnapshot` is sent on each `GetMacroDecision` call.
+    *   [ ] Evaluate if periodic state pushes (even without a decision request) are needed for certain data types, or if on-demand is sufficient.
+*   [ ] **Action Server State Persistence**
+    *   [ ] Finalize what bot-specific macro state the Action Server needs to persist (e.g., in Redis).
+    *   [ ] Implement save/load logic for this persistent state.
+*   [ ] **Consistency Model**
+    *   [ ] Define how to handle potential inconsistencies if the Action Server's cached/stored state diverges from the Game Server's real-time state. (Game server is source of truth).
+
+## V. Testing
+
+*   [ ] **Unit Tests**
+    *   [ ] For `ActionServiceImpl` decision logic snippets.
+    *   [ ] For `PlayerbotAI::PopulateBotStateSnapshot` data gathering.
+    *   [ ] For `PlayerbotAI::ProcessRpcDecision` response handling.
+    *   [ ] For `GameControlServiceImpl` command processing.
+*   [ ] **Integration Tests**
+    *   [ ] Test RPC communication channel (GameServer client to ActionServer).
+    *   [ ] Test `GetMacroDecision` call and response flow with basic decisions.
+    *   [ ] Test `SendBotCommand` call and response flow.
+*   [ ] **Performance Tests**
+    *   [ ] Measure latency of `GetMacroDecision` RPC calls.
+    *   [ ] Assess overhead of `PopulateBotStateSnapshot`.
+    *   [ ] Monitor overall bot responsiveness and server performance impact.
+*   [ ] **End-to-End Scenario Tests**
+    *   [ ] Bot completing a simple quest guided by Action Server.
+    *   [ ] Bot selecting a grinding spot based on Action Server logic.
+
+## V. Testing Strategy Details
+
+This section expands on the testing approaches for the RPC refactor.
+
+### V.A. Unit Tests
+
+*   **Scope:** Focus on individual components in isolation.
+*   **Action Server (`action_server`):**
+    *   **`ActionServiceImpl`:**
+        *   Test specific decision logic branches within `GetMacroDecision`. Mock `BotStateSnapshot` inputs to trigger different decision paths (e.g., low health leading to a "flee" suggestion, presence of a quest mob leading to a "target" suggestion).
+        *   If Redis is used: Test Redis interaction logic (e.g., correctly reading/writing bot goals). This might involve a test-specific Redis instance or mocking the Redis client.
+    *   **Helper/Utility Functions:** Any new utility functions for parsing state, evaluating conditions, etc.
+*   **Game Server (`playerbot` module):**
+    *   **`PlayerbotRpcClientMgr`:** Test initialization and stub provision.
+    *   **`PlayerbotRpcClient`:** Test `GetMacroDecision` call logic, including deadline handling and error parsing from `grpc::Status`. (Requires a mock gRPC server or service).
+    *   **`PlayerbotAI::PopulateBotStateSnapshot`:**
+        *   Given a `Player* bot` in a specific state (e.g., in combat, specific quests active, certain items in inventory), verify that the generated `BotStateSnapshot` protobuf message is populated correctly with all expected fields.
+        *   Test edge cases (e.g., no target, no quests, empty inventory).
+    *   **`PlayerbotAI::ProcessRpcDecision`:**
+        *   Given a mock `MacroDecisionResponse` from the Action Server, verify that `PlayerbotAI` correctly interprets it and initiates the appropriate game server actions (e.g., calls `ChangeStrategy`, queues a command, updates `TravelTarget`).
+    *   **`GameControlServiceImpl` (when implemented):**
+        *   Test `SendBotCommand` logic: correctly finding the bot, passing the command, and returning status. Mock `PlayerbotAI::HandleCommand`.
+*   **Tools:** Use a C++ testing framework like Google Test (gtest) or Catch2.
+
+### V.B. Integration Tests
+
+*   **Scope:** Test interactions between components or services.
+*   **Game Server <-> Action Server RPC Communication:**
+    *   **Basic Connectivity:** Verify that the Game Server can successfully connect to the Action Server and make a `GetMacroDecision` call, and the Action Server can receive it and respond.
+    *   **Data Serialization/Deserialization:** Ensure `BotStateSnapshot` and `MacroDecisionResponse` are correctly serialized and deserialized across the RPC boundary. Test with various field values and edge cases.
+    *   **Error Handling:**
+        *   Test Action Server being unavailable: Game Server should handle this gracefully (e.g., fallback to local AI, log error).
+        *   Test RPC timeouts: Game Server should correctly handle calls that exceed the deadline.
+        *   Test Action Server returning error statuses: Game Server should interpret these correctly.
+*   **Action Server <-> Redis (if used):**
+    *   Verify that the Action Server can connect to, read from, and write to the Redis instance correctly.
+*   **GameControlService RPC (when implemented):**
+    *   Test an external client (or the Action Server itself) sending a command via `SendBotCommand` and verify the command is relayed to the correct bot on the Game Server.
+*   **Tools/Setup:**
+    *   May require running both Action Server and Game Server instances (or mock versions).
+    *   Could use Docker Compose to orchestrate services for testing environments.
+
+### V.C. Performance Tests
+
+*   **Scope:** Measure performance characteristics and identify bottlenecks.
+*   **`GetMacroDecision` RPC Latency:**
+    *   Measure round-trip time for `GetMacroDecision` calls under various loads (e.g., number of concurrent requests, complexity of decision).
+    *   Identify if network latency or Action Server processing time is the dominant factor.
+*   **`PopulateBotStateSnapshot` Overhead:**
+    *   Profile the time taken by `PlayerbotAI::PopulateBotStateSnapshot` on the Game Server to understand its impact on the game loop, especially with many bots active.
+*   **Action Server Throughput:**
+    *   Determine how many decisions per second the Action Server can handle.
+*   **Resource Utilization:**
+    *   Monitor CPU, memory, and network usage of both Game Server and Action Server during load tests.
+*   **Tools:** Profiling tools (e.g., gprof, Valgrind for C++), load testing frameworks (e.g., k6, Locust, or custom scripts), system monitoring tools.
+
+### V.D. End-to-End (E2E) / Scenario Tests
+
+*   **Scope:** Test complete user stories or bot behaviors involving the entire RPC flow.
+*   **Setup:** Requires a fully running Game Server and Action Server, potentially with a populated game world.
+*   **Scenarios:**
+    *   **Quest Completion:**
+        1.  Bot starts with a simple "collect X items" or "kill Y mobs" quest.
+        2.  Game Server sends state to Action Server.
+        3.  Action Server decides the bot should pursue the quest, identifies the target mob/item area, and responds with a travel/target/strategy decision.
+        4.  Game Server makes the bot execute this (travel, engage, loot).
+        5.  Repeat until quest objectives are met.
+        6.  Action Server guides bot to quest turn-in NPC.
+    *   **Grinding Spot Selection:**
+        1.  Bot is idle.
+        2.  Action Server analyzes bot level, class, and potentially nearby mob density/level (if this info is passed or cached) and suggests a suitable grinding spot/strategy.
+        3.  Bot travels to the spot and begins grinding.
+    *   **Dynamic Strategy Change:**
+        1.  Bot is grinding. A hostile high-level player appears nearby.
+        2.  `BotStateSnapshot` includes the hostile player.
+        3.  Action Server decides the bot should switch to a "flee" or "defensive" strategy and responds.
+        4.  Game Server applies the new strategy.
+    *   **Command Execution via `GameControlService`:**
+        1.  Use a test client to send a command (e.g., "follow player X", "use hearthstone") to a bot via the `GameControlService` RPC endpoint on the Game Server.
+        2.  Verify the bot executes the command.
+*   **Verification:** Observe bot behavior in-game, check logs on both servers, and verify game state changes (e.g., quest completion, inventory changes).
+
+### V.E. Test Environment Considerations
+
+*   **Dedicated Test Environment:** Essential to avoid impacting development or production.
+*   **Mocking:** For unit and some integration tests, mock external services (e.g., a mock Action Server for testing Game Server client logic, or a mock Redis for Action Server logic).
+*   **Data Management:** For E2E tests, a way to reset or set up specific game world states (e.g., bot characters with specific quests/levels/items) will be beneficial.
+
+This detailed testing strategy should provide good coverage for the RPC refactor.
+
+## VI. Deployment and Configuration
+
+*   [ ] Add configuration options to `aiplayerbot.conf`:
+    *   [x] `ActionServer.Address` (e.g., `localhost:50051`)
+    *   [x] `ActionServer.RpcTimeoutMs` (e.g., `500`)
+    *   [x] `ActionServer.EnableDecisionMaking` (true/false global toggle)
+    *   [ ] `GameControlServer.Port` (e.g., `50052`, if different from ActionServer)
+    *   [ ] `GameControlServer.Enable` (true/false)
+*   [ ] Document how to build and run the Action Server.
+*   [ ] Document new configuration options.
+
+## VII. Future Considerations (Post-Initial Implementation)
+
+*   [ ] More sophisticated AI logic in Action Server.
+*   [ ] Bi-directional streaming for more dynamic updates.
+*   [ ] Secure RPC channels (TLS).
+*   [ ] Metrics and monitoring for the Action Server.
+*   [ ] Scalability of the Action Server (e.g., handling many bots).
+
+---
+*Marked items ([x]) are considered structurally complete or initiated as per current progress.*
+*Items with ([-]) indicate partial completion or known environmental limitations.*


### PR DESCRIPTION
Defines the RPC interface using gRPC/Protobuf for communication between the game server and a new external Action Server.

Includes:
- playerbot_rpc.proto: RPC service and message definitions.
- action_server/: Project setup for the standalone Action Server with CMake and placeholder gRPC service implementation.
- Game server modifications:
  - Updates to the root CMakeLists.txt to integrate gRPC/Protobuf client generation.
  - PlayerbotRpcClientMgr: Manages a shared gRPC client connection.
  - PlayerbotRpcClient: Wrapper for making RPC calls.
  - PlayerbotAI: Integration points (InitRpcClient, stubs for PopulateBotStateSnapshot, ProcessRpcDecision) to call the Action Server.
  - PlayerbotAI_rpc.cpp: Houses RPC-related implementations for PlayerbotAI.
- rpc-refactor.md: Detailed checklist and testing strategy for the refactor.

This commit establishes the foundational architecture. Further work is needed to fully implement the AI logic in the Action Server, complete data synchronization in PlayerbotAI, and execute the testing plan.