### PR TITLE
Build: link ws2_32.lib without using comment lib pragma for MinGW compatability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ target_link_libraries(${LIBRARY_NAME}
   PRIVATE g3dlite
   PRIVATE zlib
 )
+if(WIN32)
+  target_link_libraries(${LIBRARY_NAME}
+    PRIVATE ws2_32
+  )
+endif()
 
 target_include_directories(${LIBRARY_NAME}
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/playerbot/PlayerbotLLMInterface.cpp
+++ b/playerbot/PlayerbotLLMInterface.cpp
@@ -19,7 +19,6 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#pragma comment(lib, "ws2_32.lib")
 #else
 #include <sys/socket.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Linking libraries with `#pragma comment(lib, ...)` in code only works with MSVC.
https://github.com/cmangos/playerbots/blob/4acf9360314ad17566b139056dce93c7d9444561/playerbot/PlayerbotLLMInterface.cpp#L19-L23
This change replaces it in favor of CMake scripts configuration, which makes it compatible with other Windows toolchains such as MinGW (which is supposedly [expected to be compatible](https://github.com/cmangos/issues/wiki/Notes-on-MinGW-toolchains-for-developers)).