### PR TITLE
Fix quest reward picking

### DIFF
--- a/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
+++ b/playerbot/strategy/actions/TalkToQuestGiverAction.cpp
@@ -232,16 +232,16 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
     }
     else
     {
-        // Try to pick the usable item. If multiple list usable rewards.
+        // Try to pick the usable item. If multiple, list usable rewards.
         bestIds = BestRewards(quest);
-        if (bestIds.size() > 0)
+        if (bestIds.size() > 1)
         {
             AskToSelectReward(requester, quest, out, true);
         }
         else
         {
-            //Pick the first item
-            ItemPrototype const* proto = sObjectMgr.GetItemPrototype(quest->RewChoiceItemId[*bestIds.begin()]);
+            uint32 rewardIndex = bestIds.empty() ? 0 : *bestIds.begin();
+            ItemPrototype const* proto = sObjectMgr.GetItemPrototype(quest->RewChoiceItemId[rewardIndex]);
             if (proto)
             {
                 args["%item"] = chat->formatItem(proto);
@@ -250,7 +250,7 @@ void TalkToQuestGiverAction::RewardMultipleItem(Player* requester, Quest const* 
                 BroadcastHelper::BroadcastQuestTurnedIn(ai, bot, quest);
             }
 
-            bot->RewardQuest(quest, *bestIds.begin(), questGiver, true);
+            bot->RewardQuest(quest, rewardIndex, questGiver, true);
         }
     }
 }


### PR DESCRIPTION
- Fixes a potential out of bounds error (if bestIds.size < 1, then *bestIds.begin could be out of bounds).
- Fixes a logic error : shouldn't ask to select reward if only one available.