### PR TITLE
Check if aura is a positive effect before trying to dispel it

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -5472,7 +5472,8 @@ bool PlayerbotAI::HasAuraToDispel(Unit* target, uint32 dispelType)
 			uint32 spellId = entry->Id;
 
 			bool isPositiveSpell = IsPositiveSpell(spellId);
-			if (isPositiveSpell && isFriend)
+            bool isPositiveAuraEffect = IsPositiveAuraEffect(entry, aura->GetEffIndex());
+			if ((isPositiveSpell || isPositiveAuraEffect) && isFriend)
 				continue;
 
 			if (!isPositiveSpell && !isFriend)


### PR DESCRIPTION
Check if aura is a positive effect before trying to dispel it

Prevent bots from trying to spam dispel something which can't be dispelled.