### PR TITLE
Fix divide-by-zero crash when using fixedClassRaceCounts

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -311,53 +311,51 @@ bool PlayerbotAIConfig::Initialize()
     useFixedClassRaceCounts = config.GetBoolDefault("AiPlayerbot.ClassRace.UseFixedClassRaceCounts", false);
     RandomPlayerbotFactory factory(0);
 
-    if (!useFixedClassRaceCounts)
+    for (uint32 race = 1; race < MAX_RACES; ++race)
     {
-        for (uint32 race = 1; race < MAX_RACES; ++race)
+        //Set race defaults
+        if (race > 0)
         {
-            //Set race defaults
-            if (race > 0)
-            {
-                int rProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb.0." + std::to_string(race), 100);
+            int rProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb.0." + std::to_string(race), 100);
 
-                for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
-                {
-                    classRaceProbability[cls][race] = rProb;
-                }
-            }
-        }
-
-        //Class overrides
-        for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
-        {
-            int cProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb." + std::to_string(cls), -1);
-
-            if (cProb >= 0)
-            {
-                for (uint32 race = 1; race < MAX_RACES; ++race)
-                {
-                    classRaceProbability[cls][race] = cProb;
-                }
-            }
-        }
-
-        //Race Class overrides
-        for (uint32 race = 1; race < MAX_RACES; ++race)
-        {
             for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
             {
-                int rcProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb." + std::to_string(cls) + "." + std::to_string(race), -1);
-                if (rcProb >= 0)
-                    classRaceProbability[cls][race] = rcProb;
-
-                if (!factory.isAvailableRace(cls, race))
-                    classRaceProbability[cls][race] = 0;
-                else
-                    classRaceProbabilityTotal += classRaceProbability[cls][race];
+                classRaceProbability[cls][race] = rProb;
             }
         }
     }
-    else
+
+    //Class overrides
+    for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
+    {
+        int cProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb." + std::to_string(cls), -1);
+
+        if (cProb >= 0)
+        {
+            for (uint32 race = 1; race < MAX_RACES; ++race)
+            {
+                classRaceProbability[cls][race] = cProb;
+            }
+        }
+    }
+
+    //Race Class overrides
+    for (uint32 race = 1; race < MAX_RACES; ++race)
+    {
+        for (uint32 cls = 1; cls < MAX_CLASSES; ++cls)
+        {
+            int rcProb = config.GetIntDefault("AiPlayerbot.ClassRaceProb." + std::to_string(cls) + "." + std::to_string(race), -1);
+            if (rcProb >= 0)
+                classRaceProbability[cls][race] = rcProb;
+
+            if (!factory.isAvailableRace(cls, race))
+                classRaceProbability[cls][race] = 0;
+            else
+                classRaceProbabilityTotal += classRaceProbability[cls][race];
+        }
+    }
+
+    if (useFixedClassRaceCounts)
     {
 
         // Warn about unsupported config keys


### PR DESCRIPTION
### Fix: Prevent divide-by-zero when using fixed class/race counts
**Summary**
When `AiPlayerbot.ClassRace.UseFixedClassRaceCounts = 1` is set, the server crashes due to a divide-by-zero in `RandomPlayerbotMgr::AddRandomBots()`:

```
classRaceAllowed[cls][race] =
    ((sPlayerbotAIConfig.classRaceProbability[cls][race] * maxAllowedBotCount
    / sPlayerbotAIConfig.classRaceProbabilityTotal) + 1) * (noCriteria + 1);
```
**Root** Cause
`classRaceProbabilityTotal` remains 0 in fixed mode because its calculation was skipped behind:

```
if (!useFixedClassRaceCounts)
    classRaceProbabilityTotal += ...;
```
The shared logic later assumes it was augmented, causing a crash.

**Fix**
Always populate `classRaceProbability` and its total, regardless of mode.

In fixed mode, also:

- Warn about unsupported config keys (e.g. ClassRaceProb.X).
- Build fixedClassRaceCounts as expected.

**Result**

- Fixed mode no longer crashes.
- Shared probability structures are always available.
- No behavior changes to either fixed or weighted generation.