### PR TITLE
Add formations to flying

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -384,7 +384,7 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 #ifndef MANGOSBOT_TWO
     if (!bot->IsStopped() && !IsJumping() && !CanMove() && !bot->IsTaxiFlying() && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING) && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED))
 #else
-    if (!bot->IsStopped() && !IsJumping() && !CanMove() && !bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FALLING) && !bot->IsTaxiFlying() && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING) && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED))
+    if (!bot->IsStopped() && !IsJumping() && !CanMove() && !bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FALLING) && !bot->IsTaxiFlying() && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING) && !bot->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_CONFUSED) && !bot->IsFreeFlying())
 #endif
     {
         StopMoving();

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -8425,8 +8425,15 @@ void PlayerbotAI::StopMoving()
     if (bot->GetTransport())
         bot->m_movementInfo.SetMovementFlags(MOVEFLAG_ONTRANSPORT);
     else
+    {
+#ifndef MANGOSBOT_ZERO
+        if (!bot->IsFlying() && !bot->IsFreeFlying())
+            bot->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+#else
         bot->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
-
+#endif        
+    }
+    
     bot->InterruptMoving(true);
     MovementInfo mInfo = bot->m_movementInfo;
     float x, y, z;

--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -8427,7 +8427,7 @@ void PlayerbotAI::StopMoving()
     else
     {
 #ifndef MANGOSBOT_ZERO
-        if (!bot->IsFlying() && !bot->IsFreeFlying())
+        if (!bot->IsFlying())
             bot->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
 #else
         bot->m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);

--- a/playerbot/strategy/actions/FollowActions.cpp
+++ b/playerbot/strategy/actions/FollowActions.cpp
@@ -61,11 +61,11 @@ bool FollowAction::isUseful()
     if (followTarget)
     {
 #ifndef MANGOSBOT_ZERO
-        if (bot->IsFreeFlying() || bot->IsFlying())
+        if (bot->IsFreeFlying() || bot->IsFlying() || bot->IsSwimming())
             distance = sServerFacade.GetDistance(bot, followTarget);
         else
 #endif
-            distance = sServerFacade.GetDistance2d(bot, followTarget);
+        distance = sServerFacade.GetDistance2d(bot, followTarget);
     }
     else
     {
@@ -74,7 +74,11 @@ bool FollowAction::isUseful()
         {
             return false;
         }
-
+#ifndef MANGOSBOT_ZERO
+        if (bot->IsFreeFlying() || bot->IsFlying() || bot->IsSwimming())
+            distance = sServerFacade.GetDistance(bot, loc.coord_x, loc.coord_y, loc.coord_z);
+        else
+#endif
         distance = sServerFacade.GetDistance2d(bot, loc.coord_x, loc.coord_y);
     }
 

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -228,7 +228,7 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
         mm.Clear();
     }
     
-    bool flying = bot->IsFlying() || bot->IsFreeFlying();
+    bool flying = bot->IsFlying() && bot->IsFreeFlying();
     mm.MovePoint(movePosition.getMapId(), Position(movePosition.getX(), movePosition.getY(), movePosition.getZ(), 0.f), flying  ? FORCED_MOVEMENT_FLIGHT : FORCED_MOVEMENT_RUN, flying ? bot->GetSpeed(MOVE_FLIGHT) : 0.f, flying);
     WaitForReach(25.0f);
     

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -221,13 +221,13 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
     MotionMaster& mm = *bot->GetMotionMaster();
 
     //Clean movement if not already moving the same way.
-    /*
-    if (mm.GetCurrent()->GetMovementGeneratorType() != POINT_MOTION_TYPE && mm.GetCurrent()->GetMovementGeneratorType() != IDLE_MOTION_TYPE)
+    
+    if (mm.GetCurrent()->GetMovementGeneratorType() != POINT_MOTION_TYPE)
     {
         ai->StopMoving();
         mm.Clear();
     }
-    */
+    
     bool flying = bot->IsFlying() || bot->IsFreeFlying();
     mm.MovePoint(movePosition.getMapId(), Position(movePosition.getX(), movePosition.getY(), movePosition.getZ(), 0.f), flying  ? FORCED_MOVEMENT_FLIGHT : FORCED_MOVEMENT_RUN, flying ? bot->GetSpeed(MOVE_FLIGHT) : 0.f, flying);
     WaitForReach(25.0f);

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -178,7 +178,7 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
         {
             float height = terrain->GetHeightStatic(bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ());
             float ground = terrain->GetWaterOrGroundLevel(bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), height);
-            if (bot->GetPositionZ() < ground + 1.0f)
+            if (bot->GetPositionZ() < ground + 5.0f)
                 needLand = true;
         }
         if (needLand)

--- a/playerbot/strategy/actions/MovementActions.cpp
+++ b/playerbot/strategy/actions/MovementActions.cpp
@@ -97,7 +97,7 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
     if (!startPosition.isOutside())
         return false;
 
-    float totalDistance = startPosition.distance(endPosition);  //Total distance to where we want to go
+    float totalDistance = startPosition.fDist(endPosition);  //Total distance to where we want to go
     float minDist = sPlayerbotAIConfig.targetPosRecalcDistance; //Minium distance a bot should move.
     float maxDist = sPlayerbotAIConfig.reactDistance;           //Maxium distance a bot can move in one single action.
 
@@ -151,28 +151,24 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
     float originalZ = endPosition.getZ();
     bool detailedMove = ai->AllowActivity(DETAILED_MOVE_ACTIVITY);
 
-    //Crop the distance we can travel to maxDist;
-    if (totalDistance > maxDist)
+    flyHeight = std::min(100.0f, totalDistance / 10.0f);
+
+    //movePosition = movePosition.limit(startPosition, maxDist);
+
+    if (!bot->IsFlying())
     {
-        flyHeight = std::min(100.0f, totalDistance / 10.0f);
+        WorldPacket data(SMSG_SPLINE_MOVE_SET_FLYING, 9);
+        data << bot->GetPackGUID();
+        bot->SendMessageToSet(data, true);
 
-        movePosition = movePosition.limit(startPosition, maxDist);
-
-        if (!bot->IsFlying())
-        {
-            WorldPacket data(SMSG_SPLINE_MOVE_SET_FLYING, 9);
-            data << bot->GetPackGUID();
-            bot->SendMessageToSet(data, true);
-
-            if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING))
-                bot->m_movementInfo.AddMovementFlag(MOVEFLAG_FLYING);
+        if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING))
+            bot->m_movementInfo.AddMovementFlag(MOVEFLAG_FLYING);
 #ifdef MANGOSBOT_ONE
-            if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING2))
-                bot->m_movementInfo.AddMovementFlag(MOVEFLAG_FLYING2);
+        if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_FLYING2))
+            bot->m_movementInfo.AddMovementFlag(MOVEFLAG_FLYING2);
 #endif
-            if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_LEVITATING))
-                bot->m_movementInfo.AddMovementFlag(MOVEFLAG_LEVITATING);
-        }
+        if (!bot->m_movementInfo.HasMovementFlag(MOVEFLAG_LEVITATING))
+            bot->m_movementInfo.AddMovementFlag(MOVEFLAG_LEVITATING);
     }
     else
     {
@@ -182,7 +178,7 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
         {
             float height = terrain->GetHeightStatic(bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ());
             float ground = terrain->GetWaterOrGroundLevel(bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), height);
-            if (bot->GetPositionZ() > originalZ && (bot->GetPositionZ() - originalZ < 5.0f) && (fabs(originalZ - ground) < 5.0f))
+            if (bot->GetPositionZ() < ground + 1.0f)
                 needLand = true;
         }
         if (needLand)
@@ -207,9 +203,9 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
         if (movePosition.currentHeight() > flyHeight && startPosition.IsInLineOfSight(movePosition))
             break;
 
-        movePosition.setZ(movePosition.getZ() + 5.0f);
+        //movePosition.setZ(movePosition.getZ() + 5.0f);
 
-        if (movePosition.distance(startPosition) > maxDist)
+        if (movePosition.fDist(startPosition) > maxDist)
             movePosition = movePosition.limit(startPosition, maxDist);
     }
 
@@ -225,28 +221,18 @@ bool MovementAction::FlyDirect(const WorldPosition &startPosition, const WorldPo
     MotionMaster& mm = *bot->GetMotionMaster();
 
     //Clean movement if not already moving the same way.
-    if (mm.GetCurrent()->GetMovementGeneratorType() != POINT_MOTION_TYPE)
+    /*
+    if (mm.GetCurrent()->GetMovementGeneratorType() != POINT_MOTION_TYPE && mm.GetCurrent()->GetMovementGeneratorType() != IDLE_MOTION_TYPE)
     {
         ai->StopMoving();
         mm.Clear();
     }
-    else
-    {
-        float x, y, z;
-        mm.GetDestination(x, y, z);
-
-        if (movePosition.distance(WorldPosition(movePosition.getMapId(), x, y, z, 0)) > minDist)
-        {
-            ai->StopMoving();
-            mm.Clear();
-        }
-    }
-
+    */
     bool flying = bot->IsFlying() || bot->IsFreeFlying();
     mm.MovePoint(movePosition.getMapId(), Position(movePosition.getX(), movePosition.getY(), movePosition.getZ(), 0.f), flying  ? FORCED_MOVEMENT_FLIGHT : FORCED_MOVEMENT_RUN, flying ? bot->GetSpeed(MOVE_FLIGHT) : 0.f, flying);
-    WaitForReach(movePosition.distance(WorldPosition(movePosition.getX(), movePosition.getY(), movePosition.getZ(), 0.f)));
+    WaitForReach(25.0f);
     
-    AI_VALUE(LastMovement&, "last movement").lastAreaTrigger = movePosition;
+    AI_VALUE(LastMovement&, "last movement").lastAreaTrigger = WorldPosition(bot->GetMapId(), bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ(), bot->GetOrientation());
 
     return true;
 #endif
@@ -2504,29 +2490,14 @@ bool MovementAction::Follow(Unit* target, float distance, float angle)
             }
         }
         WorldPosition moveToPos = tarPos;
-        PathFinder pathfinder(bot);
-        //Use standard pathfinder to find a route.
-        WorldPosition prevPoint = botPos;
-        pathfinder.calculate(moveToPos.getVector3(), tarPos.getVector3());
-        Movement::PointsArray& pathPoints = pathfinder.getPath();
-        if (pathPoints.size() >= 2)
+        Formation* formation = AI_VALUE(Formation*, "formation");
+        if (formation)
         {
-            for (uint32 i = 1; i < pathPoints.size() - 1; i++)
-            {
-                WorldPosition pathPoint(bot->GetMapId(), pathPoints[i].x, pathPoints[i].y, pathPoints[i].z);
-                if (pathPoint.canFly())
-                {
-                    prevPoint = pathPoint;
-                    continue;
-                }
-                if (!MoveTo(prevPoint))
-                {
-                    return MoveTo(pathPoint);
-                }
-                return true;
-            }
+            WorldLocation loc = formation->GetLocation();
+            if (!Formation::IsNullLocation(loc) && bot->GetMapId() == loc.mapid)
+                moveToPos = WorldPosition(loc.mapid, loc.coord_x, loc.coord_y, loc.coord_z, loc.orientation);
         }
-        moveToPos = tarPos;
+
         return MoveTo(moveToPos);
     }
 #endif

--- a/playerbot/strategy/values/Arrow.cpp
+++ b/playerbot/strategy/values/Arrow.cpp
@@ -46,15 +46,21 @@ WorldLocation ArrowFormation::GetLocationInternal()
     float y = followTarget->GetPositionY() - masterUnit->GetY() + botUnit->GetY();
     float z = followTarget->GetPositionZ();
 
+    float ox, oy, oz;
+    followTarget->GetPosition(ox, oy, oz);
 #ifdef MANGOSBOT_TWO
-    float ground = followTarget->GetMap()->GetHeight(followTarget->GetPhaseMask(), x, y, z + 0.5f);
+    followTarget->GetMap()->GetHitPosition(ox, oy, oz + bot->GetCollisionHeight(), x, y, z, bot->GetPhaseMask(), -0.5f);
 #else
-    float ground = followTarget->GetMap()->GetHeight(x, y, z + 0.5f);
+    followTarget->GetMap()->GetHitPosition(ox, oy, oz + bot->GetCollisionHeight(), x, y, z, -0.5f);
 #endif
-    if (ground <= INVALID_HEIGHT)
-        return Formation::NullLocation;
 
-    return WorldLocation(followTarget->GetMapId(), x, y, 0.05f + ground);
+    if (!bot->IsFlying() && !bot->IsFreeFlying() && !bot->IsSwimming())
+    {
+        z += CONTACT_DISTANCE;
+        bot->UpdateAllowedPositionZ(x, y, z);
+    }
+
+    return WorldLocation(followTarget->GetMapId(), x, y, z);
 }
 
 void ArrowFormation::Build()

--- a/playerbot/strategy/values/Formations.cpp
+++ b/playerbot/strategy/values/Formations.cpp
@@ -153,15 +153,7 @@ namespace ai
             float x = followTarget->GetPositionX() + cos(angle) * range;
             float y = followTarget->GetPositionY() + sin(angle) * range;
             float z = followTarget->GetPositionZ();
-#ifdef MANGOSBOT_TWO
-            float ground = followTarget->GetMap()->GetHeight(followTarget->GetPhaseMask(), x, y, z);
-#else
-            float ground = followTarget->GetMap()->GetHeight(x, y, z);
-#endif
-            //if (ground <= INVALID_HEIGHT)
-            //    return Formation::NullLocation;
 
-            // prevent going into terrain
             float ox, oy, oz;
             followTarget->GetPosition(ox, oy, oz);
 #ifdef MANGOSBOT_TWO


### PR DESCRIPTION
Add formation position support for flying.

Improve general responsiveness for flying.

Fix issue related to bots sometimes appearing 5 yds above you when you were on the ground on a flying mount.

Fix arrow formation code not factoring in z above ground. Also cleanup ground references for near and arrow formations.