### PR TITLE
Minor CPPCheck fixes.

### DIFF
--- a/playerbot/WorldPosition.cpp
+++ b/playerbot/WorldPosition.cpp
@@ -1056,10 +1056,10 @@ bool WorldPosition::cropPathTo(std::vector<WorldPosition>& path, const float max
 
    auto bestPos = std::min_element(path.begin(), path.end(), [this](WorldPosition i, WorldPosition j) {return this->sqDistance(i) < this->sqDistance(j); });
 
-   bool insRange = this->sqDistance(*bestPos) <= realMaxDistance * realMaxDistance;
-
    if (bestPos == path.end())
-       return insRange;
+       return false;
+
+   bool insRange = this->sqDistance(*bestPos) <= realMaxDistance * realMaxDistance;
 
    path.erase(std::next(bestPos), path.end());
 

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -368,7 +368,7 @@ bool EquipUpgradesAction::Execute(Event& event)
         bool jMain = j->GetProto()->InventoryType == INVTYPE_WEAPONMAINHAND;
 
         if (iMain != jMain)
-            return iMain > jMain; // mainhand comes first
+            return iMain; // mainhand comes first
 
         return sRandomItemMgr.ItemStatWeight(plr, i) > sRandomItemMgr.ItemStatWeight(plr, j); });
 

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -557,7 +557,7 @@ bool MovementAction::MinimalMove(PlayerbotAI* ai)
     }
 
    //Transport handling: If not on transport wait for transport and teleport on it when it's near (and cut to last transport point). If on transport wait until it is near exit and teleport to exit.
-    if (nextStep->type == PathNodeType::NODE_TRANSPORT && nextStep != path.end())
+    if (nextStep != path.end() && nextStep->type == PathNodeType::NODE_TRANSPORT)
     {
         auto exitStep = std::next(nextStep);
 

--- a/playerbot/strategy/rogue/RogueStrategy.cpp
+++ b/playerbot/strategy/rogue/RogueStrategy.cpp
@@ -1441,7 +1441,6 @@ public:
             (actionName == "bg check objective") ||
             (actionName == "bg check flag") ||
             (actionName == "attack enemy flag carrier") ||
-            (actionName == "attack enemy flag carrier") ||
             (actionName == "travel") ||
             (actionName == "move to suppression device") ||
             (actionName == "disarm suppression device"))

--- a/playerbot/strategy/values/ItemUsageValue.cpp
+++ b/playerbot/strategy/values/ItemUsageValue.cpp
@@ -20,25 +20,14 @@ std::unordered_map<uint32, std::vector<std::pair<uint32, uint32>>> ItemUsageValu
 std::unordered_set<uint32> ItemUsageValue::m_allItemIdsSoldByAnyVendors;
 std::unordered_set<uint32> ItemUsageValue::m_itemIdsSoldByAnyVendorsWithLimitedMaxCount;
 
-ItemQualifier::ItemQualifier(std::string qualifier, bool linkQualifier)
-{
-    itemId = 0;
-    enchantId = 0;
-    randomPropertyId = 0;
-    gem1 = 0;
-    gem2 = 0;
-    gem3 = 0;
-    gem4 = 0;
-    proto = nullptr;
-
+ItemQualifier::ItemQualifier(std::string qualifier, bool linkQualifier) : itemId(0), enchantId(0), randomPropertyId(0), gem1(0), gem2(0), gem3(0), gem4(0), proto(nullptr) {
     std::vector<std::string> numbers = Qualified::getMultiQualifiers(qualifier, ":");
 
     if (numbers.empty())
         return;
 
-    for (char& d : numbers[0]) //Check if itemId contains only numbers
-        if (!isdigit(d))
-            return;
+    if (!std::all_of(numbers[0].begin(), numbers[0].end(), ::isdigit))
+        return;
 
     itemId = stoi(numbers[0]);
 


### PR DESCRIPTION
Fixes for minor issues detected by CPPCheck :

- EquipAction : invalid comparison operators between two booleans. "return iMain" is the same as "iMain > jMain" in this context (since iMain != jMain is guaranteed).
- MovementActions and WorldPosition : pointer dereferencing BEFORE testing against path.end(). For WorldPosition, since we already check with path.empty() above, bestPos will never be path.end().
- ItemUsageValue : use of initialization list instead of initializing in constructor body, + use of std::all_of to reduce algorithm.