### PR TITLE
Fix blessing of protection targeting to allow melee/hunter with conditions

### DIFF
--- a/playerbot/strategy/paladin/PaladinActions.h
+++ b/playerbot/strategy/paladin/PaladinActions.h
@@ -679,7 +679,7 @@ namespace ai
         bool isUseful() override 
         { 
             Unit* target = GetTarget();
-            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target))
+            if(target && target->IsPlayer() && !ai->IsTank((Player*)target))
             {
                 return CastProtectSpellAction::isUseful();
             }

--- a/playerbot/strategy/paladin/PaladinActions.h
+++ b/playerbot/strategy/paladin/PaladinActions.h
@@ -679,7 +679,7 @@ namespace ai
         bool isUseful() override 
         { 
             Unit* target = GetTarget();
-            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target) && !ai->IsMelee((Player*)target) && target->getClass() != CLASS_HUNTER))
+            if(target && target->IsPlayer() && (!ai->IsTank((Player*)target))
             {
                 return CastProtectSpellAction::isUseful();
             }

--- a/playerbot/strategy/values/PartyMemberToHeal.cpp
+++ b/playerbot/strategy/values/PartyMemberToHeal.cpp
@@ -267,8 +267,8 @@ Unit* PartyMemberToProtect::Calculate()
 
         if (ai->IsTank((Player*)pVictim) && pVictim->GetHealthPercent() > 25)
             continue;
-        //else if (pVictim->GetHealthPercent() > 90)
-            //continue;
+        else if ((ai->IsMelee((Player*)target) || target->getClass() != CLASS_HUNTER) && pVictim->GetHealthPercent() > 50)
+            continue;
 
         if (find(needProtect.begin(), needProtect.end(), pVictim) == needProtect.end())
             needProtect.push_back(pVictim);

--- a/playerbot/strategy/values/PartyMemberToHeal.cpp
+++ b/playerbot/strategy/values/PartyMemberToHeal.cpp
@@ -267,7 +267,7 @@ Unit* PartyMemberToProtect::Calculate()
 
         if (ai->IsTank((Player*)pVictim) && pVictim->GetHealthPercent() > 25)
             continue;
-        else if ((ai->IsMelee((Player*)target) || target->getClass() != CLASS_HUNTER) && pVictim->GetHealthPercent() > 50)
+        else if ((ai->IsMelee((Player*)pVictim) || pVictim->getClass() != CLASS_HUNTER) && pVictim->GetHealthPercent() > 50)
             continue;
 
         if (find(needProtect.begin(), needProtect.end(), pVictim) == needProtect.end())


### PR DESCRIPTION
Fix blessing of protection targeting to allow melee/hunter by shifting protection logic to the protect party member calculation, but with HP threshold condition restored.

The idea motivating this change is that in a given circumstance priority for protection should fall on group members who are less "tanky". In BoP case, because it blocks you from doing physical actions, I wanted it to ignore physical damage dealers since the spell is more useful on spell casters. 

I had also changed the logic in the protect party member to ignore HP thresholds on non tanks since I wanted there to be behavior to protect casters/healers before they even take damage. In many cases later on, your opportunity to BoP/Intervene a healer/caster will only be before the enemy makes contact, or they'll be dead after so there's no point checking HP if they get 1 shot. So HP threshold requirements meant that in many cases in late game, they'd never trigger because the damage is much higher on non-tanks.

But by this same token, physical damage dealers were getting bop when they weren't in danger. I also presume that the party targeting would prioritize melee more since they're closer to the tanks in most cases. So rather than ignoring them completely, protect party member should prioritize these actions towards those who'd take more physical damage, in the same way that we prioritize non-tanks in general by giving tanks the HP threshold to be protected. That way the ability is available more often to use on the more defenseless members.

Hunters can regularly feign death to clear aggro, rogues can vanish so they should (and do) use those tools to protect themselves.

Basically non-hunter ranged and healers will have more priority to be protected than melee/hunters who will have more priority than tanks, and this goes for all party protect type actions, except bop which is never casted on tanks.