### PR TITLE
Check All school immunity for attack targeting

### DIFF
--- a/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
@@ -172,6 +172,10 @@ bool PossibleAttackTargetsValue::IsImmuneToDamage(Unit* target, Player* player)
     }
 
     // Immune to damage
+    // Before we check auras, check school derived immunity
+    if (target->IsImmuneToDamage(SPELL_SCHOOL_MASK_ALL))
+        return true;
+
     PlayerbotAI* ai = player->GetPlayerbotAI();
     if (!ai)
         return false;


### PR DESCRIPTION
Immunity is not just derived by aura, it can be derived from the target itself. So it is possible for a target to be immune to our spells because it has specific immunity (like certain elementals are immune to their respective schools, or during a fight an npc may just be immune to all schools). We should check for this when targeting, that way the bots don't try to attack things that are immune to all their spells.