### PR TITLE
Various bot priority changes

### DIFF
--- a/playerbot/strategy/actions/PullActions.cpp
+++ b/playerbot/strategy/actions/PullActions.cpp
@@ -98,7 +98,7 @@ bool PullStartAction::Execute(Event& event)
             {
                 result = ai->DoSpecificAction(strategy->GetPreActionName(), event, true);
                 if(result)
-                    SetDuration(ai->GetAIInternalUpdateDelay());
+                    SetDuration(sPlayerbotAIConfig.globalCoolDown);
             }
 
             // Set the pet on passive mode during the pull

--- a/playerbot/strategy/actions/PullActions.cpp
+++ b/playerbot/strategy/actions/PullActions.cpp
@@ -98,7 +98,7 @@ bool PullStartAction::Execute(Event& event)
             {
                 result = ai->DoSpecificAction(strategy->GetPreActionName(), event, true);
                 if(result)
-                    SetDuration(sPlayerbotAIConfig.globalCoolDown);
+                    SetDuration((sPlayerbotAIConfig.globalCoolDown * 2) + sPlayerbotAIConfig.reactDelay);
             }
 
             // Set the pet on passive mode during the pull

--- a/playerbot/strategy/actions/PullActions.cpp
+++ b/playerbot/strategy/actions/PullActions.cpp
@@ -98,7 +98,7 @@ bool PullStartAction::Execute(Event& event)
             {
                 result = ai->DoSpecificAction(strategy->GetPreActionName(), event, true);
                 if(result)
-                    SetDuration((sPlayerbotAIConfig.globalCoolDown * 2) + sPlayerbotAIConfig.reactDelay);
+                    SetDuration(3000);
             }
 
             // Set the pet on passive mode during the pull

--- a/playerbot/strategy/deathknight/BloodDKStrategy.cpp
+++ b/playerbot/strategy/deathknight/BloodDKStrategy.cpp
@@ -92,7 +92,7 @@ void BloodDKStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("dark command", ACTION_HIGH + 3), NULL)));
+        NextAction::array(0, new NextAction("dark command", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "low health",

--- a/playerbot/strategy/druid/TankFeralDruidStrategy.cpp
+++ b/playerbot/strategy/druid/TankFeralDruidStrategy.cpp
@@ -60,7 +60,7 @@ void TankFeralDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigger
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("growl", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("growl", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "faerie fire (feral)",
@@ -506,7 +506,7 @@ void TankFeralDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigger
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("growl", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("growl", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "faerie fire (feral)",
@@ -952,7 +952,7 @@ void TankFeralDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigger
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("growl", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("growl", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "faerie fire (feral)",

--- a/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
@@ -59,7 +59,7 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("hand of reckoning", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("hand of reckoning", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "holy shield",
@@ -573,7 +573,7 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("righteous defense", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("righteous defense", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "holy shield",
@@ -1080,7 +1080,7 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("hand of reckoning", ACTION_MOVE), NULL)));
+        NextAction::array(0, new NextAction("hand of reckoning", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "holy shield",
@@ -1214,9 +1214,9 @@ void ProtectionPaladinAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
 {
     PaladinAoeStrategy::InitCombatTriggers(triggers);
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee light aoe",

--- a/playerbot/strategy/rogue/CombatRogueStrategy.cpp
+++ b/playerbot/strategy/rogue/CombatRogueStrategy.cpp
@@ -533,9 +533,9 @@ void CombatRogueAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigger
         "melee light aoe",
         NextAction::array(0, new NextAction("blade flurry", ACTION_HIGH + 4), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
 }
 
 void CombatRogueAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -940,9 +940,9 @@ void CombatRogueAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigger
         "melee light aoe",
         NextAction::array(0, new NextAction("blade flurry", ACTION_HIGH + 4), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH + 4), NULL)));
 }
 
 void CombatRogueAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/EnhancementShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/EnhancementShamanStrategy.cpp
@@ -594,9 +594,9 @@ void EnhancementShamanAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
         "melee medium aoe",
         NextAction::array(0, new NextAction("fire nova", ACTION_HIGH), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
 }
 
 void EnhancementShamanAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -1030,9 +1030,9 @@ void EnhancementShamanAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
         "melee medium aoe",
         NextAction::array(0, new NextAction("fire nova", ACTION_HIGH), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
 }
 
 void EnhancementShamanAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
+++ b/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
@@ -151,7 +151,7 @@ namespace ai
                 creators["totembar spirits"] = [](PlayerbotAI* ai) { return new ShamanTotemBarSpiritsStrategy(ai); };
                 creators["totem fire nova"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire nova", "fire totem", "fire nova"); };
                 creators["totem fire flametongue"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire flametongue", "fire totem", "flametongue totem"); };
-                creators["totem fire resistance"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire resistance", "fire totem", "fire resistance totem"); };
+                creators["totem fire resistance"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire resistance", "fire totem", "frost resistance totem"); };
                 creators["totem fire magma"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire magma", "fire totem", "magma totem"); };
                 creators["totem fire searing"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire searing", "fire totem", "searing totem"); };
                 creators["totem fire wrath"] = [](PlayerbotAI* ai) { return new ShamanManualTotemStrategy(ai, "totem fire wrath", "fire totem", "totem of wrath"); };

--- a/playerbot/strategy/values/PartyMemberToHeal.cpp
+++ b/playerbot/strategy/values/PartyMemberToHeal.cpp
@@ -265,13 +265,13 @@ Unit* PartyMemberToProtect::Calculate()
         if (sServerFacade.GetDistance2d(pVictim, unit) > attackDistance)
             continue;
 
-        if (ai->IsTank((Player*)pVictim) && pVictim->GetHealthPercent() > 10)
+        if (ai->IsTank((Player*)pVictim) && pVictim->GetHealthPercent() > 25)
             continue;
-        else if (pVictim->GetHealthPercent() > 30)
-            continue;
+        //else if (pVictim->GetHealthPercent() > 90)
+            //continue;
 
         if (find(needProtect.begin(), needProtect.end(), pVictim) == needProtect.end())
-        needProtect.push_back(pVictim);
+            needProtect.push_back(pVictim);
     }
 
     if (needProtect.empty())

--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -72,9 +72,9 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         "has greater blessing of salvation",
         NextAction::array(0, new NextAction("remove greater blessing of salvation", ACTION_EMERGENCY), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "enemy out of melee",
-        NextAction::array(0, new NextAction("heroic throw", ACTION_MOVE + 8), new NextAction("charge", ACTION_MOVE + 7), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"enemy out of melee",
+        //NextAction::array(0, new NextAction("heroic throw", ACTION_MOVE + 8), new NextAction("charge", ACTION_MOVE + 7), NULL)));
 
     triggers.push_back(new TriggerNode(
         "intercept and rage",
@@ -86,11 +86,11 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_PASSTROUGH), NULL)));
+        NextAction::array(0, new NextAction("taunt", ACTION_PASSTROUGH), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "taunt on snare target",
-        NextAction::array(0, new NextAction("heroic throw on snare target", ACTION_MOVE), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"taunt on snare target",
+        //NextAction::array(0, new NextAction("heroic throw on snare target", ACTION_MOVE), NULL)));
 
     triggers.push_back(new TriggerNode(
         "demoralizing shout",
@@ -472,9 +472,9 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         "protect party member",
         NextAction::array(0, new NextAction("intervene", ACTION_EMERGENCY), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "enemy out of melee",
-        NextAction::array(0, new NextAction("heroic throw", ACTION_MOVE + 8), new NextAction("charge", ACTION_MOVE + 7), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"enemy out of melee",
+        //NextAction::array(0, new NextAction("heroic throw", ACTION_MOVE + 8), new NextAction("charge", ACTION_MOVE + 7), NULL)));
 
     triggers.push_back(new TriggerNode(
         "intercept and rage",
@@ -486,7 +486,7 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_PASSTROUGH), NULL)));
+        NextAction::array(0, new NextAction("taunt", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "spell reflection",

--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -492,9 +492,9 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         "spell reflection",
         NextAction::array(0, new NextAction("spell reflection", ACTION_MOVE + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "taunt on snare target",
-        NextAction::array(0, new NextAction("heroic throw on snare target", ACTION_MOVE), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"taunt on snare target",
+        //NextAction::array(0, new NextAction("heroic throw on snare target", ACTION_MOVE), NULL)));
 
     triggers.push_back(new TriggerNode(
         "demoralizing shout",

--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -86,7 +86,7 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_MOVE + 4), NULL)));
+        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "taunt on snare target",
@@ -486,7 +486,7 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_MOVE + 4), NULL)));
+        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "spell reflection",
@@ -882,7 +882,7 @@ void ProtectionWarriorStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "lose aggro",
-        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_MOVE + 4), NULL)));
+        NextAction::array(0, new NextAction("heroic throw taunt", ACTION_PASSTROUGH), NULL)));
 
     triggers.push_back(new TriggerNode(
         "spell reflection",

--- a/playerbot/strategy/warrior/WarriorActions.h
+++ b/playerbot/strategy/warrior/WarriorActions.h
@@ -64,7 +64,7 @@ namespace ai
     BUFF_ACTION(CastRampageAction, "rampage");
 
     // protection
-    MELEE_ACTION_U(CastTauntAction, "taunt", GetTarget() && GetTarget()->GetVictim() && GetTarget()->GetVictim() != bot);
+    SPELL_ACTION_U(CastTauntAction, "taunt", GetTarget() && GetTarget()->GetVictim() && GetTarget()->GetVictim() != bot);
     SNARE_ACTION(CastTauntOnSnareTargetAction, "taunt");
     BUFF_ACTION(CastBloodrageAction, "bloodrage");
     MELEE_ACTION(CastShieldBashAction, "shield bash");

--- a/playerbot/strategy/warrior/WarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/WarriorStrategy.cpp
@@ -468,9 +468,9 @@ void WarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         "thunder clap on snare target",
         NextAction::array(0, new NextAction("thunder clap on snare target", ACTION_HIGH + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
 }
 
 void WarriorAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -755,9 +755,9 @@ void WarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         "thunder clap on snare target",
         NextAction::array(0, new NextAction("thunder clap on snare target", ACTION_HIGH + 1), NULL)));
 
-    triggers.push_back(new TriggerNode(
-        "melee light aoe",
-        NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
+    //triggers.push_back(new TriggerNode(
+        //"melee light aoe",
+        //NextAction::array(0, new NextAction("oil of immolation", ACTION_HIGH), NULL)));
 }
 
 void WarriorAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)


### PR DESCRIPTION
-change prepull action delay to be much shorter
-change warrior taunt to be a spell_action_u
-remove pre-wotlk references to heroic throw.
-increase taunt action priority
-change party member to protect conditions to be less strict (warriors will now use intervene)
-remove oil of immolation from various non-vanilla bot strategies.

Removing the heroic throw actions and triggers now enables warrior bots in tbc (i checked) to taunt off of npcs, players and bots even if they're standing still. Currently you have to move in order for the warrior to taunt, which in many cases means that the warrior tanks will let healers/dps die if they don't move.

I think what was happening is that the heroic throw stuff was taking precedence before the lose aggro stuff, so they were not checking aggro conditions to taunt.

I've found the oil of immolation to be more annoying than not since it breaks cc and it isn't going to contribute to much damage.