### PR TITLE
Fix possible null dereference in ConfirmQuestAction::Execute

### DIFF
--- a/playerbot/strategy/actions/AcceptQuestAction.cpp
+++ b/playerbot/strategy/actions/AcceptQuestAction.cpp
@@ -157,6 +157,9 @@ bool ConfirmQuestAction::Execute(Event& event)
     uint32 quest;
     p >> quest;
     Quest const* qInfo = sObjectMgr.GetQuestTemplate(quest);
+    
+    if (!qInfo)
+        return false;
 
     quest = qInfo->GetQuestId();
     if( !bot->CanTakeQuest( qInfo, false ) )


### PR DESCRIPTION
Add null check for quest template in ConfirmQuestAction::Execute

GetQuestTemplate() can return nullptr for an unknown quest id, but its result was dereferenced without a check, unlike the other handlers in the same file.