### PR TITLE
Minor fixes 1

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4176,9 +4176,9 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, uint8 effectMask, b
 
         if (!damage)
         {
-            for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
+            for (uint8 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
             {
-                bool immune = target->IsImmuneToSpellEffect(spellInfo, (SpellEffectIndex)i, false);
+                bool immune = target->IsImmuneToSpellEffect(spellInfo, SpellEffectIndex(i), false);
                 if (immune)
                 {
                     if (checkResult)
@@ -4737,7 +4737,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget, bool
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting " <<ChatHelper::formatSpell(pSpellInfo);
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id << " target " << target->GetDbGuid();
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 
@@ -4884,7 +4884,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, GameObject* goTarget, Item* itemTarg
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting " << ChatHelper::formatSpell(pSpellInfo);
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id;
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 
@@ -5036,7 +5036,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, float x, float y, float z, Item* ite
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting " << ChatHelper::formatSpell(pSpellInfo);
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id;
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 
@@ -5326,7 +5326,7 @@ bool PlayerbotAI::CastVehicleSpell(uint32 spellId, Unit* target, float projectil
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting Vehicle Spell" << ChatHelper::formatSpell(pSpellInfo);
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id << " target " << target->GetDbGuid();
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 
@@ -5442,13 +5442,13 @@ bool PlayerbotAI::IsInterruptableSpellCasting(Unit* target, std::string spell, u
 	if (!spellInfo)
 		return false;
 
-	for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
+	for (uint8 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
 	{
 		if ((spellInfo->InterruptFlags & SPELL_INTERRUPT_FLAG_COMBAT) && spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE)
 			return true;
 
 		if ((spellInfo->Effect[i] == SPELL_EFFECT_INTERRUPT_CAST) &&
-			!target->IsImmuneToSpellEffect(spellInfo, (SpellEffectIndex)i, true))
+			!target->IsImmuneToSpellEffect(spellInfo, SpellEffectIndex(i), true))
 			return true;
 
         if ((spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA) && spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_SILENCE)
@@ -6216,16 +6216,20 @@ bool PlayerbotAI::IsOpposing(uint8 race1, uint8 race2)
 
 void PlayerbotAI::RemoveShapeshift()
 {
-    RemoveAura("bear form");
-    RemoveAura("dire bear form");
-    RemoveAura("moonkin form");
-    RemoveAura("travel form");
-    RemoveAura("cat form");
-    RemoveAura("flight form");
-    RemoveAura("swift flight form");
-    RemoveAura("aquatic form");
-    RemoveAura("ghost wolf");
-    RemoveAura("tree of life");
+    if (!bot->HasCharm())
+    {
+        RemoveAura("bear form");
+        RemoveAura("dire bear form");
+        RemoveAura("moonkin form");
+        RemoveAura("travel form");
+        RemoveAura("cat form");
+        RemoveAura("flight form");
+        RemoveAura("swift flight form");
+        RemoveAura("aquatic form");
+        RemoveAura("ghost wolf");
+        RemoveAura("tree of life");
+    }
+
 }
 
 uint32 PlayerbotAI::GetEquipGearScore(Player* player, bool withBags, bool withBank)

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4737,7 +4737,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget, bool
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id << " target " << target->GetDbGuid();
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id;
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 
@@ -5326,7 +5326,7 @@ bool PlayerbotAI::CastVehicleSpell(uint32 spellId, Unit* target, float projectil
     if (HasStrategy("debug spell", BotState::BOT_STATE_NON_COMBAT))
     {
         std::ostringstream out;
-        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id << " target " << target->GetDbGuid();
+        out << "Casting " << ChatHelper::formatSpell(pSpellInfo) << " spellid " << pSpellInfo->Id;
         TellPlayerNoFacing(GetMaster() ? GetMaster() : bot, out);
     }
 

--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -1040,7 +1040,7 @@ namespace ai
         bool IsActive() override
         {
             return bot->HasAuraType(SPELL_AURA_MOD_ROOT) ||
-                   bot->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
+                   (bot->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED) && !ai->HasAnyAuraOf(bot, "tree of life", NULL));
         }
     };
 

--- a/playerbot/strategy/values/PartyMemberToHeal.cpp
+++ b/playerbot/strategy/values/PartyMemberToHeal.cpp
@@ -298,7 +298,7 @@ Unit* PartyMemberToRemoveRoots::Calculate()
 
                 if (player->HasAuraType(SPELL_AURA_MOD_ROOT) || player->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED))
                 {
-                    if (!ai->HasAura("stealth", player) && !ai->HasAura("prowl", player))
+                    if (!ai->HasAura("stealth", player) && !ai->HasAura("prowl", player) && !ai->HasAura("tree of life", player))
                     {
                         target = player;
                         break;

--- a/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
@@ -166,7 +166,7 @@ bool PossibleAttackTargetsValue::HasUnBreakableCC(Unit* target, Player* player)
 bool PossibleAttackTargetsValue::IsImmuneToDamage(Unit* target, Player* player)
 {
     // Charmed
-    if (sServerFacade.IsCharmed(target) && target->IsInTeam(player, true))
+    if (sServerFacade.IsCharmed(target) && (target->IsInTeam(player, true) || target->IsInGroup(player, true, true)))
     {
         return true;
     }


### PR DESCRIPTION
- Try not to nuke your teammates if they were just mind controlled by checking if they're in your group, since a faction check may fail in many cases when mobs charm as your faction changes temporarily.
- When druids are charmed, don't leave the current shapeshift form, as what often happens in current charmed AI implementation is the druids will attempt to shift out to cast the spell, then shift back, then shift out, repeat and waste a lot of mana. Basically means you have to tell resto druids to ignore tree form so they save mana, which is not good. Players don't shift out when charmed, the spell simply fails, so this should not happen to bots either. But the bots see that they're being requested to cast the spells, which are currently caster spells. The spell would fail so they shift to humanoid form, rather than being limited to their current form and not casting it. Later on this may not be necessary if the CharmedAI is reworked.
- With spell debug, also give the spell id of the casted spell

- (In Progress) attempt to fix check for if a target is immune to a particular spell. Bots are currently trying to stun bosses, which are immune to spells, something's wrong with the immunity check. It's especially a problem for tanks as they will use their global to stun a boss rather than taunt.