### PR TITLE
Fix logic errors

### DIFF
--- a/playerbot/PlayerbotMgr.h
+++ b/playerbot/PlayerbotMgr.h
@@ -51,8 +51,8 @@ public:
     static std::unordered_map<std::string, std::string> GetCommandTexts();
 
     bool DeleteBot(ObjectGuid guid, bool allowInstant = true);
-#ifdef GenerateBotTests
     void CreateBot(Player* master, const std::string param, std::list<std::string>& messages, ObjectGuid& guid);
+#ifdef GenerateBotTests
     void DepositTestResult(const std::string& testName, const std::string& result);
 #endif
 

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -115,8 +115,8 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
         }
         else
         {
-            std::reverse(path.begin(), path.end());
             path = movePath.getPointPath();
+            std::reverse(path.begin(), path.end());
         }
 
         if (path.empty())
@@ -1543,14 +1543,9 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, 
                 if (sPlayerbotAIConfig.hasLog("bot_movement.csv"))
                 {
                     WorldPosition telePos;
-                    if (entry)
-                    {
-                        AreaTrigger const* at = sObjectMgr.GetAreaTrigger(entry);
-                        if (at)
-                            telePos = WorldPosition(at->target_mapId, at->target_X, at->target_Y, at->target_Z, at->target_Orientation);
-                    }
-                    else
-                        telePos = movePosition;
+                    AreaTrigger const* at = sObjectMgr.GetAreaTrigger(entry);
+                    if (at)
+                        telePos = WorldPosition(at->target_mapId, at->target_X, at->target_Y, at->target_Z, at->target_Orientation);
 
                     std::ostringstream out;
                     out << sPlayerbotAIConfig.GetTimestampStr() << "+00,";
@@ -4123,9 +4118,6 @@ bool JumpAction::CanJumpTo(const WorldPosition& src, const WorldPosition& dest, 
 bool JumpAction::JumpTowards(const ai::WorldPosition &src, const ai::WorldPosition &dest, Unit* jumper, float jumpSpeed, bool preSetLanding)
 {
     if (src.getMapId() != dest.getMapId())
-        return false;
-
-    if (src.fDist(dest) > sPlayerbotAIConfig.sightDistance)
         return false;
 
     if (src.fDist(dest) > sPlayerbotAIConfig.sightDistance)


### PR DESCRIPTION
Fixes 3 logic errors and 1 compilation error.

Logic errors on MovementActions : 
- Line 118 : Line swap (because path will always be empty since it's only initialized and not populated in the else)
- Line 1546 : if(entry) will always be true (variable already checked in parent block)
- Line 4131 : Removed duplicate if.

Compile error : misplaced ifdef that included CreateBot.