### PR TITLE
Inactivate Orc racial Blood Fury trigger for tanks

### DIFF
--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -984,6 +984,13 @@ namespace ai
     {
     public:
         BloodFuryTrigger(PlayerbotAI* ai) : BoostTrigger(ai, "blood fury") {}
+        
+#ifdef MANGOSBOT_ZERO
+        virtual bool IsActive()
+        {
+            return !ai->IsTank(bot);
+        }
+#endif
     };
 
     class CannibalizeTrigger : public Trigger


### PR DESCRIPTION
Prior to this change Orc tanks would, if not on cooldown, cast Blood Fury upon engaging a target.

This is problematic due to the 50% healing reduction debuff that is applied with Blood Fury in vanilla.

This is mostly relevant for vanilla. In TBC and WOTLK Blood Fury gives different types of bonuses based on class and the healing debuff is eventually removed.