### PR TITLE
Add totemic call trigger and action for TBC shamans and add "place totems" chat command

### DIFF
--- a/playerbot/strategy/actions/ReachTargetActions.h
+++ b/playerbot/strategy/actions/ReachTargetActions.h
@@ -238,7 +238,7 @@ namespace ai
                 if (!bot->IsWithinDistInMap(member, 100.0f, false))
                     continue;
 
-                if (!ai->HasAura(totemSpell, member, false, true))
+                if (!ai->HasAura(totemSpell, member))
                     return member;
             }
 

--- a/playerbot/strategy/actions/SayAction.cpp
+++ b/playerbot/strategy/actions/SayAction.cpp
@@ -11,7 +11,7 @@
 
 using namespace ai;
 
-std::unordered_set<std::string> noReplyMsgs = { "all ?", "attack", "attack rti", "bank", "c", "co ?", "de ?", "dead ?", "do accept invitation", "faction", "flee", "follow", "give leader", "guard", "guild leave", "help", "home", "items", "join", "jump", "leave", "lfg", "loot", "los", "nc ?", "pet aggressive", "pet defensive", "pet passive", "pet follow", "pet stay", "pet attack", "pet dismiss", "pet call", "pull", "pull rti", "quests", "quests co", "quests in", "quests all", "react ?", "release", "repair", "reset", "reset ai", "reset strats", "revive", "roll feedback", "rtsc", "rtsc cancel", "rtsc select", "skill", "spells", "stats", "stay", "summon", "talents", "talk", "trainer" "trainer learn", "u go", "who", "where" };
+std::unordered_set<std::string> noReplyMsgs = { "all ?", "attack", "attack rti", "bank", "c", "co ?", "de ?", "dead ?", "do accept invitation", "faction", "flee", "follow", "give leader", "guard", "guild leave", "help", "home", "items", "join", "jump", "leave", "lfg", "loot", "los", "nc ?", "pet aggressive", "pet defensive", "pet passive", "pet follow", "pet stay", "pet attack", "pet dismiss", "pet call", "pull", "pull rti", "place totems", "quests", "quests co", "quests in", "quests all", "react ?", "release", "repair", "reset", "reset ai", "reset strats", "revive", "roll feedback", "rtsc", "rtsc cancel", "rtsc select", "skill", "spells", "stats", "stay", "summon", "talents", "talk", "trainer" "trainer learn", "u go", "who", "where" };
 
 std::unordered_set<std::string> noReplyMsgParts = {  };
 

--- a/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
@@ -572,6 +572,10 @@ void RestorationShamanStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
     triggers.push_back(new TriggerNode(
         "party member almost full health",
         NextAction::array(0, new NextAction("lesser healing wave on party", ACTION_LIGHT_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "pull start",
+        NextAction::array(0, new NextAction("fire totem", ACTION_MEDIUM_HEAL), new NextAction("air totem", ACTION_MEDIUM_HEAL), new NextAction("water totem", ACTION_MEDIUM_HEAL), new NextAction("earth totem", ACTION_MEDIUM_HEAL) NULL)));
 }
 
 void RestorationShamanStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
@@ -575,7 +575,7 @@ void RestorationShamanStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "pull start",
-        NextAction::array(0, new NextAction("fire totem", ACTION_MEDIUM_HEAL), new NextAction("air totem", ACTION_MEDIUM_HEAL), new NextAction("water totem", ACTION_MEDIUM_HEAL), new NextAction("earth totem", ACTION_MEDIUM_HEAL) NULL)));
+        NextAction::array(0, new NextAction("fire totem", ACTION_MEDIUM_HEAL), new NextAction("air totem", ACTION_MEDIUM_HEAL), new NextAction("water totem", ACTION_MEDIUM_HEAL), new NextAction("earth totem", ACTION_MEDIUM_HEAL), NULL)));
 }
 
 void RestorationShamanStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/RestorationShamanStrategy.cpp
@@ -572,10 +572,6 @@ void RestorationShamanStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
     triggers.push_back(new TriggerNode(
         "party member almost full health",
         NextAction::array(0, new NextAction("lesser healing wave on party", ACTION_LIGHT_HEAL), NULL)));
-
-    triggers.push_back(new TriggerNode(
-        "pull start",
-        NextAction::array(0, new NextAction("fire totem", ACTION_MEDIUM_HEAL), new NextAction("air totem", ACTION_MEDIUM_HEAL), new NextAction("water totem", ACTION_MEDIUM_HEAL), new NextAction("earth totem", ACTION_MEDIUM_HEAL), NULL)));
 }
 
 void RestorationShamanStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/ShamanActions.h
+++ b/playerbot/strategy/shaman/ShamanActions.h
@@ -128,11 +128,18 @@ namespace ai
                 if (!member->IsInWorld() || member->GetMapId() != bot->GetMapId())
                     continue;
 
-                if (!bot->IsWithinDistInMap(member, 100.0f, false))
+                if (!bot->IsWithinDistInMap(member, 30.0f, false))
                     continue;
 
-                if (!ai->HasAura(GetSpellName(), member, false, true))
-                    return true;
+                // TODO: Implement a better check if member is affected
+                // The aura we want to check is not the same as the spell to summon the totem
+                // While all totems give an aura, aura behavior and naming is not consistent.
+                // The consistent option between all totems is to check if the member is in range to the totem
+                
+                // This is somewhat inaccurate but a much simpler check: if the totem is down already,
+                // then casting the totem is useless. This also checks proximity to owner. 
+                // And if we are not within 30 yd of other members, then dropping the totem won't help them. 
+                return !AI_VALUE2(bool, "has totem", name);
             }
 
             return false;

--- a/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
+++ b/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
@@ -4,6 +4,7 @@
 #include "ShamanAiObjectContext.h"
 #include "ShamanTriggers.h"
 #include "playerbot/strategy/NamedObjectContext.h"
+#include "playerbot/strategy/triggers/ChatCommandTrigger.h"
 #include "ElementalShamanStrategy.h"
 #include "RestorationShamanStrategy.h"
 #include "EnhancementShamanStrategy.h"
@@ -283,6 +284,7 @@ namespace ai
                 creators["earth totem"] = [](PlayerbotAI* ai) { return new EarthTotemTrigger(ai); };
                 creators["water totem"] = [](PlayerbotAI* ai) { return new WaterTotemTrigger(ai); };
                 creators["air totem"] = [](PlayerbotAI* ai) { return new AirTotemTrigger(ai); };
+                creators["place totems"] = [](PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "place totems"); };
                 creators["call of the elements"] = [](PlayerbotAI* ai) { return new TotemsAreNotSummonedTrigger(ai); };
                 creators["call of the ancestors"] = [](PlayerbotAI* ai) { return new TotemsAreNotSummonedTrigger(ai); };
                 creators["call of the spirits"] = [](PlayerbotAI* ai) { return new TotemsAreNotSummonedTrigger(ai); };

--- a/playerbot/strategy/shaman/ShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/ShamanStrategy.cpp
@@ -1567,4 +1567,15 @@ void ShamanManualTotemStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
     triggers.push_back(new TriggerNode(
         triggerName,
         NextAction::array(0, new NextAction(actionName, ACTION_HIGH), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "place totems",
+        NextAction::array(0, new NextAction(actionName, ACTION_MEDIUM_HEAL + 5), NULL)));
+}
+
+void ShamanManualTotemStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode(
+        "place totems",
+        NextAction::array(0, new NextAction(actionName, ACTION_MEDIUM_HEAL + 5), NULL)));
 }

--- a/playerbot/strategy/shaman/ShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/ShamanStrategy.cpp
@@ -901,6 +901,10 @@ void ShamanBuffStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers
     triggers.push_back(new TriggerNode(
         "water walking on party",
         NextAction::array(0, new NextAction("water walking on party", ACTION_NORMAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "totemic recall",
+        NextAction::array(0, new NextAction("totemic recall", ACTION_NORMAL), NULL)));
 }
 
 void ShamanBuffPvpStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/shaman/ShamanStrategy.h
+++ b/playerbot/strategy/shaman/ShamanStrategy.h
@@ -321,6 +321,7 @@ namespace ai
 
     private:
         void InitCombatTriggers(std::list<TriggerNode*>& triggers) override;
+        void InitNonCombatTriggers(std::list<TriggerNode*>& triggers) override;
 
     private:
         std::string name;

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -12,7 +12,7 @@ namespace ai
         static std::list<std::string> spells;
     };
 
-    class ReadyToRemoveTotemsTrigger : public Trigger 
+    class ReadyToRemoveTotemsTrigger : public Trigger
     {
     public:
         ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 10) {}
@@ -31,14 +31,13 @@ namespace ai
                 if (!totem || !totem->IsTotem())
                     continue;
 
-                const bool totemIsInRange = strstri(totem->GetName(), qualifier.c_str()) &&
-                    sServerFacade.GetDistance2d(bot, totem) <= ai->GetRange("spell");
-
                 Unit* totemOwner = totem->GetCreator(totem);
-                if (!totemOwner)
+                if (!totemOwner || totemOwner != bot)
                     continue;
-                
-                if (totemIsInRange && totemOwner == bot) 
+
+                const bool totemIsInRange = sServerFacade.GetDistance2d(totemOwner, totem) <= ai->GetRange("spell");
+
+                if (totemIsInRange) 
                 {
                     totemIsNear = true;
                     break;

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -15,12 +15,38 @@ namespace ai
     class ReadyToRemoveTotemsTrigger : public Trigger 
     {
     public:
-        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 30) {}
+        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 5) {}
 
         virtual bool IsActive() override
         {
+            bool totemIsNear = false;
+            std::list<ObjectGuid> units = *context->GetValue<std::list<ObjectGuid>>("nearest npcs");
+            for (std::list<ObjectGuid>::iterator i = units.begin(); i != units.end(); i++)
+            {
+                Unit* unit = ai->GetUnit(*i);
+                if (!unit)
+                    continue;
+
+                Creature* totem = dynamic_cast<Creature*>(unit);
+                if (!totem || !totem->IsTotem())
+                    continue;
+
+                const bool totemIsInRange = strstri(totem->GetName(), qualifier.c_str()) &&
+                    sServerFacade.GetDistance2d(bot, totem) <= ai->GetRange("spell");
+
+                Unit* totemOwner = totem->GetCreator(totem);
+                if (!totemOwner)
+                    continue;
+                
+                if (totemIsInRange && totemOwner == bot) 
+                {
+                    totemIsNear = true;
+                    break;
+                }
+            }
             // Avoid removing any of the big cooldown totems.
             return AI_VALUE(bool, "have any totem")
+                && !totemIsNear;
                 && !AI_VALUE2(bool, "has totem", "mana tide totem")
                 && !AI_VALUE2(bool, "has totem", "earth elemental totem")
                 && !AI_VALUE2(bool, "has totem", "fire elemental totem");

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -15,7 +15,7 @@ namespace ai
     class ReadyToRemoveTotemsTrigger : public Trigger 
     {
     public:
-        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 5) {}
+        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 10) {}
 
         virtual bool IsActive() override
         {

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -46,7 +46,7 @@ namespace ai
             }
             // Avoid removing any of the big cooldown totems.
             return AI_VALUE(bool, "have any totem")
-                && !totemIsNear;
+                && !totemIsNear
                 && !AI_VALUE2(bool, "has totem", "mana tide totem")
                 && !AI_VALUE2(bool, "has totem", "earth elemental totem")
                 && !AI_VALUE2(bool, "has totem", "fire elemental totem");

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -15,7 +15,7 @@ namespace ai
     class ReadyToRemoveTotemsTrigger : public Trigger 
     {
     public:
-        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 5) {}
+        ReadyToRemoveTotemsTrigger(PlayerbotAI* ai) : Trigger(ai, "ready to remove totems", 30) {}
 
         virtual bool IsActive() override
         {


### PR DESCRIPTION
Add totemic call trigger and action for TBC shamans and add "place totems" chat command.

Shamans will now use totemic call in tbc (totemic recall in wotlk) when they are far away (past distance of aura) from totems.

typing "place totems" in the chat will cause shamans to drop the totems assigned to their manual totem strategies.

Also, fix issue with TotemAction Useful not checking correct aura, it was checking the spell id of the totem and not the auras the totems use. However, this check is not comprehensive since not all totems give a persistent aura; some totems do a pulse and some do no aura. Instead, I've decided that we should just check if the totem is already down next to the shaman, after we check that our party members are nearby. In the future we should implement a more comprehensive check which includes this and checking the correct auras from members, but this has been good enough in dungeon testing.

I also removed the owner check from totemreachaction because the shaman isn't the creator of the aura, it's technically the totem npc which gives the aura.

It was necessary to fix this issue in order to get the features to work. Now the place totems command will only make the shaman drop totems they haven't already dropped.