### PR TITLE
Dont derank buffs for saving mana

### DIFF
--- a/playerbot/strategy/values/SpellIdValue.cpp
+++ b/playerbot/strategy/values/SpellIdValue.cpp
@@ -131,6 +131,31 @@ uint32 SpellIdValue::Calculate()
     int highestSpellId = 0;
     int lowestRank = 0;
     int lowestSpellId = 0;
+    // Bots shouldn't derank buff spells (Fortitude, Mark of the Wild, Totems, Blessings etc.)
+    // Quickest way is instant and not damage or healing
+    bool isBuff = false;
+
+    for (std::set<uint32>::reverse_iterator itr = spellIds.rbegin(); itr != spellIds.rend(); ++itr)
+    {
+        const SpellEntry* pSpellInfo = sServerFacade.LookupSpellInfo(*itr);
+        if (!pSpellInfo)
+            continue;
+        uint32 castingTime = pSpellInfo->CastingTimeIndex;
+        bool damageOrHeal = false;
+        for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
+        {
+            if (pSpellInfo->Effect[i] == SPELL_EFFECT_HEAL || pSpellInfo->Effect[i] == SPELL_EFFECT_SCHOOL_DAMAGE)
+            {
+                damageOrHeal = true;
+                break;
+            }
+        }
+        if (!damageOrHeal && castingTime <= 1)
+        {
+            isBuff = true;
+            break;
+        }     
+    }
 
     if (saveMana <= 1)
     {
@@ -177,13 +202,13 @@ uint32 SpellIdValue::Calculate()
         {
             if (!highestSpellId) highestSpellId = *i;
             if (sSpellMgr.IsSpellHigherRankOfSpell(*i, highestSpellId)) highestSpellId = *i;
-            if (saveMana == rank) return *i;
+            if (saveMana == rank && !isBuff) return *i;
             lowestSpellId = *i;
             rank++;
         }
     }
 
-    return saveMana > 1 ? lowestSpellId : highestSpellId;
+    return saveMana > 1 && !isBuff ? lowestSpellId : highestSpellId;
 }
 
 uint32 VehicleSpellIdValue::Calculate()

--- a/playerbot/strategy/values/SpellIdValue.cpp
+++ b/playerbot/strategy/values/SpellIdValue.cpp
@@ -147,7 +147,7 @@ uint32 SpellIdValue::Calculate()
             if (pSpellInfo->Effect[i] == SPELL_EFFECT_HEAL || pSpellInfo->Effect[i] == SPELL_EFFECT_SCHOOL_DAMAGE ||
                 pSpellInfo->Effect[i] == SPELL_EFFECT_PERSISTENT_AREA_AURA || 
                (pSpellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA && (pSpellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_DAMAGE ||
-                pSpellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_HEAL))
+                pSpellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_HEAL)))
             {
                 damageOrHeal = true;
                 break;

--- a/playerbot/strategy/values/SpellIdValue.cpp
+++ b/playerbot/strategy/values/SpellIdValue.cpp
@@ -145,7 +145,9 @@ uint32 SpellIdValue::Calculate()
         for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
         {
             if (pSpellInfo->Effect[i] == SPELL_EFFECT_HEAL || pSpellInfo->Effect[i] == SPELL_EFFECT_SCHOOL_DAMAGE ||
-                pSpellInfo->Effect[i] == SPELL_EFFECT_PERSISTENT_AREA_AURA)
+                pSpellInfo->Effect[i] == SPELL_EFFECT_PERSISTENT_AREA_AURA || 
+               (pSpellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA && (pSpellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_DAMAGE ||
+                pSpellInfo->EffectApplyAuraName[i] == SPELL_AURA_PERIODIC_HEAL))
             {
                 damageOrHeal = true;
                 break;

--- a/playerbot/strategy/values/SpellIdValue.cpp
+++ b/playerbot/strategy/values/SpellIdValue.cpp
@@ -144,7 +144,8 @@ uint32 SpellIdValue::Calculate()
         bool damageOrHeal = false;
         for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
         {
-            if (pSpellInfo->Effect[i] == SPELL_EFFECT_HEAL || pSpellInfo->Effect[i] == SPELL_EFFECT_SCHOOL_DAMAGE)
+            if (pSpellInfo->Effect[i] == SPELL_EFFECT_HEAL || pSpellInfo->Effect[i] == SPELL_EFFECT_SCHOOL_DAMAGE ||
+                pSpellInfo->Effect[i] == SPELL_EFFECT_PERSISTENT_AREA_AURA)
             {
                 damageOrHeal = true;
                 break;


### PR DESCRIPTION
Don't derank buff spells when save mana level is on. That way, bots can conserve mana but not reduce the impact of their class and spec.

A quick test for buff spell is instant and not damage or healing. While this is not 100% accurate, it captures the gist of the kinds of spells you don't want the bots to derank.

More often than not you want bots to conserve mana in repetitive actions, that being heals and damage spells they're doing. You don't want them to conserve mana for something that is probably being cast once every 30 minutes for example. Ironically if bots are de-ranking spells which give mana regeneration buffs then mana management becomes more difficult which defeats the purpose of the setting. 

Case in point, saving 50-100 mana deranking blessing of wisdom or mana spring totem doesn't save mana as you would net lose a lot more mana over the period of the buff than what you saved by deranking.

In the absence of smarter heal deranking and heal prediction, you would want the bots to spend less mana on healing, but not spend less mana on placing buffs, since in most contexts those buffs are cast out of combat, meaning you can just drink to regain mana. 

Deranking buffs also causes dps to do less damage, or tanks to take more damage, which necessitates longer/harder encounters which actually spends more mana.

Put simply, we need bots to derank spells that are worth deranking to improve mana retention, not all spells.