### PR TITLE
Add RandomBotAutoCreate config option and safe early return logic

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -202,6 +202,7 @@ bool PlayerbotAIConfig::Initialize()
 
     botAutologin = BotAutoLogin(config.GetIntDefault("AiPlayerbot.BotAutologin", 0));
     randomBotAutologin = config.GetBoolDefault("AiPlayerbot.RandomBotAutologin", true);
+    randomBotAutoCreate = config.GetBoolDefault("AiPlayerbot.RandomBotAutoCreate", true);
     minRandomBots = config.GetIntDefault("AiPlayerbot.MinRandomBots", 50);
     maxRandomBots = config.GetIntDefault("AiPlayerbot.MaxRandomBots", 200);
     randomBotUpdateInterval = config.GetIntDefault("AiPlayerbot.RandomBotUpdateInterval", 1);

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -149,6 +149,7 @@ public:
     float randomBotRpgChance;
     float usePotionChance;
     float attackEmoteChance;
+    bool randomBotAutoCreate;
     uint32 minRandomBots, maxRandomBots;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;
     uint32 loginBoostPercentage;

--- a/playerbot/RandomPlayerbotFactory.cpp
+++ b/playerbot/RandomPlayerbotFactory.cpp
@@ -760,7 +760,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
 
         totalRandomBotChars += sAccountMgr.GetCharactersCount(accountId);
     }
-    if (sPlayerbotAIConfig.useFixedClassRaceCounts && !remaining.empty())
+    if (sPlayerbotAIConfig.useFixedClassRaceCounts && sPlayerbotAIConfig.randomBotAutoCreate && !remaining.empty())
     {
 	sLog.outError("Unable to create all requested fixed class/race bots due to account character limits.");
 	sLog.outError("The following class/race combination(s) were left uncreated:");
@@ -784,9 +784,12 @@ void RandomPlayerbotFactory::CreateRandomBots()
     }
 
 
-    if (!botsCreated)
+    if (!sPlayerbotAIConfig.randomBotAutoCreate || !botsCreated)
     {
-        sLog.outString("No new random bots needed accounts: %zu, bots: %d.", sPlayerbotAIConfig.randomBotAccounts.size(), totalRandomBotChars);
+	if (!sPlayerbotAIConfig.randomBotAutoCreate)
+            sLog.outString("Random bot auto-creation disabled. Skipping character generation.");
+	else
+	    sLog.outString("No new random bots needed. Accounts: %zu, bots: %d.", sPlayerbotAIConfig.randomBotAccounts.size(), totalRandomBotChars);
 
         return;
     }


### PR DESCRIPTION
### Summary

This PR implements existing config option `AiPlayerbot.RandomBotAutoCreate`, allowing control over whether random bots are auto-created on server init.
Logic is gated at the safest point (after account/character prep but before DB commits), preventing undefined behavior while allowing `RandomPlayerbotMgr::AddRandomBots()` to function properly.

### Tested return points:
I tested adding the return logic in various places within `RandomPlayerbotFactory::CreateRandomBotName()`
- After account deletion
- After account creation
- After name population
- After bot creation and prior to persisting to database

### Observed Behavior
Returns prior to bot creation caused `RandomPlayerbotMgr::AddRandomBots()` to fail to log in any bots, while also producing the following console errors:

- "Not enough accounts to meet selection criteria..." (at server init)
- "Not enough random bot accounts available. Need X more!!" (logged continuously after init)

### Root Cause

1. `sPlayerbotAIConfig.randomBotAccounts` is **not populated** if the early return is placed prior to bot 'creation' (storage in memory, not persistence in database).
2. `AddRandomBots()` relies exclusively on this list to query the database for bots.
3. For each account, it queries the DB like:
```SELECT guid, level, race, class FROM characters WHERE account = <accountId>```
5. If `randomBotAccounts` is empty or incomplete:
> - No accounts are queried
> - No bots are found even though they exist

6. Resulting in:
> - No bots logged in
> - Log spam

### Working Implementation
The early return is placed after the bot 'creation' logic (where `randomBotAccounts` is fully populated) but before DB persistence.

This guarantees:
- No undefined DB state
- No zombie accounts
- `AddRandomBots()` behaves correctly with existing accounts

### Possible Future Improvement:
An optimal fix might refactor the current dependency on `randomBotAccounts` to allow `RandomPlayerbotMgr::AddRandomBots()` to dynamically discover valid bot accounts directly from the database, rather than relying on manual population within `CreateRandomBots()`.