### PR TITLE
Remove the auto enchants on equip, keep on upgrade

### DIFF
--- a/playerbot/strategy/actions/EquipAction.cpp
+++ b/playerbot/strategy/actions/EquipAction.cpp
@@ -162,9 +162,6 @@ void EquipAction::EquipItemsToSlot(Player* requester, ItemIds ids, uint8 targetS
             Item* item = *items.begin();
             
             EquipItemToSlot(requester, *items.begin(), targetSlot);
-            // auto enchant if cheat is turned on
-            if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item) && !item->GetEnchantmentId(EnchantmentSlot(0)))
-                EnchantItem(item);
         }
     }
 }
@@ -178,9 +175,6 @@ void EquipAction::EquipItem(Player* requester, FindItemVisitor* visitor)
         Item* item = *items.begin();
 
         EquipItem(ai, requester, item);
-        // auto enchant if cheat is turned on
-        if (sPlayerbotAIConfig.autoEnchantUpgradeLoot && IsEnchantable(item) && !item->GetEnchantmentId(EnchantmentSlot(0)))
-            EnchantItem(item);
     }
 }
 


### PR DESCRIPTION
There's a lot of things bots are equipping in the normal course of gameplay for various reasons that can't be enchanted as an upgrade which is showing errors in the server log, so for now, remove the auto-enchant when equipping items (equip command, non upgrade equip) and keep it only when an upgrade is obtained (after winning a loot roll and upgrading).