### PR TITLE
Stop pet attacking only if there aren't any more attackers

### DIFF
--- a/playerbot/strategy/actions/ChooseTargetActions.cpp
+++ b/playerbot/strategy/actions/ChooseTargetActions.cpp
@@ -128,28 +128,8 @@ bool SelectNewTargetAction::Execute(Event& event)
     ai->InterruptSpell();
     bot->AttackStop();
 
-    // Stop pet attacking
-    Pet* pet = bot->GetPet();
-    if (pet)
-    {
-        UnitAI* creatureAI = ((Creature*)pet)->AI();
-        if (creatureAI)
-        {
-            // Send pet action packet
-            const ObjectGuid& petGuid = pet->GetObjectGuid();
-            const ObjectGuid& targetGuid = ObjectGuid();
-            const uint8 flag = ACT_COMMAND;
-            const uint32 spellId = COMMAND_FOLLOW;
-            const uint32 command = (flag << 24) | spellId;
 
-            WorldPacket data(CMSG_PET_ACTION);
-            data << petGuid;
-            data << command;
-            data << targetGuid;
-            bot->GetSession()->HandlePetAction(data);
-        }
-    }
-
+    bool moreAttackers = false;
     // Check if there is any enemy targets available to attack
     if (AI_VALUE(bool, "has attackers"))
     {
@@ -159,6 +139,7 @@ bool SelectNewTargetAction::Execute(Event& event)
             // Check if there is an enemy player nearby
             if (AI_VALUE(bool, "has enemy player targets"))
             {
+                moreAttackers = true;
                 return ai->DoSpecificAction("attack enemy player", event, true);
             }
         }
@@ -166,11 +147,38 @@ bool SelectNewTargetAction::Execute(Event& event)
         // Let the dps/tank assist pick a target to attack
         if (ai->HasStrategy("dps assist", BotState::BOT_STATE_NON_COMBAT))
         {
+            moreAttackers = true;
             return ai->DoSpecificAction("dps assist", event, true);
         }
         else if (ai->HasStrategy("tank assist", BotState::BOT_STATE_NON_COMBAT))
         {
+            moreAttackers = true;
             return ai->DoSpecificAction("tank assist", event, true);
+        }
+    }
+    
+    if (!moreAttackers)
+    {
+        // Stop pet attacking
+        Pet* pet = bot->GetPet();
+        if (pet)
+        {
+            UnitAI* creatureAI = ((Creature*)pet)->AI();
+            if (creatureAI)
+            {
+                // Send pet action packet
+                const ObjectGuid& petGuid = pet->GetObjectGuid();
+                const ObjectGuid& targetGuid = ObjectGuid();
+                const uint8 flag = ACT_COMMAND;
+                const uint32 spellId = COMMAND_FOLLOW;
+                const uint32 command = (flag << 24) | spellId;
+
+                WorldPacket data(CMSG_PET_ACTION);
+                data << petGuid;
+                data << command;
+                data << targetGuid;
+                bot->GetSession()->HandlePetAction(data);
+            }
         }
     }
 


### PR DESCRIPTION
Attempt to prevent bug where the pet will either be stuck on follow even while bot continues to fight more attackers, or it chooses to just look at and follow enemies without attacking them.