### PR TITLE
Check if aura is a positive effect before trying to dispel it

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -5472,7 +5472,8 @@ bool PlayerbotAI::HasAuraToDispel(Unit* target, uint32 dispelType)
 			uint32 spellId = entry->Id;
 
 			bool isPositiveSpell = IsPositiveSpell(spellId);
-			if (isPositiveSpell && isFriend)
+            bool isPositiveAuraEffect = IsPositiveAuraEffect(entry, aura->GetEffIndex());
+			if ((isPositiveSpell || isPositiveAuraEffect) && isFriend)
 				continue;
 
 			if (!isPositiveSpell && !isFriend)


### PR DESCRIPTION
Fixes issue with spells such as 35336 which the playerbots attempt to dispel but it's not dispellable because it's a negative spell with positive aura effect.