### PR TITLE
Modify blessing of protection targets

### DIFF
--- a/playerbot/strategy/paladin/PaladinActions.h
+++ b/playerbot/strategy/paladin/PaladinActions.h
@@ -679,7 +679,7 @@ namespace ai
         bool isUseful() override 
         { 
             Unit* target = GetTarget();
-            if(target && target->IsPlayer() && !ai->IsTank((Player*)target))
+            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target) && !ai->IsMelee((Player*)target) && !target->getClass() != CLASS_HUNTER))
             {
                 return CastProtectSpellAction::isUseful();
             }

--- a/playerbot/strategy/paladin/PaladinActions.h
+++ b/playerbot/strategy/paladin/PaladinActions.h
@@ -679,7 +679,7 @@ namespace ai
         bool isUseful() override 
         { 
             Unit* target = GetTarget();
-            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target) && !ai->IsMelee((Player*)target) && !target->getClass() != CLASS_HUNTER))
+            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target) && !ai->IsMelee((Player*)target) && target->getClass() != CLASS_HUNTER))
             {
                 return CastProtectSpellAction::isUseful();
             }


### PR DESCRIPTION
Change BoP targets to prioritize casters since BoP prevents physical actions from being done, so it's more useful to cast on casters. I didn't want to change the code that prioritizes party member since it works well for the other actions like intervene, this is a paladin specific thing.
