### PR TITLE
fix underflow in TravelNodeMap::getRoute

### DIFF
--- a/playerbot/TravelNode.cpp
+++ b/playerbot/TravelNode.cpp
@@ -1727,11 +1727,11 @@ TravelNodeRoute TravelNodeMap::getRoute(WorldPosition startPos, WorldPosition en
     std::vector<WorldPosition> newStartPath;
     std::vector<TravelNode*> startNodes = getNodes(startPos, -1, transportEntry), endNodes = getNodes(endPos);
 
-    if (startNodes.empty())
+    if (startNodes.empty() || endNodes.empty())
         return TravelNodeRoute();    
 
-    uint32 startNr = std::min(5, (int)startNodes.size()-1);
-    uint32 endNr = std::min(5, (int)endNodes.size()-1);
+    uint32 startNr = std::min(5, (int)startNodes.size());
+    uint32 endNr = std::min(5, (int)endNodes.size());
 
     //Partial sort to get the closest 5 nodes at the begin of the array.        
     std::partial_sort(startNodes.begin(), startNodes.begin() + startNr, startNodes.end(), [startPos](TravelNode* i, TravelNode* j) {return i->getPosition()->sqDistance(startPos) < j->getPosition()->sqDistance(startPos); });


### PR DESCRIPTION
Fixes an underflow when `endNodes` is empty in `TravelNodeMap::getRoute`. There was already a check here for `startNodes` so I just added a check on `endNodes` too.

In the case where `endNodes=5` the sorting bounds were also off by one (the sort would yield the nearest 4 nodes, not the nearest 5). I fixed this as well. Here was the top of my stack trace:

```gdb
(gdb) bt
#0  0x000000000187bf48 in std::__make_heap<__gnu_cxx::__normal_iterator<ai::TravelNode**, std::vector<ai::TravelNode*> >, __gnu_cxx::__ops::_Iter_comp_iter<ai::
TravelNodeMap::getRoute(ai::WorldPosition, ai::WorldPosition, std::vector<ai::WorldPosition>&, std::vector<ai::WorldPosition>&, Unit*)::<lambda(ai::TravelNode*,
 ai::TravelNode*)> > > (__comp=..., __last=<error reading variable: Cannot access memory at address 0x7fffffff8>,
    __first=non-dereferenceable iterator for std::vector) at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-12.3.0/include/c++/12.3.0/bits/stl_heap.h:355
#1  std::__heap_select<__gnu_cxx::__normal_iterator<ai::TravelNode**, std::vector<ai::TravelNode*> >, __gnu_cxx::__ops::_Iter_comp_iter<ai::TravelNodeMap::getRo
ute(ai::WorldPosition, ai::WorldPosition, std::vector<ai::WorldPosition>&, std::vector<ai::WorldPosition>&, Unit*)::<lambda(ai::TravelNode*, ai::TravelNode*)> >
 > (__comp=..., __last=..., __middle=<error reading variable: Cannot access memory at address 0x7fffffff8>,
    __first=non-dereferenceable iterator for std::vector) at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-12.3.0/include/c++/12.3.0/bits/stl_algo.h:1629
#2  std::__partial_sort<__gnu_cxx::__normal_iterator<ai::TravelNode**, std::vector<ai::TravelNode*> >, __gnu_cxx::__ops::_Iter_comp_iter<ai::TravelNodeMap::getR
oute(ai::WorldPosition, ai::WorldPosition, std::vector<ai::WorldPosition>&, std::vector<ai::WorldPosition>&, Unit*)::<lambda(ai::TravelNode*, ai::TravelNode*)>
> > (__comp=..., __last=..., __middle=<error reading variable: Cannot access memory at address 0x7fffffff8>,
    __first=non-dereferenceable iterator for std::vector) at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-12.3.0/include/c++/12.3.0/bits/stl_algo.h:1900
#3  std::partial_sort<__gnu_cxx::__normal_iterator<ai::TravelNode**, std::vector<ai::TravelNode*> >, ai::TravelNodeMap::getRoute(ai::WorldPosition, ai::WorldPos
ition, std::vector<ai::WorldPosition>&, std::vector<ai::WorldPosition>&, Unit*)::<lambda(ai::TravelNode*, ai::TravelNode*)> > (__comp=..., __last=...,
    __middle=<error reading variable: Cannot access memory at address 0x7fffffff8>, __first=non-dereferenceable iterator for std::vector)
    at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gcc-12.3.0/include/c++/12.3.0/bits/stl_algo.h:4710
#4  ai::TravelNodeMap::getRoute (this=this@entry=0x565facb0, startPos=..., endPos=..., startPath=std::vector of length 1, capacity 1 = {...},
    endPath=std::vector of length 0, capacity 0, unit=0x7f416927d850) at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/TravelNode.cpp:1664
#5  0x000000000187f6f7 in ai::TravelNodeMap::getFullPath (startPos=..., endPos=..., unit=0x7f416927d850)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/TravelNode.cpp:1831
#6  0x0000000001b5db1a in ai::MovementAction::ResolveMovePath (this=this@entry=0x7f42690eefe0, startPosition=..., endPosition=...,
    mover=mover@entry=0x7f416927d850, minDist=minDist@entry=0.100000001, maxDist=maxDist@entry=60, outMovePosition=..., outMovePath=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/MovementActions.cpp:653
#7  0x0000000001b63fd1 in ai::MovementAction::MoveTo2 (this=0x7f42690eefe0, mapId=<optimized out>, x=<optimized out>, y=<optimized out>, z=-55.2596016,
    idle=<optimized out>, react=<optimized out>, noPath=<optimized out>, ignoreEnemyTargets=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/MovementActions.cpp:1142
#8  0x0000000001b65343 in ai::MovementAction::MoveTo (this=<optimized out>, mapId=<optimized out>, x=<optimized out>, y=<optimized out>, z=<optimized out>,
    idle=<optimized out>, react=<optimized out>, noPath=<optimized out>, ignoreEnemyTargets=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/MovementActions.cpp:1295]
[...]
```