### PR TITLE
Better bot profession init

### DIFF
--- a/playerbot/PlayerbotFactory.cpp
+++ b/playerbot/PlayerbotFactory.cpp
@@ -4022,27 +4022,45 @@ void PlayerbotFactory::InitTradeSkills()
             SpellEntry const* proto = sServerFacade.LookupSpellInfo(tSpell->spell);
             if (!proto)
                 continue;
-
+            
             SpellEntry const* spell = sServerFacade.LookupSpellInfo(tSpell->spell);
             if (spell)
             {
                 std::string SpellName = spell->SpellName[0];
+#ifdef MANGOSBOT_ZERO
                 if (spell->Effect[EFFECT_INDEX_1] == SPELL_EFFECT_SKILL_STEP)
+#elif defined(MANGOSBOT_ONE) || defined(MANGOSBOT_TWO) // TBC OR WOTLK
+                if (spell->Effect[EFFECT_INDEX_1] == SPELL_EFFECT_SKILL || spell->Effect[EFFECT_INDEX_1] == SPELL_EFFECT_SKILL_STEP)
+#endif
                 {
                     uint32 skill = spell->EffectMiscValue[EFFECT_INDEX_1];
 
-                    if (skill && !bot->HasSkill(skill))
+                    if (skill)
                     {
                         SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
                         if (pSkill)
                         {
-                            if (SpellName.find("Apprentice") != std::string::npos && pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY)
-                                continue;
+                            if (!bot->HasSkill(skill))
+                            {
+#ifdef MANGOSBOT_ZERO
+                                if (SpellName.find("Apprentice") != std::string::npos && pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY)
+                                    continue;
+#elif defined(MANGOSBOT_ONE) || defined(MANGOSBOT_TWO) // TBC OR WOTLK
+                                std::string SpellRank = spell->Rank[0];
+                                if (SpellName.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
+                                    continue;
+                                else if (SpellRank.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
+                                    continue;
+#endif
+                            }
+                            else
+                                bot->learnSpell(spell->Id, false);
                         }
                     }
+                    
                 }
             }
-
+            
 #ifdef MANGOSBOT_ZERO
             if (tSpell->learnedSpell)
             {

--- a/playerbot/PlayerbotFactory.cpp
+++ b/playerbot/PlayerbotFactory.cpp
@@ -4246,17 +4246,68 @@ void PlayerbotFactory::SetRandomSkill(uint16 id)
 {
     uint32 maxValue = level * 5; // vanilla 60*5 = 300
 
-// do not let skill go beyond limit even if maxlevel > blizzlike
-#ifndef MANGOSBOT_ZERO
-	if (level > 60)
+    SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(id);
+    if (!pSkill)
+        return;
+
+    SkillRangeType skillType = GetSkillRangeType(pSkill, false);
+
+    // if this is not a profession type of skill or skill that is 1/1
+    if (skillType != SKILL_RANGE_LEVEL && skillType != SKILL_RANGE_MONO)
     {
+        // do not let skill go beyond limit even if maxlevel > blizzlike
+#ifndef MANGOSBOT_ZERO
+            if (level > 60)
+            {
 #ifdef MANGOSBOT_ONE
-        maxValue = (level + 5) * 5;   // tbc (70 + 5)*5 = 375
+                maxValue = (level + 5) * 5;   // tbc (70 + 5)*5 = 375
 #else
-        maxValue = (level + 10) * 5;  // wotlk (80 + 10)*5 = 450
+                maxValue = (level + 10) * 5;  // wotlk (80 + 10)*5 = 450
 #endif
-	}
+            }
 #endif
+    }
+    else
+    {
+        // profession based levels. They should learn ranks from trainers, but for now assume
+        // scaling similar to riding skill
+#ifdef MANGOSBOT_ZERO
+        if (bot->GetLevel() >= 35)
+            maxValue = 300;
+        else if (bot->GetLevel() >= 20)
+            maxValue = 225;
+        else if (bot->GetLevel() >= 10)
+            maxValue = 150;
+        else 
+            maxValue = 75;
+#endif
+#ifdef MANGOSBOT_ONE
+        if (bot->GetLevel() >= 50)
+            maxValue = 375;
+        else if (bot->GetLevel() >= 35)
+            maxValue = 300;
+        else if (bot->GetLevel() >= 20)
+            maxValue = 225;
+        else if (bot->GetLevel() >= 10)
+            maxValue = 150;
+        else 
+            maxValue = 75;
+#endif
+#ifdef MANGOSBOT_TWO
+        if (bot->GetLevel() >= 65)
+            maxValue = 450;
+        else if (bot->GetLevel() >= 50)
+            maxValue = 375;
+        else if (bot->GetLevel() >= 35)
+            maxValue = 300;
+        else if (bot->GetLevel() >= 20)
+            maxValue = 225;
+        else if (bot->GetLevel() >= 10)
+            maxValue = 150;
+        else 
+            maxValue = 75;
+#endif
+    }
 
     uint32 value = urand(maxValue - level, maxValue);
     uint32 curValue = bot->GetSkillValue(id);

--- a/playerbot/strategy/actions/AutoLearnSpellAction.cpp
+++ b/playerbot/strategy/actions/AutoLearnSpellAction.cpp
@@ -107,7 +107,7 @@ void AutoLearnSpellAction::LearnTrainerSpells(std::ostringstream* out)
             TrainerSpellState state = bot->GetTrainerSpellState(tSpell, reqLevel);
             if (state != TRAINER_SPELL_GREEN)
                 continue;
-
+            
             if (co->TrainerType == TRAINER_TYPE_TRADESKILLS)
             {
                 SpellEntry const* spell = sServerFacade.LookupSpellInfo(tSpell->spell);
@@ -127,22 +127,29 @@ void AutoLearnSpellAction::LearnTrainerSpells(std::ostringstream* out)
                                 SkillLineEntry const* pSkill = sSkillLineStore.LookupEntry(skill);
                                 if (pSkill)
                                 {
+                                    if (!bot->HasSkill(skill))
+                                    {
 #ifdef MANGOSBOT_ZERO
-                                    if (SpellName.find("Apprentice") != std::string::npos && pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY)
-                                        continue;
+                                        if (SpellName.find("Apprentice") != std::string::npos && pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY)
+                                            continue;
 #elif defined(MANGOSBOT_ONE) || defined(MANGOSBOT_TWO) // TBC OR WOTLK
-                                    std::string SpellRank = spell->Rank[0];
-                                    if (SpellName.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
-                                        continue;
-                                    else if (SpellRank.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
-                                        continue;
+                                        std::string SpellRank = spell->Rank[0];
+                                        if (SpellName.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
+                                            continue;
+                                        else if (SpellRank.find("Apprentice") != std::string::npos && (pSkill->categoryId == SKILL_CATEGORY_PROFESSION || pSkill->categoryId == SKILL_CATEGORY_SECONDARY))
+                                            continue;
 #endif
+                                    }
+                                    else
+                                        bot->learnSpell(spell->Id, false);
+
                                 }
                             }
                         }
                 }
 
             }
+            
 #ifdef MANGOSBOT_ZERO // Vanilla
             LearnSpellFromSpell(tSpell->spell, out);
 #elif defined(MANGOSBOT_ONE) || defined(MANGOSBOT_TWO)


### PR DESCRIPTION
This PR does two things with regards to running init on bots:

1. Organizes the max levels of professions learned based on certain level points and according to the relevant profession ranks. So instead of profession skill max being strictly based on level, it will be organized as 75/150/225/300/375/450, depending on expansion of course.

2. Allows bots to actually learn the profession ranks, that way they keep their levels on logout. This hopefully prevents the bug where their max level is lower than current level.

The spells to learn profession ranks (apprentice, journeyman etc) exists in the trainer templates, but bots were previously "casting" the spell, since the spell did not have a spell you could train. Casting these spells does nothing, you need to learn the spells to receive the profession. For instance, Apprentice First aid spell in trainer template is 3273. When you go to a trainer and select this spell, the trainer will cast spell 3279, which teaches you 3273, which teaches you Apprentice first aid. Since 3279 is not in the trainer templates (which are in the cmangos core db), we must manually teach the bot the spell 3273 (equivalent to doing .learn for gm commands) rather than the cast which it was defaulting to.

Because bots were receiving max levels for professions, but they weren't actually learning the ranks for those professions, you could end up in a situation where a bot is stuck at a certain max level, or, on logout the game sees that the max level is higher than the rank the bot has learned and decides to lower it to the next level (so if max is 300 but bot does not have artisan, it drops to 225, all the way to 75).

Now when you run init, bots will have max levels appropriate for primary professions (I haven't got secondary to work yet) and these will persist. I also cleaned up the code a bit so there's parity in the checks between init and auto training while leveling, if you have that set.