### PR TITLE
Fix immunity check for spell casts

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4176,18 +4176,15 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, uint8 effectMask, b
 
         if (!damage)
         {
-            for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
+            bool immune = target->IsImmuneToSpell(spellInfo, false, effectMask, bot);
+            if (immune)
             {
-                bool immune = target->IsImmuneToSpellEffect(spellInfo, (SpellEffectIndex)i, false);
-                if (immune)
+                if (checkResult)
                 {
-                    if (checkResult)
-                    {
-                        *checkResult = SPELL_FAILED_IMMUNE;
-                    }
-
-                    return false;
+                    *checkResult = SPELL_FAILED_IMMUNE;
                 }
+
+                return false;
             }
         }
 
@@ -5448,8 +5445,8 @@ bool PlayerbotAI::IsInterruptableSpellCasting(Unit* target, std::string spell, u
 			return true;
 
 		if ((spellInfo->Effect[i] == SPELL_EFFECT_INTERRUPT_CAST) &&
-			!target->IsImmuneToSpellEffect(spellInfo, (SpellEffectIndex)i, true))
-			return true;
+            !target->IsImmuneToSpell(spellInfo, true, effectMask, bot))
+            return true;
 
         if ((spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA) && spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_SILENCE)
             return true;

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4177,6 +4177,12 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, uint8 effectMask, b
         if (!damage)
         {
             bool immune = target->IsImmuneToSpell(spellInfo, false, effectMask, bot);
+            if (!immune)
+            {
+                for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
+                    immune = target->IsImmuneToSpellEffect(spellInfo, SpellEffectIndex(i), false);
+            }
+
             if (immune)
             {
                 if (checkResult)
@@ -5445,7 +5451,7 @@ bool PlayerbotAI::IsInterruptableSpellCasting(Unit* target, std::string spell, u
 			return true;
 
 		if ((spellInfo->Effect[i] == SPELL_EFFECT_INTERRUPT_CAST) &&
-            !target->IsImmuneToSpell(spellInfo, true, effectMask, bot))
+            (!target->IsImmuneToSpell(spellInfo, true, effectMask, bot) || !target->IsImmuneToSpellEffect(spellInfo, SpellEffectIndex(i), true)))
             return true;
 
         if ((spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA) && spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_SILENCE)


### PR DESCRIPTION
Fix immunity checking for spell casts which was faulty. IsImmuneToSpellEffect is currently faulty in the core (Until my PR gets merged), but IsImmuneToSpell works.