### PR TITLE
Increase priority for warlock cc

### DIFF
--- a/playerbot/strategy/warlock/WarlockStrategy.cpp
+++ b/playerbot/strategy/warlock/WarlockStrategy.cpp
@@ -354,11 +354,11 @@ void WarlockCcStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "banish",
-        NextAction::array(0, new NextAction("banish on cc", ACTION_INTERRUPT + 2), NULL)));
+        NextAction::array(0, new NextAction("banish on cc", ACTION_EMERGENCY + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "fear",
-        NextAction::array(0, new NextAction("fear on cc", ACTION_INTERRUPT + 1), NULL)));
+        NextAction::array(0, new NextAction("fear on cc", ACTION_EMERGENCY + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "enemy ten yards",
@@ -818,11 +818,11 @@ void WarlockCcStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "banish",
-        NextAction::array(0, new NextAction("banish on cc", ACTION_INTERRUPT + 2), NULL)));
+        NextAction::array(0, new NextAction("banish on cc", ACTION_EMERGENCY + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "fear",
-        NextAction::array(0, new NextAction("fear on cc", ACTION_INTERRUPT + 1), NULL)));
+        NextAction::array(0, new NextAction("fear on cc", ACTION_EMERGENCY + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "enemy ten yards",
@@ -1284,11 +1284,11 @@ void WarlockCcStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode(
         "banish",
-        NextAction::array(0, new NextAction("banish on cc", ACTION_INTERRUPT + 2), NULL)));
+        NextAction::array(0, new NextAction("banish on cc", ACTION_EMERGENCY + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "fear",
-        NextAction::array(0, new NextAction("fear on cc", ACTION_INTERRUPT + 1), NULL)));
+        NextAction::array(0, new NextAction("fear on cc", ACTION_EMERGENCY + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "enemy ten yards",


### PR DESCRIPTION
Same vein as mage, more priority for cc actions. That way they're more prone to focus on that at the start.