### PR TITLE
Add auto enchant upgrades option

### DIFF
--- a/playerbot/PlayerbotAIConfig.cpp
+++ b/playerbot/PlayerbotAIConfig.cpp
@@ -628,6 +628,7 @@ bool PlayerbotAIConfig::Initialize()
     //SPP automation
     autoPickReward = config.GetStringDefault("AiPlayerbot.AutoPickReward", "no");
     autoEquipUpgradeLoot = config.GetBoolDefault("AiPlayerbot.AutoEquipUpgradeLoot", false);
+    autoEnchantUpgradeLoot = config.GetBoolDefault("AiPlayerbot.AutoEnchantUpgradeLoot", false);
     syncQuestWithPlayer = config.GetBoolDefault("AiPlayerbot.SyncQuestWithPlayer", false);
     syncQuestForPlayer = config.GetBoolDefault("AiPlayerbot.SyncQuestForPlayer", false);
     autoTrainSpells = config.GetStringDefault("AiPlayerbot.AutoTrainSpells", "no");

--- a/playerbot/PlayerbotAIConfig.h
+++ b/playerbot/PlayerbotAIConfig.h
@@ -328,6 +328,7 @@ public:
 
     std::string autoPickReward;
     bool autoEquipUpgradeLoot;
+    bool autoEnchantUpgradeLoot;
     bool syncQuestWithPlayer;
     bool syncQuestForPlayer;
     std::string autoTrainSpells;

--- a/playerbot/aiplayerbot.conf.dist.in
+++ b/playerbot/aiplayerbot.conf.dist.in
@@ -355,6 +355,10 @@ AiPlayerbot.AutoPickReward = yes
 # Default: 0 (disabled)
 AiPlayerbot.AutoEquipUpgradeLoot = 1
 
+# Bots enchant upgrades automatically
+# Default: 0 (disabled)
+AiPlayerbot.AutoEnchantUpgradeLoot = 0
+
 # Sync quests with player (Bots will complete quests the moment you hand them in. Bots will ignore looting quest items.)
 # Default: 0 (disabled)
 AiPlayerbot.SyncQuestWithPlayer = 0

--- a/playerbot/aiplayerbot.conf.dist.in.tbc
+++ b/playerbot/aiplayerbot.conf.dist.in.tbc
@@ -353,6 +353,10 @@ AiPlayerbot.AutoPickReward = yes
 # Default: 0 (disabled)
 AiPlayerbot.AutoEquipUpgradeLoot = 1
 
+# Bots enchant upgrades automatically
+# Default: 0 (disabled)
+AiPlayerbot.AutoEnchantUpgradeLoot = 0
+
 # Sync quests with player (Bots will complete quests the moment you hand them in. Bots will ignore looting quest items.)
 # Default: 0 (disabled)
 AiPlayerbot.SyncQuestWithPlayer = 0

--- a/playerbot/aiplayerbot.conf.dist.in.wotlk
+++ b/playerbot/aiplayerbot.conf.dist.in.wotlk
@@ -359,6 +359,10 @@ AiPlayerbot.AutoPickReward = yes
 # Default: 0 (disabled)
 AiPlayerbot.AutoEquipUpgradeLoot = 1
 
+# Bots enchant upgrades automatically
+# Default: 0 (disabled)
+AiPlayerbot.AutoEnchantUpgradeLoot = 0
+
 # Sync quests with player (Bots will complete quests the moment you hand them in. Bots will ignore looting quest items.)
 # Default: 0 (disabled)
 AiPlayerbot.SyncQuestWithPlayer = 0

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -384,6 +384,10 @@ bool EquipUpgradesAction::Execute(Event& event)
         {
             sLog.outDetail("Bot #%d <%s> auto equips item %d (%s)", bot->GetGUIDLow(), bot->GetName(), item->GetProto()->ItemId, usage == ItemUsage::ITEM_USAGE_EQUIP ? "better than current" : usage == ItemUsage::ITEM_USAGE_BAD_EQUIP ? "wrong item but empty slot" : "");
             ai->TellDebug(ai->GetMaster(), "Equipping: " + chat->formatItem(item) + " - " + ItemUsageValue::ReasonForNeed(usage, item, 1, bot), "debug equip");
+            
+            // add an auto enchant if cheat is turned on
+            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot)
+                EnchantItem(item);
 
             EquipItem(ai, GetMaster(), item, item == oldMainhand || item == oldOffhand);   
             didEquip = true;

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -98,6 +98,48 @@ void EquipAction::ListItems(Player* requester)
     ai->InventoryTellItems(requester, items, soulbound);
 }
 
+bool EquipAction::IsEnchantable(Item* item)
+{
+    return !(item->GetProto()->Class == ITEM_CLASS_CONTAINER || item->GetProto()->Class == ITEM_CLASS_QUIVER || item->GetProto()->InventoryType == INVTYPE_AMMO)
+}
+
+void EquipAction::EnchantItem(Item* item)
+{
+    if (item)
+    {
+        int tab = AiFactory::GetPlayerSpecTab(bot);
+        uint32 tempId = uint32((uint32)bot->getClass() * (uint32)10);
+        uint8 spec = tempId += (uint32)tab;
+
+        if (enchants.empty())
+        {
+            auto result = WorldDatabase.PQuery("SELECT class, spec, spellid, slotid FROM ai_playerbot_enchants");
+            if (result)
+            {
+                do
+                {
+                    Field* fields = result->Fetch();
+
+                    EnchantTemplate pEnchant;
+                    pEnchant.ClassId = fields[0].GetUInt8();
+                    pEnchant.SpecId = fields[1].GetUInt8();
+                    pEnchant.SpellId = fields[2].GetUInt32();
+                    pEnchant.SlotId = fields[3].GetUInt8();
+                    enchants.push_back(pEnchant);
+                } while (result->NextRow());
+            }
+        }
+
+        for (const auto& enchant : enchants)
+        {
+            if (enchant.ClassId == bot->getClass() && enchant.SpecId == spec)
+            {
+                ai->EnchantItemT(enchant.SpellId, enchant.SlotId, item);
+            }
+        }
+    }
+}
+
 void EquipAction::EquipItems(Player* requester, ItemIds ids)
 {
     for (ItemIds::iterator i = ids.begin(); i != ids.end(); i++)
@@ -187,6 +229,9 @@ void EquipAction::EquipItemToSlot(Player* requester, Item* item, uint8 targetSlo
     uint16 src = ((bagIndex << 8) | slot);
     uint16 dstPos = ((INVENTORY_SLOT_BAG_0 << 8) | targetSlot);
 
+    // auto enchant if cheat is turned on
+    if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
+        EnchantItem(item);
     bot->SwapItem(src, dstPos);
 
     RESET_AI_VALUE2(ItemUsage, "item usage", ItemQualifier(item).GetQualifier());
@@ -255,6 +300,9 @@ void EquipAction::EquipItem(PlayerbotAI* ai, Player* requester, Item* item, bool
 
         if (!equipedBag) 
         {
+            // auto enchant if cheat is turned on
+            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
+                EnchantItem(item);
             WorldPacket packet(CMSG_AUTOEQUIP_ITEM, 2);
             packet << bagIndex << slot;
             bot->GetSession()->HandleAutoEquipItemOpcode(packet);
@@ -275,43 +323,6 @@ void EquipAction::EquipItem(PlayerbotAI* ai, Player* requester, Item* item, bool
         std::map<std::string, std::string> args;
         args["%item"] = ChatHelper::formatItem(item);
         ai->TellPlayer(requester, BOT_TEXT2("equip_command", args), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
-    }
-}
-
-void EquipUpgradesAction::EnchantItem(Item* item)
-{
-    if (item)
-    {
-        int tab = AiFactory::GetPlayerSpecTab(bot);
-        uint32 tempId = uint32((uint32)bot->getClass() * (uint32)10);
-        uint8 spec = tempId += (uint32)tab;
-
-        if (enchants.empty())
-        {
-            auto result = WorldDatabase.PQuery("SELECT class, spec, spellid, slotid FROM ai_playerbot_enchants");
-            if (result)
-            {
-                do
-                {
-                    Field* fields = result->Fetch();
-
-                    EnchantTemplate pEnchant;
-                    pEnchant.ClassId = fields[0].GetUInt8();
-                    pEnchant.SpecId = fields[1].GetUInt8();
-                    pEnchant.SpellId = fields[2].GetUInt32();
-                    pEnchant.SlotId = fields[3].GetUInt8();
-                    enchants.push_back(pEnchant);
-                } while (result->NextRow());
-            }
-        }
-
-        for (const auto& enchant : enchants)
-        {
-            if (enchant.ClassId == bot->getClass() && enchant.SpecId == spec)
-            {
-                ai->EnchantItemT(enchant.SpellId, enchant.SlotId, item);
-            }
-        }
     }
 }
 
@@ -422,8 +433,8 @@ bool EquipUpgradesAction::Execute(Event& event)
             sLog.outDetail("Bot #%d <%s> auto equips item %d (%s)", bot->GetGUIDLow(), bot->GetName(), item->GetProto()->ItemId, usage == ItemUsage::ITEM_USAGE_EQUIP ? "better than current" : usage == ItemUsage::ITEM_USAGE_BAD_EQUIP ? "wrong item but empty slot" : "");
             ai->TellDebug(ai->GetMaster(), "Equipping: " + chat->formatItem(item) + " - " + ItemUsageValue::ReasonForNeed(usage, item, 1, bot), "debug equip");
             
-            // add an auto enchant if cheat is turned on
-            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot)
+            // auto enchant if cheat is turned on
+            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
                 EnchantItem(item);
 
             EquipItem(ai, GetMaster(), item, item == oldMainhand || item == oldOffhand);   

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -100,7 +100,8 @@ void EquipAction::ListItems(Player* requester)
 
 bool EquipAction::IsEnchantable(Item* item)
 {
-    return !(item->GetProto()->Class == ITEM_CLASS_CONTAINER || item->GetProto()->Class == ITEM_CLASS_QUIVER || item->GetProto()->InventoryType == INVTYPE_AMMO)
+    return !(item->GetProto()->Class == ITEM_CLASS_CONTAINER || item->GetProto()->Class == ITEM_CLASS_QUIVER 
+        || item->GetProto()->InventoryType == INVTYPE_AMMO || item->GetProto()->InventoryType == INVTYPE_RELIC);
 }
 
 void EquipAction::EnchantItem(Item* item)
@@ -158,7 +159,12 @@ void EquipAction::EquipItemsToSlot(Player* requester, ItemIds ids, uint8 targetS
         std::list<Item*> items = visitor.GetResult();
         if (!items.empty())
         {
+            Item* item = *items.begin();
+            
             EquipItemToSlot(requester, *items.begin(), targetSlot);
+            // auto enchant if cheat is turned on
+            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item) && !item->GetEnchantmentId(EnchantmentSlot(0)))
+                EnchantItem(item);
         }
     }
 }
@@ -169,7 +175,12 @@ void EquipAction::EquipItem(Player* requester, FindItemVisitor* visitor)
     std::list<Item*> items = visitor->GetResult();
 	if (!items.empty()) 
     {
-        EquipItem(ai, requester, *items.begin());
+        Item* item = *items.begin();
+
+        EquipItem(ai, requester, item);
+        // auto enchant if cheat is turned on
+        if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item) && !item->GetEnchantmentId(EnchantmentSlot(0)))
+            EnchantItem(item);
     }
 }
 
@@ -229,9 +240,6 @@ void EquipAction::EquipItemToSlot(Player* requester, Item* item, uint8 targetSlo
     uint16 src = ((bagIndex << 8) | slot);
     uint16 dstPos = ((INVENTORY_SLOT_BAG_0 << 8) | targetSlot);
 
-    // auto enchant if cheat is turned on
-    if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
-        EnchantItem(item);
     bot->SwapItem(src, dstPos);
 
     RESET_AI_VALUE2(ItemUsage, "item usage", ItemQualifier(item).GetQualifier());
@@ -300,9 +308,6 @@ void EquipAction::EquipItem(PlayerbotAI* ai, Player* requester, Item* item, bool
 
         if (!equipedBag) 
         {
-            // auto enchant if cheat is turned on
-            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
-                EnchantItem(item);
             WorldPacket packet(CMSG_AUTOEQUIP_ITEM, 2);
             packet << bagIndex << slot;
             bot->GetSession()->HandleAutoEquipItemOpcode(packet);
@@ -432,13 +437,13 @@ bool EquipUpgradesAction::Execute(Event& event)
         {
             sLog.outDetail("Bot #%d <%s> auto equips item %d (%s)", bot->GetGUIDLow(), bot->GetName(), item->GetProto()->ItemId, usage == ItemUsage::ITEM_USAGE_EQUIP ? "better than current" : usage == ItemUsage::ITEM_USAGE_BAD_EQUIP ? "wrong item but empty slot" : "");
             ai->TellDebug(ai->GetMaster(), "Equipping: " + chat->formatItem(item) + " - " + ItemUsageValue::ReasonForNeed(usage, item, 1, bot), "debug equip");
-            
-            // auto enchant if cheat is turned on
-            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item))
-                EnchantItem(item);
 
-            EquipItem(ai, GetMaster(), item, item == oldMainhand || item == oldOffhand);   
+            EquipItem(ai, GetMaster(), item, item == oldMainhand || item == oldOffhand);  
             didEquip = true;
+
+            // auto enchant if cheat is turned on
+            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item) && !item->GetEnchantmentId(EnchantmentSlot(0)))
+                EnchantItem(item); 
         }
     }
 

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -422,3 +422,41 @@ bool EquipUpgradesAction::Execute(Event& event)
 
     return didEquip;
 }
+
+void EquipUpgradesAction::EnchantItem(Item* item)
+{
+    if (item)
+    {
+        int tab = AiFactory::GetPlayerSpecTab(bot);
+        uint32 tempId = uint32((uint32)bot->getClass() * (uint32)10);
+        uint8 spec = tempId += (uint32)tab;
+
+        if (enchants.empty())
+        {
+            auto result = WorldDatabase.PQuery("SELECT class, spec, spellid, slotid FROM ai_playerbot_enchants");
+            if (result)
+            {
+                do
+                {
+                    Field* fields = result->Fetch();
+
+                    EnchantTemplate pEnchant;
+                    pEnchant.ClassId = fields[0].GetUInt8();
+                    pEnchant.SpecId = fields[1].GetUInt8();
+                    pEnchant.SpellId = fields[2].GetUInt32();
+                    pEnchant.SlotId = fields[3].GetUInt8();
+                    enchants.push_back(pEnchant);
+                } 
+                while (result->NextRow());
+            }
+        }
+
+        for (const auto& enchant : enchants)
+        {
+            if (enchant.ClassId == bot->getClass() && enchant.SpecId == spec)
+            {
+                ai->EnchantItemT(enchant.SpellId, enchant.SlotId, item);
+            }
+        }
+    }
+}

--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -278,6 +278,43 @@ void EquipAction::EquipItem(PlayerbotAI* ai, Player* requester, Item* item, bool
     }
 }
 
+void EquipUpgradesAction::EnchantItem(Item* item)
+{
+    if (item)
+    {
+        int tab = AiFactory::GetPlayerSpecTab(bot);
+        uint32 tempId = uint32((uint32)bot->getClass() * (uint32)10);
+        uint8 spec = tempId += (uint32)tab;
+
+        if (enchants.empty())
+        {
+            auto result = WorldDatabase.PQuery("SELECT class, spec, spellid, slotid FROM ai_playerbot_enchants");
+            if (result)
+            {
+                do
+                {
+                    Field* fields = result->Fetch();
+
+                    EnchantTemplate pEnchant;
+                    pEnchant.ClassId = fields[0].GetUInt8();
+                    pEnchant.SpecId = fields[1].GetUInt8();
+                    pEnchant.SpellId = fields[2].GetUInt32();
+                    pEnchant.SlotId = fields[3].GetUInt8();
+                    enchants.push_back(pEnchant);
+                } while (result->NextRow());
+            }
+        }
+
+        for (const auto& enchant : enchants)
+        {
+            if (enchant.ClassId == bot->getClass() && enchant.SpecId == spec)
+            {
+                ai->EnchantItemT(enchant.SpellId, enchant.SlotId, item);
+            }
+        }
+    }
+}
+
 bool EquipUpgradesAction::Execute(Event& event)
 {
     if (!sPlayerbotAIConfig.autoEquipUpgradeLoot && !sRandomPlayerbotMgr.IsRandomBot(bot))
@@ -423,40 +460,4 @@ bool EquipUpgradesAction::Execute(Event& event)
     return didEquip;
 }
 
-void EquipUpgradesAction::EnchantItem(Item* item)
-{
-    if (item)
-    {
-        int tab = AiFactory::GetPlayerSpecTab(bot);
-        uint32 tempId = uint32((uint32)bot->getClass() * (uint32)10);
-        uint8 spec = tempId += (uint32)tab;
 
-        if (enchants.empty())
-        {
-            auto result = WorldDatabase.PQuery("SELECT class, spec, spellid, slotid FROM ai_playerbot_enchants");
-            if (result)
-            {
-                do
-                {
-                    Field* fields = result->Fetch();
-
-                    EnchantTemplate pEnchant;
-                    pEnchant.ClassId = fields[0].GetUInt8();
-                    pEnchant.SpecId = fields[1].GetUInt8();
-                    pEnchant.SpellId = fields[2].GetUInt32();
-                    pEnchant.SlotId = fields[3].GetUInt8();
-                    enchants.push_back(pEnchant);
-                } 
-                while (result->NextRow());
-            }
-        }
-
-        for (const auto& enchant : enchants)
-        {
-            if (enchant.ClassId == bot->getClass() && enchant.SpecId == spec)
-            {
-                ai->EnchantItemT(enchant.SpellId, enchant.SlotId, item);
-            }
-        }
-    }
-}

--- a/playerbot/strategy/actions/EquipAction.h
+++ b/playerbot/strategy/actions/EquipAction.h
@@ -52,5 +52,6 @@ namespace ai
 #endif 
     private:
         void EnchantItem(Item* item);
+        std::vector<EnchantTemplate> enchants;
     };
 }

--- a/playerbot/strategy/actions/EquipAction.h
+++ b/playerbot/strategy/actions/EquipAction.h
@@ -14,6 +14,10 @@ namespace ai
         void EquipItemToSlot(Player* requester, Item* item, uint8 targetSlot);
         virtual bool isUsefulWhenStunned() override { return true; }
 
+        bool IsEnchantable(Item* item);
+        void EnchantItem(Item* item);
+
+        std::vector<EnchantTemplate> enchants;
 #ifdef GenerateBotHelp
         virtual std::string GetHelpName() { return "equip"; }
         virtual std::string GetHelpDescription()
@@ -29,11 +33,7 @@ namespace ai
     private:
         void EquipItem(Player* requester, FindItemVisitor* visitor);
         void ListItems(Player* requester);
-        bool IsEnchantable(Item* item);
-        void EnchantItem(Item* item);
         static uint8 GetSmallestBagSlot(Player* bot);
-
-        std::vector<EnchantTemplate> enchants;
     };
 
     class EquipUpgradesAction : public EquipAction

--- a/playerbot/strategy/actions/EquipAction.h
+++ b/playerbot/strategy/actions/EquipAction.h
@@ -29,6 +29,7 @@ namespace ai
     private:
         void EquipItem(Player* requester, FindItemVisitor* visitor);
         void ListItems(Player* requester);
+        void EnchantItem(Item* item);
         static uint8 GetSmallestBagSlot(Player* bot);
     };
 

--- a/playerbot/strategy/actions/EquipAction.h
+++ b/playerbot/strategy/actions/EquipAction.h
@@ -29,7 +29,11 @@ namespace ai
     private:
         void EquipItem(Player* requester, FindItemVisitor* visitor);
         void ListItems(Player* requester);
+        bool IsEnchantable(Item* item);
+        void EnchantItem(Item* item);
         static uint8 GetSmallestBagSlot(Player* bot);
+
+        std::vector<EnchantTemplate> enchants;
     };
 
     class EquipUpgradesAction : public EquipAction
@@ -50,8 +54,5 @@ namespace ai
         virtual std::vector<std::string> GetUsedActions() { return {}; }
         virtual std::vector<std::string> GetUsedValues() { return {}; }
 #endif 
-    private:
-        void EnchantItem(Item* item);
-        std::vector<EnchantTemplate> enchants;
     };
 }

--- a/playerbot/strategy/actions/EquipAction.h
+++ b/playerbot/strategy/actions/EquipAction.h
@@ -29,7 +29,6 @@ namespace ai
     private:
         void EquipItem(Player* requester, FindItemVisitor* visitor);
         void ListItems(Player* requester);
-        void EnchantItem(Item* item);
         static uint8 GetSmallestBagSlot(Player* bot);
     };
 
@@ -51,5 +50,7 @@ namespace ai
         virtual std::vector<std::string> GetUsedActions() { return {}; }
         virtual std::vector<std::string> GetUsedValues() { return {}; }
 #endif 
+    private:
+        void EnchantItem(Item* item);
     };
 }


### PR DESCRIPTION
Add a way to auto enchant upgrades bots receive. This makes it so that you don't have to manually run the command to enchant their gear every time they get a new item. It's basically the live version of the auto gear upgrade system which also enchants their items automatically.

By default this is disabled, you adjust the option in the config file.