### PR TITLE
fix unitialized acess in ReportTravelTarget

### DIFF
--- a/playerbot/strategy/actions/ChooseTravelTargetAction.cpp
+++ b/playerbot/strategy/actions/ChooseTravelTargetAction.cpp
@@ -165,7 +165,7 @@ void ChooseTravelTargetAction::ReportTravelTarget(Player* bot, Player* requester
 
     TravelDestination* destination = newTarget->GetDestination();
 
-    TravelDestination* oldDestination;
+    TravelDestination* oldDestination = nullptr;
 
     if (oldTarget)
         oldDestination = oldTarget->GetDestination();


### PR DESCRIPTION
oldDestination was only assigned a value when oldTarget was non-null. Otherwise it was left uninitialized. This fix explicitly initializes it and fixes a coredump I've experienced. Backtrace attached:

```
warning: Section `.reg-xstate/171802' in core file too small.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/libthread_[[db.so](http://db.so)](http://db.so).1".
Core was generated by `/opt/cmangos-tbc/run/bin/mangosd -c /opt/cmangos-tbc/run/etc/mangosd.conf -a /o'.
Program terminated with signal SIGSEGV, Segmentation fault.
warning: Section `.reg-xstate/171802' in core file too small.
#0  0x0000000001a2bcb9 in ai::ChooseTravelTargetAction::ReportTravelTarget (bot=0x7f6f87cc8fa0, requester=requester@entry=0x7f6f66cd3820,
    newTarget=newTarget@entry=0x7f6f26045900, oldTarget=oldTarget@entry=0x0)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/ChooseTravelTargetAction.cpp:191
191             if (!oldDestination || typeid(*oldDestination) != typeid(NullTravelDestination))
[Current thread is 1 (Thread 0x7f7074b5b6c0 (LWP 171802))]
(gdb) bt
#0  0x0000000001a2bcb9 in ai::ChooseTravelTargetAction::ReportTravelTarget (bot=0x7f6f87cc8fa0, requester=requester@entry=0x7f6f66cd3820,
    newTarget=newTarget@entry=0x7f6f26045900, oldTarget=oldTarget@entry=0x0)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/ChooseTravelTargetAction.cpp:191
#1  0x0000000001ac875d in ai::GoAction::TellWhereToGo (this=this@entry=0x7f7024e0b660, param="we heading?", requester=requester@entry=0x7f6f66cd3820)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/GoAction.cpp:507
#2  0x0000000001ac8886 in ai::GoAction::Execute (this=0x7f7024e0b660, event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/actions/GoAction.cpp:48
#3  0x00000000019935bc in ai::ReactionEngine::ListenAndExecute (this=0x7f6f1ca77510, action=0x7f7024e0b660, event=...)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/ReactionEngine.cpp:218
#4  0x0000000001990f4e in ai::ReactionEngine::StartReaction (this=this@entry=0x7f6f1ca77510)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/ReactionEngine.cpp:140
#5  0x000000000199254b in ai::ReactionEngine::Update (this=0x7f6f1ca77510, elapsed=elapsed@entry=100, minimal=minimal@entry=true, isStunned=isStunned@entry=false,
    reactionFound=@0x7f7074b5a947: false) at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/strategy/ReactionEngine.cpp:189
#6  0x0000000001724c56 in PlayerbotAI::UpdateAIReaction (this=this@entry=0x7f6f2dadc8b0, elapsed=elapsed@entry=100, minimal=<optimized out>,
    isStunned=<optimized out>) at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:623
#7  0x000000000172feb3 in PlayerbotAI::UpdateAI (this=<optimized out>, elapsed=100, minimal=<optimized out>)
    at /opt/cmangos-tbc/mangos/src/modules/PlayerBots/playerbot/PlayerbotAI.cpp:589
#8  0x0000000000e5e4ff in Player::UpdateAI (this=0x7f6f87cc8fa0, diff=100, minimal=<optimized out>) at /opt/cmangos-tbc/mangos/src/game/Entities/Player.cpp:1679
#9  0x0000000000fd8d97 in Map::Update (this=0x21dbf500, t_diff=@0x7f6f3a0d3cb8: 100) at /opt/cmangos-tbc/mangos/src/game/Maps/Map.cpp:883
#10 0x0000000000fe6c62 in MapUpdateWorker::execute (this=0x7f6f3a0d3ca0) at /opt/cmangos-tbc/mangos/src/game/Maps/MapWorkers.h:52
#11 0x0000000000ff111c in MapUpdater::WorkerThread (this=0xe8b4910) at /opt/cmangos-tbc/mangos/src/game/Maps/MapUpdater.cpp:96
#12 0x00007f7089ae05c3 in execute_native_thread_routine () from /nix/store/g7mbqlvnfrz032bl5aryaifdk7m45xwr-gcc-12.3.0-lib/lib/libstdc++.so.6
#13 0x00007f70898a20e4 in start_thread () from /nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/[[libc.so](http://libc.so)](http://libc.so).6
#14 0x00007f708992477c in clone3 () from /nix/store/qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77/lib/[[libc.so](http://libc.so)](http://libc.so).6
(gdb)
```