### PR TITLE
Protection paladin adjustments 1

### DIFF
--- a/playerbot/strategy/paladin/PaladinActions.cpp
+++ b/playerbot/strategy/paladin/PaladinActions.cpp
@@ -101,7 +101,7 @@ std::vector<std::string> CastPveBlessingAction::GetPossibleBlessingsForTarget(Un
         {
             if (player->getClass() == CLASS_PALADIN)
             {
-                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", , "blessing of light", "blessing of might"  };
+                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of might"  };
             }
             else
             {

--- a/playerbot/strategy/paladin/PaladinActions.cpp
+++ b/playerbot/strategy/paladin/PaladinActions.cpp
@@ -101,7 +101,7 @@ std::vector<std::string> CastPveBlessingAction::GetPossibleBlessingsForTarget(Un
         {
             if (player->getClass() == CLASS_PALADIN)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of sanctuary", "blessing of light" };
+                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", , "blessing of light", "blessing of might"  };
             }
             else
             {
@@ -120,7 +120,7 @@ std::vector<std::string> CastPveBlessingAction::GetPossibleBlessingsForTarget(Un
             }
             else
             {
-                blessings = { "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
             }
         }
     }

--- a/playerbot/strategy/paladin/PaladinActions.cpp
+++ b/playerbot/strategy/paladin/PaladinActions.cpp
@@ -175,7 +175,7 @@ std::vector<std::string> CastRaidBlessingAction::GetPossibleBlessingsForTarget(U
         {
             if (player->getClass() == CLASS_PALADIN)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of sanctuary", "blessing of light" };
+                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of might"  };
             }
             else
             {
@@ -194,7 +194,7 @@ std::vector<std::string> CastRaidBlessingAction::GetPossibleBlessingsForTarget(U
             }
             else
             {
-                blessings = { "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
             }
         }
     }
@@ -304,7 +304,7 @@ std::vector<std::string> CastPveBlessingOnPartyAction::GetPossibleBlessingsForTa
         {
             if (player->getClass() == CLASS_PALADIN)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of sanctuary", "blessing of light" };
+                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of might"  };
             }
             else
             {
@@ -319,11 +319,11 @@ std::vector<std::string> CastPveBlessingOnPartyAction::GetPossibleBlessingsForTa
         {
             if (player->getClass() == CLASS_HUNTER)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of light", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of light", "blessing of sanctuary" };
             }
             else
             {
-                blessings = { "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of sanctuary", "blessing of might" };
+                blessings = { "blessing of salvation", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of sanctuary", "blessing of might" };
             }
         }
         else
@@ -334,7 +334,7 @@ std::vector<std::string> CastPveBlessingOnPartyAction::GetPossibleBlessingsForTa
             }
             else
             {
-                blessings = { "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
             }
         }
     }
@@ -410,7 +410,7 @@ std::vector<std::string> CastRaidBlessingOnPartyAction::GetPossibleBlessingsForT
         {
             if (player->getClass() == CLASS_PALADIN)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of sanctuary", "blessing of light" };
+                blessings = { "blessing of sanctuary", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of might"  };
             }
             else
             {
@@ -419,17 +419,17 @@ std::vector<std::string> CastRaidBlessingOnPartyAction::GetPossibleBlessingsForT
         }
         else if (ai->IsHeal(player))
         {
-            blessings = { "blessing of wisdom", "blessing of kings", "blessing of sanctuary", "blessing of light", "blessing of might" };
+            blessings = { "blessing of wisdom", "blessing of kings", "blessing of light", "blessing of sanctuary", "blessing of might" };
         }
         else if (ai->IsRanged(player))
         {
             if (player->getClass() == CLASS_HUNTER)
             {
-                blessings = { "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of light", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of wisdom", "blessing of kings", "blessing of might", "blessing of light", "blessing of sanctuary" };
             }
             else
             {
-                blessings = { "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of sanctuary", "blessing of might" };
+                blessings = { "blessing of salvation", "blessing of kings", "blessing of wisdom", "blessing of light", "blessing of sanctuary", "blessing of might" };
             }
         }
         else
@@ -440,7 +440,7 @@ std::vector<std::string> CastRaidBlessingOnPartyAction::GetPossibleBlessingsForT
             }
             else
             {
-                blessings = { "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
+                blessings = { "blessing of salvation", "blessing of might", "blessing of kings", "blessing of light", "blessing of wisdom", "blessing of sanctuary" };
             }
         }
     }

--- a/playerbot/strategy/paladin/PaladinActions.h
+++ b/playerbot/strategy/paladin/PaladinActions.h
@@ -10,6 +10,8 @@ namespace ai
 	BUFF_ACTION(CastSealOfWisdomAction, "seal of wisdom");
 	BUFF_ACTION(CastSealOfCommandAction, "seal of command");
 	BUFF_ACTION(CastSealOfVengeanceAction, "seal of vengeance");
+    BUFF_ACTION(CastSealOfTheCrusaderAction, "seal of the crusader");
+    BUFF_ACTION(CastSealOfBloodAction, "seal of blood");
 
 	class CastJudgementAction : public CastMeleeDebuffSpellAction
 	{
@@ -17,7 +19,34 @@ namespace ai
 		CastJudgementAction(PlayerbotAI* ai) : CastMeleeDebuffSpellAction(ai, "judgement") { range = 10.0f; }
 		virtual bool isUseful() 
 		{
-			return ai->HasAnyAuraOf(bot, "seal of justice", "seal of command", "seal of vengeance", "seal of blood", "seal of righteousness", "seal of light", "seal of wisdom", NULL);
+            Unit* target = bot->GetTarget();
+            if (target && target->IsAlive())
+            {
+                if (ai->HasAnyAuraOf(bot, "seal of vengeance", NULL))
+                    return target->GetAuraCount(31803) > 2; // pointless to judge with no stacks!
+                else if (ai->HasAnyAuraOf(bot, "seal of wisdom", NULL))
+                {
+                    return !target->HasAura(20186) && !target->HasAura(20354) &&
+                        !target->HasAura(20355) && !target->HasAura(27164); 
+                }
+                else if (ai->HasAnyAuraOf(bot, "seal of light", NULL))
+                {
+                    return !target->HasAura(20185) && !target->HasAura(20344) &&
+                        !target->HasAura(20345) && !target->HasAura(20346) &&
+                        !target->HasAura(27162); 
+                }
+                else if (ai->HasAnyAuraOf(bot, "seal of the crusader", NULL))
+                {
+                    return !target->HasAura(21183) && !target->HasAura(20188) && 
+                        !target->HasAura(20300) && !target->HasAura(20301) &&
+                        !target->HasAura(20302) && !target->HasAura(20303) &&
+                        !target->HasAura(27159);
+                }
+                else
+                    return ai->HasAnyAuraOf(bot, "seal of justice", "seal of command", "seal of blood", "seal of righteousness", NULL);
+            }
+            else
+                return false;
 		}
 	};
 

--- a/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
+++ b/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
@@ -28,7 +28,7 @@ namespace ai
 #endif
 #ifdef MANGOSBOT_ONE
                     if (ai->HasSpell(31935))
-                        return new PullStrategy(ai, "avenger's shield"); 
+                        return new PullStrategy(ai, "avenger's shield", "seal of wisdom"); 
                     else
                         return new PullStrategy(ai, "judgement", "seal of righteousness");
 #endif
@@ -312,6 +312,8 @@ namespace ai
             {
                 creators["seal of command"] = [](PlayerbotAI* ai) { return new CastSealOfCommandAction(ai); };
                 creators["seal of vengeance"] = [](PlayerbotAI* ai) { return new CastSealOfVengeanceAction(ai); };
+                creators["seal of blood"] = [](PlayerbotAI* ai) { return new CastSealOfBloodAction(ai); };
+                creators["seal of the crusader"] = [](PlayerbotAI* ai) { return new CastSealOfTheCrusaderAction(ai); };
                 creators["pve blessing"] = [](PlayerbotAI* ai) { return new CastPveBlessingAction(ai); };
                 creators["pve greater blessing"] = [](PlayerbotAI* ai) { return new CastPveGreaterBlessingAction(ai); };
                 creators["pvp blessing"] = [](PlayerbotAI* ai) { return new CastPvpBlessingAction(ai); };

--- a/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
+++ b/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
@@ -22,11 +22,20 @@ namespace ai
                 creators["cc"] = [](PlayerbotAI* ai) { return new CcPlaceholderStrategy(ai); };
                 creators["offheal"] = [](PlayerbotAI* ai) { return new OffhealPlaceholderStrategy(ai); };
                 creators["boost"] = [](PlayerbotAI* ai) { return new BoostPlaceholderStrategy(ai); };
+                creators["pull"] = [](PlayerbotAI* ai) {
 #ifdef MANGOSBOT_TWO
-                creators["pull"] = [](PlayerbotAI* ai) { return new PullStrategy(ai, "judgement of light", "seal of righteousness"); };
-#else
-                creators["pull"] = [](PlayerbotAI* ai) { return new PullStrategy(ai, "judgement", "seal of righteousness"); };
+                    return new PullStrategy(ai, "judgement of light", "seal of righteousness");
 #endif
+#ifdef MANGOSBOT_ONE
+                    if (ai->HasSpell(31935))
+                        return new PullStrategy(ai, "avenger's shield"); 
+                    else
+                        return new PullStrategy(ai, "judgement", "seal of righteousness");
+#endif
+#ifdef MANGOSBOT_ZERO
+                    return new PullStrategy(ai, "judgement", "seal of righteousness");      
+#endif
+                };
             }
         };
 

--- a/playerbot/strategy/paladin/PaladinTriggers.cpp
+++ b/playerbot/strategy/paladin/PaladinTriggers.cpp
@@ -12,7 +12,9 @@ bool SealTrigger::IsActive()
         !ai->HasAura("seal of command", target) &&
         !ai->HasAura("seal of vengeance", target) &&
 		!ai->HasAura("seal of righteousness", target) &&
+        !ai->HasAura("seal of the crusader", target) &&
 		!ai->HasAura("seal of light", target) &&
+        !ai->HasAura("seal of blood", target) &&
         !ai->HasAura("seal of wisdom", target) &&
         AI_VALUE2(bool, "combat", "self target");
 }

--- a/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
@@ -181,11 +181,11 @@ void ProtectionPaladinAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 2), NULL)));
+        NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",
-        NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 1), NULL)));
+        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "consecration",
@@ -692,18 +692,18 @@ void ProtectionPaladinRaidStrategy::InitDeadTriggers(std::list<TriggerNode*>& tr
 void ProtectionPaladinAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 {
     PaladinAoeStrategy::InitCombatTriggers(triggers);
+    triggers.push_back(new TriggerNode(
+        "consecration",
+        NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 4), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
+        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",
         NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "consecration",
-        NextAction::array(0, new NextAction("consecration", ACTION_HIGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "avenger's shield",

--- a/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
@@ -12,6 +12,7 @@ public:
     {
         creators["seal of vengeance"] = &seal_of_vengeance;
         creators["hand of reckoning"] = &hand_of_reckoning;
+        creators["righteous defense"] = &righteous_defense;
         creators["judgement"] = &judgement;
     }
 
@@ -19,6 +20,8 @@ private:
     ACTION_NODE_A(seal_of_vengeance, "seal of vengeance", "seal of righteousness");
 
     ACTION_NODE_A(hand_of_reckoning, "hand of reckoning", "righteous defense");
+
+    ACTION_NODE_C(righteous_defense, "righteous defense", "avenger's shield");
 
     ACTION_NODE_A(judgement, "judgement", "exorcism");
 };
@@ -563,7 +566,7 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("hand of reckoning", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("righteous defense", ACTION_MOVE), NULL)));
 
     triggers.push_back(new TriggerNode(
         "holy shield",
@@ -617,6 +620,7 @@ void ProtectionPaladinPveStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
     triggers.push_back(new TriggerNode(
         "target critical health",
         NextAction::array(0, new NextAction("hammer of wrath", ACTION_HIGH), NULL)));
+    
 }
 
 void ProtectionPaladinPveStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -696,18 +700,18 @@ void ProtectionPaladinAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
         "consecration",
         NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 4), NULL)));
 
-    triggers.push_back(new TriggerNode(
+    /*triggers.push_back(new TriggerNode(
         "melee light aoe",
         NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
-
+    */
     triggers.push_back(new TriggerNode(
         "melee light aoe",
         NextAction::array(0, new NextAction("consecration", ACTION_HIGH + 1), NULL)));
 
-
-    triggers.push_back(new TriggerNode(
+    /*triggers.push_back(new TriggerNode(
         "avenger's shield",
         NextAction::array(0, new NextAction("avenger's shield", ACTION_HIGH), NULL)));
+    */
 }
 
 void ProtectionPaladinAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
@@ -21,7 +21,14 @@ private:
 
     ACTION_NODE_A(hand_of_reckoning, "hand of reckoning", "righteous defense");
 
-    ACTION_NODE_C(righteous_defense, "righteous defense", "avenger's shield");
+    static ActionNode* righteous_defense(PlayerbotAI* ai)
+    {
+        return new ActionNode("righteous defense",
+            /*P*/ NULL,
+            /*A*/ NULL,
+            /*C*/ NextAction::array(0, new NextAction("avenger's shield"), 
+                                       new NextAction("judgement"), NULL));
+    }
 
     ACTION_NODE_A(judgement, "judgement", "exorcism");
 };

--- a/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
@@ -24,8 +24,11 @@ public:
 private:
     ACTION_NODE_A(seal_of_vengeance, "seal of vengeance", "seal of command");
 
+#ifndef MANGOSBOT_ONE
     ACTION_NODE_A(seal_of_command, "seal of command", "seal of righteousness");
-
+#else
+    ACTION_NODE_A(seal_of_command, "seal of blood", "seal of command");
+#endif
     ACTION_NODE_A(crusader_strike, "crusader strike", "melee");
 
     ACTION_NODE_A(repentance, "repentance", "hammer of justice");


### PR DESCRIPTION
This is the first round of improvements for protection paladin.

- Added missing seal triggers and context
- Better judgement usage (should not judge something that is already up, judge vengeance only at 3+ stacks)
- (Attempted) better usage of taunt with aggro builder after (need confirmation/fixing)
- In TBC, don't use avenger's shield for aoe threat as it has a cast time.