### PR TITLE
Fix check hunter uses when serpent sting is in manual strategy

### DIFF
--- a/playerbot/strategy/hunter/HunterActions.cpp
+++ b/playerbot/strategy/hunter/HunterActions.cpp
@@ -7,7 +7,7 @@ using namespace ai;
 
 bool CastSerpentStingAction::isUseful()
 {
-    return CastRangedDebuffSpellAction::isUseful() && AI_VALUE2(uint8, "health", GetTargetName()) > 50 && !(AI_VALUE2(uint8, "mana", GetTargetName()) >= 10);
+    return CastRangedDebuffSpellAction::isUseful() && AI_VALUE2(uint8, "health", GetTargetName()) > 50 && (!(AI_VALUE2(uint8, "mana", GetTargetName()) >= 10) || (ai->HasStrategy("sting serpent", BotState::BOT_STATE_COMBAT)));
 }
 
 bool CastViperStingAction::isUseful()

--- a/playerbot/strategy/hunter/HunterTriggers.cpp
+++ b/playerbot/strategy/hunter/HunterTriggers.cpp
@@ -61,7 +61,7 @@ bool SerpentStingOnAttackerTrigger::IsActive()
                               !ai->HasAura("viper sting", target);
         if (noStings)
         {
-            if (target->GetPower(POWER_MANA) < 10)
+            if (target->GetPower(POWER_MANA) < 10 || ai->HasStrategy("sting serpent", BotState::BOT_STATE_COMBAT))
             {
                 return DebuffOnAttackerTrigger::IsActive();
             }


### PR DESCRIPTION
Fix hunter serpent sting manual strategy (when you only want them to use serpent, "sting serpent") to ignore mana check. This fixes the issue where the hunters will not serpent a target thinking it should use viper sting, even when you opt them to only use serpent and not viper.