### PR TITLE
Playerbots: Add support for fixed class/race random bot generation

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -354,6 +354,25 @@ bool PlayerbotAIConfig::Initialize()
         }
     }
 
+    useFixedClassRaceCounts = config.GetBoolDefault("AiPlayerbot.ClassRace.UseFixedClassRaceCounts", false);
+
+    if (useFixedClassRaceCounts)
+    {
+	for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
+	{
+	    for (uint32 race = 1; race < MAX_RACES; ++race)
+	    {
+		std::string key = "AiPlayerbot.ClassRaceProb." + std::to_string(cls) + "." + std::to_string(race);
+		int count = config.GetIntDefault(key, -1);
+
+		if (count >= 0 && factory.isAvailableRace(cls, race))
+		{
+		    fixedClassRaceCounts[{cls, race}] = count;
+		}
+	    }
+	}
+    }
+
     botCheats.clear();
     LoadListString<std::list<std::string>>(config.GetStringDefault("AiPlayerbot.BotCheats", "taxi,item,breath"), botCheats);
 

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -184,6 +184,9 @@ public:
     std::string premadeLevelSpec[MAX_CLASSES][10][91]; //lvl 10 - 100
     uint32 classRaceProbabilityTotal;
     uint32 classRaceProbability[MAX_CLASSES][MAX_RACES];
+    bool useFixedClassRaceCounts;
+    using ClassRacePair = std::pair<uint8, uint8>;
+    std::map<ClassRacePair, uint32> fixedClassRaceCounts;
     uint32 levelProbability[DEFAULT_MAX_LEVEL + 1];
     ClassSpecs classSpecs[MAX_CLASSES];
     GlyphPrioritySpecMap glyphPriorityMap[MAX_CLASSES];

--- a/playerbot/RandomPlayerbotFactory.cpp
+++ b/playerbot/RandomPlayerbotFactory.cpp
@@ -22,6 +22,7 @@
 #endif
 #endif
 
+#include <random>
 
 std::map<uint8, std::vector<uint8> > RandomPlayerbotFactory::availableRaces;
 
@@ -206,13 +207,13 @@ uint8 RandomPlayerbotFactory::GetRandomRace(uint8 cls)
     return availableRaces[cls].front();
 }
 
-bool RandomPlayerbotFactory::CreateRandomBot(uint8 cls, std::unordered_map<NameRaceAndGender, std::vector<std::string>>& names)
+bool RandomPlayerbotFactory::CreateRandomBot(uint8 cls, std::unordered_map<NameRaceAndGender, std::vector<std::string>>& names, uint8 inputRace)
 {
     sLog.outDebug( "Creating new random bot for class %d", cls);
 
     uint8 gender = rand() % 2 ? GENDER_MALE : GENDER_FEMALE;
 
-    uint8 race = GetRandomRace(cls);
+    uint8 race = inputRace == 0 ? GetRandomRace(cls) : inputRace;
 
     NameRaceAndGender raceAndGender = CombineRaceAndGender(gender, race);
 
@@ -654,6 +655,11 @@ void RandomPlayerbotFactory::CreateRandomBots()
     sLog.outString("Creating random bot characters...");
     uint32 botsCreated = 0;
     BarGoLink bar1(totalCharCount);
+
+
+    // Shallow copy of the fixed config so we can modify it
+    std::map<std::pair<uint8, uint8>, uint32> remaining = sPlayerbotAIConfig.fixedClassRaceCounts;
+
     for (uint32 accountNumber = 0; accountNumber < sPlayerbotAIConfig.randomBotAccountCount; ++accountNumber)
     {
         std::ostringstream out; out << sPlayerbotAIConfig.randomBotAccountPrefix << accountNumber;
@@ -679,28 +685,96 @@ void RandomPlayerbotFactory::CreateRandomBots()
             continue;
         }
 
-        RandomPlayerbotFactory factory(accountId);
-        for (uint8 cls = CLASS_WARRIOR; cls < MAX_CLASSES - count; ++cls)
-        {
-            // skip nonexistent classes
-            if (!((1 << (cls - 1)) & CLASSMASK_ALL_PLAYABLE) || !sChrClassesStore.LookupEntry(cls))
-                continue;
+	RandomPlayerbotFactory factory(accountId);
+	if (sPlayerbotAIConfig.useFixedClassRaceCounts)
+	{
+#ifdef MANGOSBOT_TWO
+	    uint32 maxAllowed = 10 - count;
+#else
+	    uint32 maxAllowed = 9 - count;
+#endif
+	    uint32 created = 0;
+
+	    while (!remaining.empty() && created < maxAllowed)
+	    {
+	        std::vector<std::pair<uint8, uint8>> shuffledKeys;
+	        for (const auto& entry : remaining)
+	            shuffledKeys.push_back(entry.first);
+
+	        // Shuffle the keys of the map
+	        std::random_device rnd;
+		std::mt19937 rng(rnd()); // Mersenne Twister RNG
+		std::shuffle(shuffledKeys.begin(), shuffledKeys.end(), rng);
+
+	        for (const auto& key : shuffledKeys)
+	        {
+	            if (created >= maxAllowed)
+	                break;
+
+	            uint8 cls = key.first;
+	            uint8 race = key.second;
+
+	            if (!((1 << (cls - 1)) & CLASSMASK_ALL_PLAYABLE) || !sChrClassesStore.LookupEntry(cls))
+	                continue;
 
 #ifdef MANGOSBOT_TWO
-            if (cls != 10)
+	            if (cls == 10)
+	                continue;
 #else
-            if (cls != 10 && cls != 6)
+	            if (cls == 10 || cls == 6)
+	                continue;
 #endif
+
+	            if (factory.CreateRandomBot(cls, freeNames, race))
+	            {
+	                created++;
+	                botsCreated++;
+	                bar1.step();
+	                if (--remaining[key] == 0)
+	                    remaining.erase(key);
+	            }
+	        }
+	    }
+	}
+	else
+	{
+            for (uint8 cls = CLASS_WARRIOR; cls < MAX_CLASSES - count; ++cls)
             {
-                uint8 rclss = factory.GetRandomClass();
-                botsCreated++;
-                factory.CreateRandomBot(rclss, freeNames);
-                bar1.step();
+                // skip nonexistent classes
+                if (!((1 << (cls - 1)) & CLASSMASK_ALL_PLAYABLE) || !sChrClassesStore.LookupEntry(cls))
+                    continue;
+
+#ifdef MANGOSBOT_TWO
+                if (cls != 10)
+#else
+                if (cls != 10 && cls != 6)
+#endif
+                {
+                    uint8 rclss = factory.GetRandomClass();
+                    botsCreated++;
+                    factory.CreateRandomBot(rclss, freeNames);
+                    bar1.step();
+                }
             }
-        }
+	}
 
         totalRandomBotChars += sAccountMgr.GetCharactersCount(accountId);
     }
+    if (sPlayerbotAIConfig.useFixedClassRaceCounts && !remaining.empty())
+    {
+	sLog.outError("Unable to create all requested fixed class/race bots due to account character limits.");
+	sLog.outError("The following class/race combinations were left uncreated:");
+
+	for(const auto& entry : remaining)
+	{
+	    uint8 cls = entry.first.first;
+	    uint8 race = entry.first.second;
+	    uint32 count = entry.second;
+
+	    sLog.outError(" - Class %u, Race %u: %u bots remaining", cls, race, count);
+	}
+    }
+
 
     if (!botsCreated)
     {

--- a/playerbot/RandomPlayerbotFactory.cpp
+++ b/playerbot/RandomPlayerbotFactory.cpp
@@ -763,16 +763,24 @@ void RandomPlayerbotFactory::CreateRandomBots()
     if (sPlayerbotAIConfig.useFixedClassRaceCounts && !remaining.empty())
     {
 	sLog.outError("Unable to create all requested fixed class/race bots due to account character limits.");
-	sLog.outError("The following class/race combinations were left uncreated:");
+	sLog.outError("The following class/race combination(s) were left uncreated:");
 
+	uint32 totalCount = 0;
 	for(const auto& entry : remaining)
 	{
 	    uint8 cls = entry.first.first;
 	    uint8 race = entry.first.second;
 	    uint32 count = entry.second;
+	    totalCount += count;
 
 	    sLog.outError(" - Class %u, Race %u: %u bots remaining", cls, race, count);
 	}
+#ifdef MANGOSBOT_TWO
+	uint32 missingAccounts = (totalCount + 9) / 10;
+#else
+        uint32 missingAccounts = (totalCount + 8) / 9;
+#endif
+	sLog.outError("You need at least %u additional account(s) to fill the remaining fixed class/race combinations.", missingAccounts);
     }
 
 
@@ -811,7 +819,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
         delete player;
         delete session;
     }
-    sLog.outString("%zu random bot accounts with %d characters available", sPlayerbotAIConfig.randomBotAccounts.size(), totalRandomBotChars);
+    sLog.outString("%zu random bot accounts with %d characters available", sPlayerbotAIConfig.randomBotAccounts.size(), totalRandomBotChars+botsCreated);
 }
 
 

--- a/playerbot/RandomPlayerbotFactory.h
+++ b/playerbot/RandomPlayerbotFactory.h
@@ -43,7 +43,7 @@ class RandomPlayerbotFactory
 		virtual ~RandomPlayerbotFactory() {}
 
 	public:
-        bool CreateRandomBot(uint8 cls, std::unordered_map<NameRaceAndGender, std::vector<std::string>>& names);
+        bool CreateRandomBot(uint8 cls, std::unordered_map<NameRaceAndGender, std::vector<std::string>>& names, uint8 inputRace = 0);
         static void CreateRandomBots();
         static void CreateRandomGuilds();
         static void CreateRandomArenaTeams();

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -389,7 +389,7 @@ AiPlayerbot.AutoLearnDroppedSpells = 0
 # This will generate random bots based on a fixed total count per class/race combo as defined by:
 # AiPlayerbot.ClassRaceProb.<class>.<race> = <number>
 #
-AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 1
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 0
 
 # AiPlayerbot.ClassRaceProb.1.0 = 178    # Human chance
 # AiPlayerbot.ClassRaceProb.2.0 = 65     # Orc chance

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -381,8 +381,15 @@ AiPlayerbot.AutoLearnDroppedSpells = 0
 # All non-orc warriors will have a 75% lower chance to be generated.
 # Human mages have a 65% lower chance to generate. 
 # Orc warriors have a 55% lower chance to generate.
-
+#
 # Source https://web.archive.org/web/20050115034332/http://www.warcraftrealms.com/census.php
+
+# As an alternative to probability-based generation, you can enable:
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts
+# This will generate random bots based on a fixed total count per class/race combo as defined by:
+# AiPlayerbot.ClassRaceProb.<class>.<race> = <number>
+#
+AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 1
 
 # AiPlayerbot.ClassRaceProb.1.0 = 178    # Human chance
 # AiPlayerbot.ClassRaceProb.2.0 = 65     # Orc chance

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -363,8 +363,15 @@ AiPlayerbot.AutoLearnDroppedSpells = 0
 # All non-orc warriors will have a 75% lower chance to be generated.
 # Human mages have a 65% lower chance to generate. 
 # Orc warriors have a 55% lower chance to generate.
-
+#
 # Source https://web.archive.org/web/20080730172509/http://www.warcraftrealms.com/census.php
+
+# As an alternative to probability-based generation, you can enable:
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts
+# This will generate random bots based on a fixed total count per class/race combo as defined by:
+# AiPlayerbot.ClassRaceProb.<class>.<race> = <number>
+#
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 0
 
 # AiPlayerbot.ClassRaceProb.0.1 = 106   # Human chance
 # AiPlayerbot.ClassRaceProb.0.2 =  40   # Orc chance

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -369,8 +369,15 @@ AiPlayerbot.AutoLearnDroppedSpells = 0
 # All non-orc warriors will have a 75% lower chance to be generated.
 # Human mages have a 65% lower chance to generate. 
 # Orc warriors have a 55% lower chance to generate.
-
+#
 # Source https://web.archive.org/web/20090508173437/http://www.warcraftrealms.com/census.php
+
+# As an alternative to probability-based generation, you can enable:
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts
+# This will generate random bots based on a fixed total count per class/race combo as defined by:
+# AiPlayerbot.ClassRaceProb.<class>.<race> = <number>
+#
+# AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 0
 
 # AiPlayerbot.ClassRaceProb.0.1 =  115  # Human chance
 # AiPlayerbot.ClassRaceProb.0.2 =   36  # Orc chance


### PR DESCRIPTION
### Summary
Adds support for generating random playerbots using a fixed class/race distribution defined in the configuration file.

---

### Behavior
When `AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 1`, the system attempts to generate bots that match exact combinations defined via config:

```
AiPlayerbot.ClassRaceProb.1.1 = 6    # 6 Human warriors
AiPlayerbot.ClassRaceProb.1.2 = 5    # 5 Orc warriors
```
It respects per-account character limits and stops when accounts are full. Any remaining uncreated class/race pairs are logged in a clear summary:
```
Unable to create all requested fixed class/race bots due to account character limits.
 - Class 1, Race 1: 1 bots remaining
 - Class 1, Race 2: 3 bots remaining
```

---

### Key Features

- Shuffles bot creation order for better spread across accounts
- Stops once account character limits are hit
- Logs uncreated class/race combinations at the end
- Supports fallback to weighted probability generation when disabled

---

### Configuration
```
AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 1
AiPlayerbot.ClassRaceProb.<class>.<race> = <count>
```