### PR TITLE
Fix healer bots using bandages in dungeons too much

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4489,7 +4489,7 @@ uint8 PlayerbotAI::GetHealthPercent() const
 
 uint8 PlayerbotAI::GetManaPercent(const Unit& target) const
 {
-   return (static_cast<float>(target.GetPower(POWER_MANA)) / target.GetMaxPower(POWER_MANA)) * 100;
+   return target.GetPowerPercent();
 }
 
 uint8 PlayerbotAI::GetManaPercent() const

--- a/playerbot/strategy/actions/UseItemAction.h
+++ b/playerbot/strategy/actions/UseItemAction.h
@@ -496,6 +496,10 @@ namespace ai
                 }
             }
 
+            // Do not use consumable if bot can heal self
+            if (ai->IsHeal(bot) && ai->GetManaPercent() > 20)
+                return false;
+
             return true;
         }
 


### PR DESCRIPTION
Fix healer bots using bandages too much because the check for them was not being used in the appropriate place.