### PR TITLE
Fix crash: nullptr crash NamedObjectFactory

### DIFF
--- a/playerbot/strategy/NamedObjectContext.h
+++ b/playerbot/strategy/NamedObjectContext.h
@@ -201,13 +201,18 @@ namespace ai
         NamedObjectContext(bool shared = false, bool supportsSiblings = false) :
             NamedObjectFactory<T>(), shared(shared), supportsSiblings(supportsSiblings) {}
 
-        T* create(std::string name, PlayerbotAI* ai)
-        {
-            if (created.find(name) == created.end())
-                return created[name] = NamedObjectFactory<T>::create(name, ai);
+T* create(std::string name, PlayerbotAI* ai)
+{
+    if (created.find(name) == created.end())
+    {
+        T* val = NamedObjectFactory<T>::create(name, ai);
+        if (!val)
+            return nullptr;
 
-            return created[name];
-        }
+        created[name] = val;
+    }
+    return created[name]; 
+}
 
         virtual ~NamedObjectContext()
         {


### PR DESCRIPTION
This commit fixes a crash caused by a nullptr being stored in the created map. The code now checks if the created object is nullptr before storing it, preventing future crashes.