### PR TITLE
Bot priority 2 fixes

### DIFF
--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -2817,8 +2817,9 @@ bool MovementAction::Flee(Unit *target)
     time_t now = time(0);
     uint32 fleeDelay = urand(2, sPlayerbotAIConfig.returnDelay / 1000);
 
-    // let hunter kite mob
-    if (isTarget && bot->getClass() == CLASS_HUNTER)
+    // let hunter/kiter kite mob
+    if (isTarget && (bot->getClass() == CLASS_HUNTER || ai->HasStrategy("kite", BotState::BOT_STATE_COMBAT)
+        || ai->HasStrategy("kite", BotState::BOT_STATE_REACTION)))
     {
         fleeDelay = 1;
     }

--- a/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/ProtectionPaladinStrategy.cpp
@@ -62,6 +62,10 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         NextAction::array(0, new NextAction("hand of reckoning", ACTION_MOVE), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "protect party member",
+        NextAction::array(0, new NextAction("blessing of protection on party", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "holy shield",
         NextAction::array(0, new NextAction("holy shield", ACTION_HIGH + 3), NULL)));
 
@@ -576,6 +580,10 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
         NextAction::array(0, new NextAction("righteous defense", ACTION_MOVE), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "protect party member",
+        NextAction::array(0, new NextAction("blessing of protection on party", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "holy shield",
         NextAction::array(0, new NextAction("holy shield", ACTION_HIGH + 3), NULL)));
 
@@ -1081,6 +1089,10 @@ void ProtectionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
     triggers.push_back(new TriggerNode(
         "lose aggro",
         NextAction::array(0, new NextAction("hand of reckoning", ACTION_MOVE), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "protect party member",
+        NextAction::array(0, new NextAction("blessing of protection on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "holy shield",

--- a/playerbot/strategy/warlock/WarlockStrategy.cpp
+++ b/playerbot/strategy/warlock/WarlockStrategy.cpp
@@ -499,7 +499,7 @@ void WarlockStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("sacrifice", ACTION_EMERGENCY), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "life tap",
+        "medium mana",
         NextAction::array(0, new NextAction("life tap", ACTION_HIGH + 3), NULL)));
 
     triggers.push_back(new TriggerNode(

--- a/playerbot/strategy/warrior/ArmsWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ArmsWarriorStrategy.cpp
@@ -24,7 +24,7 @@ private:
 
     ACTION_NODE_A(death_wish, "death wish", "bloodrage");
 
-    ACTION_NODE_A(piercing_howl, "piercing howl", "mocking blow");
+    ACTION_NODE_A(piercing_howl, "piercing howl", "hamstring");
 
     ACTION_NODE_A(mocking_blow, "mocking blow", "hamstring");
 

--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -35,7 +35,7 @@ private:
 
     ACTION_NODE_A(heroic_throw_taunt, "heroic throw", "taunt");
 
-    ACTION_NODE_A(taunt, "taunt", "battle shout taunt");
+    ACTION_NODE_A(taunt, "taunt", "mocking blow");
 
     ACTION_NODE_A(berserker_rage_fear, "berserker rage", "death wish");
 };


### PR DESCRIPTION
- Allow anyone who is kiting to have the same delay as a hunter when kiting (+kite strategy)
- Add blessing of protection action with protect party member trigger for protection paladins
- Change trigger for lifetap to medium mana (The lifetap trigger isn't working for some reason but this works, the spell itself will fizzle if you are too low hp to use it anyway).
- Make hamstring the alternative to piercing howl instead of mocking blow for Arms warriors
- Making mocking blow the alternative to taunt instead of challenging shout for protection warriors. Warriors will still use challenging shout in an aoe context.

It was a bit strange that arms warriors had a context for using mocking blow but protection warriors didn't.