### PR TITLE
Enable soul link

### DIFF
--- a/playerbot/strategy/warlock/DemonologyWarlockStrategy.cpp
+++ b/playerbot/strategy/warlock/DemonologyWarlockStrategy.cpp
@@ -539,10 +539,9 @@ void DemonologyWarlockBuffStrategy::InitCombatTriggers(std::list<TriggerNode*>& 
 void DemonologyWarlockBuffStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
 {
     WarlockBuffStrategy::InitNonCombatTriggers(triggers);
-
     triggers.push_back(new TriggerNode(
         "soul link",
-        NextAction::array(0, new NextAction("soul link", ACTION_NORMAL), NULL)));
+        NextAction::array(0, new NextAction("soul link", ACTION_NORMAL + 1), NULL)));
 }
 
 void DemonologyWarlockBuffPveStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -555,6 +554,9 @@ void DemonologyWarlockBuffPveStrategy::InitNonCombatTriggers(std::list<TriggerNo
 {
     DemonologyWarlockBuffStrategy::InitNonCombatTriggers(triggers);
     WarlockBuffPveStrategy::InitNonCombatTriggers(triggers);
+    triggers.push_back(new TriggerNode(
+        "soul link",
+        NextAction::array(0, new NextAction("soul link", ACTION_NORMAL + 1), NULL)));
 }
 
 void DemonologyWarlockBuffPvpStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -910,10 +912,6 @@ void DemonologyWarlockBuffStrategy::InitCombatTriggers(std::list<TriggerNode*>& 
 void DemonologyWarlockBuffStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
 {
     WarlockBuffStrategy::InitNonCombatTriggers(triggers);
-
-    triggers.push_back(new TriggerNode(
-        "soul link",
-        NextAction::array(0, new NextAction("soul link", ACTION_NORMAL), NULL)));
 }
 
 void DemonologyWarlockBuffPveStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
+++ b/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
@@ -242,6 +242,7 @@ namespace ai
                 creators["no succubus"] = [](PlayerbotAI* ai) { return new NoSuccubusTrigger(ai); };
                 creators["no felhunter"] = [](PlayerbotAI* ai) { return new NoFelhunterTrigger(ai); };
                 creators["no felguard"] = [](PlayerbotAI* ai) { return new NoFelguardTrigger(ai); };
+                creators["soul link"] = [](PlayerbotAI* ai) { return new SoulLinkTrigger(ai); };
                 creators["spell lock"] = [](PlayerbotAI* ai) { return new SpellLockTrigger(ai); };
                 creators["spell lock enemy healer"] = [](PlayerbotAI* ai) { return new SpellLockEnemyHealerTrigger(ai); };
                 creators["seed of corruption on attacker"] = [](PlayerbotAI* ai) { return new SeedOfCorruptionOnAttackerTrigger(ai); };

--- a/playerbot/strategy/warlock/WarlockTriggers.h
+++ b/playerbot/strategy/warlock/WarlockTriggers.h
@@ -230,15 +230,15 @@ namespace ai
     class DemonicSacrificeTrigger : public Trigger
     {
     public:
-        DemonicSacrificeTrigger(PlayerbotAI* ai) : Trigger(ai, "demonic sacrifice", 5) {}
+        DemonicSacrificeTrigger(PlayerbotAI* ai) : Trigger(ai, "demonic sacrifice") {}
         bool IsActive() override;
     };
 
-    class SoulLinkTrigger : public Trigger
+    class SoulLinkTrigger : public BuffTrigger
     {
     public:
-        SoulLinkTrigger(PlayerbotAI* ai) : Trigger(ai, "soul link", 5) {}
-        bool IsActive() override;
+        SoulLinkTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "soul link", 5) {}
+        virtual bool IsActive() override;
     };
 
     class NoSpecificPetTrigger : public Trigger


### PR DESCRIPTION
Add trigger for soul link since it existed but wasn't added in the list of triggers. Now warlocks cast soul link if they have the spell, don't have the buff, and summon a pet.