### PR TITLE
Handle Totemic Call rename

### DIFF
--- a/playerbot/strategy/shaman/ShamanActions.h
+++ b/playerbot/strategy/shaman/ShamanActions.h
@@ -463,7 +463,11 @@ namespace ai
     class CastTotemicRecall : public CastBuffSpellAction
     {
     public:
+#ifdef MANGOSBOT_ONE
+        CastTotemicRecall(PlayerbotAI* ai) : CastBuffSpellAction(ai, "totemic call") {}
+#else
         CastTotemicRecall(PlayerbotAI* ai) : CastBuffSpellAction(ai, "totemic recall") {}
+#endif
     };
 
     class CastEarthShieldOnPartyTankAction : public BuffOnTankAction


### PR DESCRIPTION
Prior to this change there was only support for casting spell named Totemic Recall however this only worked for MANGOSBOT_TWO / WOTLK.

[Totemic Call](https://www.wowhead.com/tbc/spell=36936/totemic-call) was introduced in TBC and later renamed [Totemic Recall](https://www.wowhead.com/wotlk/spell=36936/totemic-recall) in WOTLK.