### PR TITLE
Rework CC for bots in PvE

### DIFF
--- a/playerbot/strategy/Action.h
+++ b/playerbot/strategy/Action.h
@@ -53,7 +53,8 @@ namespace ai
     {
         ACTION_THREAT_NONE = 0,
         ACTION_THREAT_SINGLE= 1,
-        ACTION_THREAT_AOE = 2
+        ACTION_THREAT_AOE = 2,
+        ACTION_THREAT_LOW = 3
     };
 
     class Action : public AiNamedObject

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -114,9 +114,10 @@ bool AttackAction::Attack(Player* requester, Unit* target)
         AI_VALUE(LootObjectStack*, "available loot")->Add(guid);
 
         WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
+        bool isWaitingForAttack = false;
         if (strategy)
         {
-            const bool isWaitingForAttack = strategy->ShouldWait(ai);
+            isWaitingForAttack = strategy->ShouldWait(ai);
             Pet* pet = bot->GetPet();
             if (pet)
             {

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -132,24 +132,57 @@ bool AttackAction::Attack(Player* requester, Unit* target)
                         {
                             creatureAI->SetReactState(REACT_DEFENSIVE);
                         }
-
-                        // Don't send the pet to attack if set to passive
-                        if (strategy->GetPetReactState() != REACT_PASSIVE)
+                        else 
                         {
-                            creatureAI->SetReactState(strategy->GetPetReactState());
-                            creatureAI->AttackStart(target);
+                            // If we're done waiting to attack and there's mobs to cc, we can't use defensive/aggressive
+                            // because non passive pets will ignore our cc
+                            // Therefore, we'll keep passive so we can only attack the current target specifically
+                            // In other words, pet only attacks what owner can attack
+                            Unit* ccTarget = AI_VALUE(Unit*, "rti cc target");
+                            if (!ccTarget || (ccTarget && target->GetObjectGuid() != ccTarget->GetObjectGuid()))
+                            {
+                                constexpr uint32 PET_IMP = 416;
+                                constexpr uint32 PHASE_SHIFT = 4511;
+                                if (!(bot->getClass() == CLASS_WARLOCK &&
+                                    pet->AI() && pet->AI()->HasReactState(REACT_PASSIVE) &&
+                                    pet->GetEntry() == PET_IMP && pet->HasAura(PHASE_SHIFT)))
+                                {
+                                    // Send pet action packet
+                                    const ObjectGuid& petGuid = pet->GetObjectGuid();
+                                    const ObjectGuid& targetGuid = target->GetObjectGuid();
+                                    const uint8 flag = ACT_COMMAND;
+                                    const uint32 spellId = COMMAND_ATTACK;
+                                    const uint32 command = (flag << 24) | spellId;
+
+                                    WorldPacket data(CMSG_PET_ACTION);
+                                    data << petGuid;
+                                    data << command;
+                                    data << targetGuid;
+                                    bot->GetSession()->HandlePetAction(data);
+                                }
+                            }
                         }
                     }
                     else
                     {
-                        if (creatureAI->GetReactState() != REACT_PASSIVE)
-                            // Set the pet on passive mode during the pull
-                            strategy->SetPetReactState(creatureAI->GetReactState());
-                            creatureAI->SetReactState(REACT_PASSIVE);
+                        strategy->SetPetReactState(creatureAI->GetReactState() != REACT_PASSIVE ? creatureAI->GetReactState() : REACT_PASSIVE);
+                        creatureAI->SetReactState(REACT_PASSIVE);
+
+                        // Send pet action packet
+                        const ObjectGuid& petGuid = pet->GetObjectGuid();
+                        const uint8 flag = ACT_REACTION;
+                        const uint32 spellId = REACT_PASSIVE;
+                        const uint32 data = (flag << 24) | spellId;
+
+                        WorldPacket packet(CMSG_PET_ACTION);
+                        packet << petGuid;
+                        packet << data;
+                        packet << uint64(0);
+                        bot->GetSession()->HandlePetAction(packet);
+                        bot->PetSpellInitialize();
                     }
                 }
             }
-
         }
 
         if (ai->CanMove() && !sServerFacade.IsInFront(bot, target, sPlayerbotAIConfig.sightDistance, CAST_ANGLE_IN_FRONT))

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -113,7 +113,8 @@ bool AttackAction::Attack(Player* requester, Unit* target)
         SET_AI_VALUE(Unit*, "current target", target);
         AI_VALUE(LootObjectStack*, "available loot")->Add(guid);
 
-        const bool isWaitingForAttack = WaitForAttackStrategy::ShouldWait(ai);
+        WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
+        const bool isWaitingForAttack = strategy->ShouldWait(ai);
         Pet* pet = bot->GetPet();
         if (pet)
         {
@@ -130,10 +131,18 @@ bool AttackAction::Attack(Player* requester, Unit* target)
                     }
 
                     // Don't send the pet to attack if set to passive
-                    if (creatureAI->GetReactState() != REACT_PASSIVE)
+                    if (strategy->GetPetReactState() != REACT_PASSIVE)
                     {
+                        creatureAI->SetReactState(strategy->GetPetReactState());
                         creatureAI->AttackStart(target);
                     }
+                }
+                else
+                {
+                    if (creatureAI->GetReactState() != REACT_PASSIVE)
+                        // Set the pet on passive mode during the pull
+                        strategy->SetPetReactState(creatureAI->GetReactState());
+                        creatureAI->SetReactState(REACT_PASSIVE);
                 }
             }
         }

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -114,37 +114,41 @@ bool AttackAction::Attack(Player* requester, Unit* target)
         AI_VALUE(LootObjectStack*, "available loot")->Add(guid);
 
         WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
-        const bool isWaitingForAttack = strategy->ShouldWait(ai);
-        Pet* pet = bot->GetPet();
-        if (pet)
+        if (strategy)
         {
-            UnitAI* creatureAI = ((Creature*)pet)->AI();
-            if (creatureAI)
+            const bool isWaitingForAttack = strategy->ShouldWait(ai);
+            Pet* pet = bot->GetPet();
+            if (pet)
             {
-                // Don't send the pet to attack if the bot is waiting for attack
-                if (!isWaitingForAttack && (!ai->HasStrategy("stay", BotState::BOT_STATE_COMBAT) || AI_VALUE2(float, "distance", "current target") < ai->GetRange("spell")))
+                UnitAI* creatureAI = ((Creature*)pet)->AI();
+                if (creatureAI)
                 {
-                    // Reset the pet state if no master
-                    if (creatureAI->GetReactState() == REACT_PASSIVE && !ai->GetMaster())
+                    // Don't send the pet to attack if the bot is waiting for attack
+                    if (!isWaitingForAttack && (!ai->HasStrategy("stay", BotState::BOT_STATE_COMBAT) || AI_VALUE2(float, "distance", "current target") < ai->GetRange("spell")))
                     {
-                        creatureAI->SetReactState(REACT_DEFENSIVE);
-                    }
+                        // Reset the pet state if no master
+                        if (creatureAI->GetReactState() == REACT_PASSIVE && !ai->GetMaster())
+                        {
+                            creatureAI->SetReactState(REACT_DEFENSIVE);
+                        }
 
-                    // Don't send the pet to attack if set to passive
-                    if (strategy->GetPetReactState() != REACT_PASSIVE)
-                    {
-                        creatureAI->SetReactState(strategy->GetPetReactState());
-                        creatureAI->AttackStart(target);
+                        // Don't send the pet to attack if set to passive
+                        if (strategy->GetPetReactState() != REACT_PASSIVE)
+                        {
+                            creatureAI->SetReactState(strategy->GetPetReactState());
+                            creatureAI->AttackStart(target);
+                        }
                     }
-                }
-                else
-                {
-                    if (creatureAI->GetReactState() != REACT_PASSIVE)
-                        // Set the pet on passive mode during the pull
-                        strategy->SetPetReactState(creatureAI->GetReactState());
-                        creatureAI->SetReactState(REACT_PASSIVE);
+                    else
+                    {
+                        if (creatureAI->GetReactState() != REACT_PASSIVE)
+                            // Set the pet on passive mode during the pull
+                            strategy->SetPetReactState(creatureAI->GetReactState());
+                            creatureAI->SetReactState(REACT_PASSIVE);
+                    }
                 }
             }
+
         }
 
         if (ai->CanMove() && !sServerFacade.IsInFront(bot, target, sPlayerbotAIConfig.sightDistance, CAST_ANGLE_IN_FRONT))

--- a/playerbot/strategy/actions/ChooseTargetActions.cpp
+++ b/playerbot/strategy/actions/ChooseTargetActions.cpp
@@ -127,7 +127,27 @@ bool SelectNewTargetAction::Execute(Event& event)
     bot->SetSelectionGuid(ObjectGuid());
     ai->InterruptSpell();
     bot->AttackStop();
+    // Stop pet attacking
+    Pet* pet = bot->GetPet();
+    if (pet)
+    {
+        UnitAI* creatureAI = ((Creature*)pet)->AI();
+        if (creatureAI)
+        {
+            // Send pet action packet
+            const ObjectGuid& petGuid = pet->GetObjectGuid();
+            const ObjectGuid& targetGuid = ObjectGuid();
+            const uint8 flag = ACT_COMMAND;
+            const uint32 spellId = COMMAND_FOLLOW;
+            const uint32 command = (flag << 24) | spellId;
 
+            WorldPacket data(CMSG_PET_ACTION);
+            data << petGuid;
+            data << command;
+            data << targetGuid;
+            bot->GetSession()->HandlePetAction(data);
+        }
+    }
 
     bool moreAttackers = false;
     // Check if there is any enemy targets available to attack
@@ -154,31 +174,6 @@ bool SelectNewTargetAction::Execute(Event& event)
         {
             moreAttackers = true;
             return ai->DoSpecificAction("tank assist", event, true);
-        }
-    }
-    
-    if (!moreAttackers)
-    {
-        // Stop pet attacking
-        Pet* pet = bot->GetPet();
-        if (pet)
-        {
-            UnitAI* creatureAI = ((Creature*)pet)->AI();
-            if (creatureAI)
-            {
-                // Send pet action packet
-                const ObjectGuid& petGuid = pet->GetObjectGuid();
-                const ObjectGuid& targetGuid = ObjectGuid();
-                const uint8 flag = ACT_COMMAND;
-                const uint32 spellId = COMMAND_FOLLOW;
-                const uint32 command = (flag << 24) | spellId;
-
-                WorldPacket data(CMSG_PET_ACTION);
-                data << petGuid;
-                data << command;
-                data << targetGuid;
-                bot->GetSession()->HandlePetAction(data);
-            }
         }
     }
 

--- a/playerbot/strategy/actions/GenericSpellActions.h
+++ b/playerbot/strategy/actions/GenericSpellActions.h
@@ -336,7 +336,7 @@ namespace ai
     {
     public:
         CastShootAction(PlayerbotAI* ai) : CastSpellAction(ai, "shoot"), rangedWeapon(nullptr), weaponDelay(0), needsAmmo(false) {}
-        ActionThreatType getThreatType() override { return ActionThreatType::ACTION_THREAT_NONE; }
+        ActionThreatType getThreatType() override { return ActionThreatType::ACTION_THREAT_LOW; }
         bool Execute(Event& event) override;
         bool isPossible() override;
 

--- a/playerbot/strategy/actions/PullActions.cpp
+++ b/playerbot/strategy/actions/PullActions.cpp
@@ -225,6 +225,9 @@ bool PullEndAction::Execute(Event& event)
             if (creatureAI)
             {
                 creatureAI->SetReactState(strategy->GetPetReactState());
+                Unit* target = AI_VALUE(Unit*, "current target");
+                if (creatureAI->GetReactState() != REACT_PASSIVE && target)
+                    creatureAI->AttackStart(target);
             }
         }
 

--- a/playerbot/strategy/actions/ReachTargetActions.h
+++ b/playerbot/strategy/actions/ReachTargetActions.h
@@ -53,7 +53,7 @@ namespace ai
                     chaseDist = (chaseDist - sPlayerbotAIConfig.contactDistance);
                 }
 
-                if (MoveStyleValue::WaitForEnemy(ai) && target->m_movementInfo.HasMovementFlag(movementFlagsMask) &&
+                if (MoveStyleValue::WaitForEnemy(ai) && !AI_VALUE(Unit*, "rti cc target") && target->m_movementInfo.HasMovementFlag(movementFlagsMask) &&
                         sServerFacade.IsInFront(target, bot, sPlayerbotAIConfig.sightDistance, CAST_ANGLE_IN_FRONT) &&
                         sServerFacade.IsDistanceGreaterThan(distanceToTarget, sPlayerbotAIConfig.tooCloseDistance))
                 {

--- a/playerbot/strategy/actions/RtiAction.cpp
+++ b/playerbot/strategy/actions/RtiAction.cpp
@@ -16,7 +16,7 @@ bool RtiAction::Execute(Event& event)
         type = "rti cc";
         text = text.substr(3);
     }
-    else if (text.empty() || text == "?")
+    if (text.empty() || text == "?" || text == "cc ?")
     {
         std::ostringstream outRti; outRti << "rti" << ": ";
         AppendRti(outRti, "rti");

--- a/playerbot/strategy/actions/WaitForAttackAction.cpp
+++ b/playerbot/strategy/actions/WaitForAttackAction.cpp
@@ -7,6 +7,9 @@ using namespace ai;
 
 bool WaitForAttackKeepSafeDistanceAction::Execute(Event& event)
 {
+    if (AI_VALUE(Unit*, "rti cc target"))
+        return false;
+        
     Unit* target = AI_VALUE(Unit*, "current target");
 
     if (target && !target->IsStopped() && target->GetTarget() && target->GetTarget()->IsStopped())

--- a/playerbot/strategy/actions/WaitForAttackAction.cpp
+++ b/playerbot/strategy/actions/WaitForAttackAction.cpp
@@ -2,42 +2,64 @@
 #include "playerbot/playerbot.h"
 #include "WaitForAttackAction.h"
 #include "playerbot/strategy/generic/CombatStrategy.h"
+#include "playerbot/strategy/values/PositionValue.h"
 
 using namespace ai;
 
 bool WaitForAttackKeepSafeDistanceAction::Execute(Event& event)
-{
-    if (AI_VALUE(Unit*, "rti cc target"))
-        return false;
-        
+{  
     Unit* target = AI_VALUE(Unit*, "current target");
-
-    if (target && !target->IsStopped() && target->GetTarget() && target->GetTarget()->IsStopped())
-        target = target->GetTarget();
-
-
-    if (target && target->IsAlive())
+    if (target)
     {
-        const float safeDistance = std::max(float(target->GetAttackDistance(bot) + ATTACK_DISTANCE), WaitForAttackStrategy::GetSafeDistance());
-        const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
-
-        // Find the best point around the target.
-        const WorldPosition bestPoint = GetBestPoint(target, (safeDistance - safeDistanceThreshold), safeDistance);
-        if (bestPoint)
+        WorldPosition basePos = WorldPosition(target);
+        if (target->GetTarget())
         {
-            // Move to the best point
-            return MoveTo(bestPoint.getMapId(), bestPoint.getX(), bestPoint.getY(), bestPoint.getZ(), false, false, false, true);
+            target = target->GetTarget();
+            basePos = WorldPosition(target);
+            if (target->IsPlayer())
+            {
+                // If target's target is a bot, see if we can get the pull back pos
+                // else we should just base it off of the player pos
+                Player* player = (Player*)target;
+
+                if (PlayerbotAI* pullerAI = player->GetPlayerbotAI())
+                {
+                    if (pullerAI->HasStrategy("pull back", BotState::BOT_STATE_COMBAT))
+                    {
+                        PositionMap& posMap = PAI_VALUE(PositionMap&, "position");
+                        PositionEntry pullPosition = posMap["pull"];
+                        if (pullPosition.valueSet)
+                            basePos = pullPosition.Get();
+                    }
+                }
+            }
+        }
+
+        if (target->IsAlive())
+        {
+            const float safeDistance = std::max(float(target->GetAttackDistance(bot) + ATTACK_DISTANCE), WaitForAttackStrategy::GetSafeDistance());
+            const float safeDistanceThreshold = WaitForAttackStrategy::GetSafeDistanceThreshold();
+
+            // Find the best point around the target.
+            const WorldPosition bestPoint = GetBestPoint(basePos, (safeDistance - safeDistanceThreshold), safeDistance);
+            if (bestPoint)
+            {
+                // Move to the best point
+                bool success = MoveTo(bestPoint.getMapId(), bestPoint.getX(), bestPoint.getY(), bestPoint.getZ(), false, false, false, true);
+                if (success)
+                    WaitForReach(WorldPosition(bot).fDist(bestPoint));
+                return success;
+            }
         }
     }
 
     return false;
 }
 
-const ai::WorldPosition WaitForAttackKeepSafeDistanceAction::GetBestPoint(Unit* target, float minDistance, float maxDistance) const
+const ai::WorldPosition WaitForAttackKeepSafeDistanceAction::GetBestPoint(const WorldPosition& pos, float minDistance, float maxDistance) const
 {
-    const Map* map = target->GetMap();
     const WorldPosition botPosition(bot);
-    const WorldPosition targetPosition(target);
+    const WorldPosition targetPosition = pos;
     const int8 startDir = urand(0, 1) * 2 - 1;
     const float radiansIncrement = (5.0f / 180.0f) * (M_PI_F);
     const float startAngle = targetPosition.getAngleTo(botPosition) + urand(0.f,radiansIncrement) * startDir;
@@ -52,6 +74,8 @@ const ai::WorldPosition WaitForAttackKeepSafeDistanceAction::GetBestPoint(Unit* 
             Creature* wpCreature = bot->SummonCreature(1, point.getX(), point.getY(), point.getZ(), 0.0f, TEMPSPAWN_TIMED_DESPAWN, 1000.0f + dist * 100.0f);
         }
     }
+
+    std::list<WorldPosition> points;
 
     for (float tryAngle = 0.0f; tryAngle < M_PI_F; tryAngle += radiansIncrement)
     {
@@ -70,7 +94,7 @@ const ai::WorldPosition WaitForAttackKeepSafeDistanceAction::GetBestPoint(Unit* 
             }
 
             // Check if the target is visible from the point
-            if (!target->IsWithinLOS(point.getX(), point.getY(), point.getZ() + bot->GetCollisionHeight()))
+            if (!pos.IsInLineOfSight(WorldPosition(point.getMapId(), point.getX(), point.getY(), point.getZ() + bot->GetCollisionHeight())))
                 continue;
 
             // Check if the point is not surrounded by other enemies
@@ -86,13 +110,18 @@ const ai::WorldPosition WaitForAttackKeepSafeDistanceAction::GetBestPoint(Unit* 
                 Creature* wpCreature = bot->SummonCreature(15631, point.getX(), point.getY(), point.getZ(), 0.0f, TEMPSPAWN_TIMED_DESPAWN, 5000.0f + tryAngle * 1000.0f);
             }
 
-            return point;
+            points.push_back(point);
         }
     }
 
-
-
-    return botPosition;
+    // Use a minimal move from where we are to a safe spot. If no points were found just use original pos.
+    WorldPosition minimumMove = botPosition;
+    if (!points.empty())
+    {
+        points.sort([botPosition](WorldPosition i, WorldPosition j) { return botPosition.fDist(i) < botPosition.fDist(j); });
+        return points.front();
+    }
+    return minimumMove;
 }
 
 bool WaitForAttackKeepSafeDistanceAction::IsEnemyClose(const WorldPosition& point, const std::list<ObjectGuid>& enemies) const

--- a/playerbot/strategy/actions/WaitForAttackAction.h
+++ b/playerbot/strategy/actions/WaitForAttackAction.h
@@ -11,7 +11,7 @@ namespace ai
        virtual bool Execute(Event& event) override;
 
    private:
-       const WorldPosition GetBestPoint(Unit* target, float minDistance, float maxDistance) const;
+       const WorldPosition GetBestPoint(const WorldPosition& pos, float minDistance, float maxDistance) const;
        bool IsEnemyClose(const WorldPosition& point, const std::list<ObjectGuid>& enemies) const;
        virtual bool isUsefulWhenStunned() override { return true; }
    };

--- a/playerbot/strategy/generic/CombatStrategy.cpp
+++ b/playerbot/strategy/generic/CombatStrategy.cpp
@@ -111,7 +111,7 @@ bool WaitForAttackStrategy::ShouldWait(PlayerbotAI* ai)
         {
             // Don't wait if the current target is an enemy player
             bool enemyPlayer = false;
-            Unit* target = ai->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
+            Unit* target = context->GetValue<Unit*>("current target")->Get();
             if (target)
             {
                 Player* player = dynamic_cast<Player*>(target);

--- a/playerbot/strategy/generic/CombatStrategy.cpp
+++ b/playerbot/strategy/generic/CombatStrategy.cpp
@@ -94,6 +94,11 @@ void WaitForAttackStrategy::InitCombatMultipliers(std::list<Multiplier*>& multip
     multipliers.push_back(new WaitForAttackMultiplier(ai));
 }
 
+WaitForAttackStrategy* WaitForAttackStrategy::Get(PlayerbotAI* ai)
+{
+    return ai ? ai->GetStrategy<WaitForAttackStrategy>("wait for attack", BotState::BOT_STATE_COMBAT) : nullptr;
+}
+
 bool WaitForAttackStrategy::ShouldWait(PlayerbotAI* ai)
 {
     // Only check if the bot has the strategy enabled
@@ -141,7 +146,7 @@ uint8 WaitForAttackStrategy::GetWaitTime(PlayerbotAI* ai)
 
 float WaitForAttackMultiplier::GetValue(Action* action)
 {
-    // Allow some movement and targeting actions
+    // Allow some movement and targeting actions and non threat actions (like cc!)
     const std::string& actionName = action->getName();
     if ((actionName != "wait for attack keep safe distance") && 
         (actionName != "dps assist") && 
@@ -150,7 +155,8 @@ float WaitForAttackMultiplier::GetValue(Action* action)
         (actionName != "pull rti target") &&
         (actionName != "pull start") &&
         (actionName != "pull action") &&
-        (actionName != "pull end"))
+        (actionName != "pull end") &&
+        (action->getThreatType() != ActionThreatType::ACTION_THREAT_NONE))
     {
         return WaitForAttackStrategy::ShouldWait(ai) ? 0.0f : 1.0f;
     }

--- a/playerbot/strategy/generic/CombatStrategy.h
+++ b/playerbot/strategy/generic/CombatStrategy.h
@@ -55,12 +55,15 @@ namespace ai
     {
     public:
         WaitForAttackStrategy(PlayerbotAI* ai) : Strategy(ai) {}
+        static WaitForAttackStrategy* Get(PlayerbotAI* ai);
         std::string getName() override { return "wait for attack"; }
 
         static bool ShouldWait(PlayerbotAI* ai);
         static uint8 GetWaitTime(PlayerbotAI* ai);
         static float GetSafeDistance() { return sPlayerbotAIConfig.spellDistance; }
         static float GetSafeDistanceThreshold() { return 2.5f; }
+        ReactStates GetPetReactState() const { return petReactState; }
+        void SetPetReactState(ReactStates reactState) { petReactState = reactState; }
 
 #ifdef GenerateBotHelp
         virtual std::string GetHelpName() { return "wait for attack"; } //Must equal iternal name
@@ -73,6 +76,9 @@ namespace ai
     private:
         void InitCombatTriggers(std::list<TriggerNode*>& triggers) override;
         void InitCombatMultipliers(std::list<Multiplier*>& multipliers) override;
+
+    private:
+        ReactStates petReactState;
     };
 
     class WaitForAttackMultiplier : public Multiplier

--- a/playerbot/strategy/generic/DpsAssistStrategy.cpp
+++ b/playerbot/strategy/generic/DpsAssistStrategy.cpp
@@ -9,6 +9,10 @@ void DpsAssistStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "not dps target active",
         NextAction::array(0, new NextAction("dps assist", 60.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "dps assist",
+        NextAction::array(0, new NextAction("dps assist", 60.0f), NULL)));
 }
 
 void DpsAoeStrategy::InitCombatTriggers(std::list<TriggerNode*> &triggers)

--- a/playerbot/strategy/generic/ThreatStrategy.cpp
+++ b/playerbot/strategy/generic/ThreatStrategy.cpp
@@ -8,7 +8,7 @@ using namespace ai;
 
 float ThreatMultiplier::GetValue(Action* action)
 {
-    if (action == NULL || action->getThreatType() == ActionThreatType::ACTION_THREAT_NONE)
+    if (action == NULL || action->getThreatType() == ActionThreatType::ACTION_THREAT_NONE || action->getThreatType() == ActionThreatType::ACTION_THREAT_LOW)
         return 1.0f;
 
     if (!AI_VALUE(bool, "group"))

--- a/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -608,7 +608,7 @@ bool HasCcTargetTrigger::IsActive()
     uint32 spellid = AI_VALUE2(uint32, "spell id", getName());
     if (spellid && sServerFacade.IsSpellReady(bot, spellid))
     {
-        return AI_VALUE2(Unit*, "cc target", getName()) && !AI_VALUE2(Unit*, "current cc target", getName());
+        return AI_VALUE(Unit*,"rti cc target")  || (AI_VALUE2(Unit*, "cc target", getName()) && !AI_VALUE2(Unit*, "current cc target", getName()));
     }
 
     return false;

--- a/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -586,6 +586,36 @@ bool TankAssistTrigger::IsActive()
 #endif
 }
 
+bool DpsAssistTrigger::IsActive()
+{
+    if (!AI_VALUE(bool, "has attackers"))
+        return false;
+
+    Unit* currentTarget = AI_VALUE(Unit*, "current target");
+    if (!currentTarget)
+        return false;
+
+    // If owner is waiting this will trigger attack again to call for pet
+    WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
+    bool isWaitingForAttack = false;
+    if (strategy)
+    {
+        isWaitingForAttack = strategy->ShouldWait(ai);
+        Pet* pet = bot->GetPet();
+        if (pet)
+        {
+            UnitAI* creatureAI = ((Creature*)pet)->AI();
+            if (creatureAI)
+            {
+                if (creatureAI->GetReactState() == REACT_PASSIVE && !isWaitingForAttack)
+                    return true;
+            }
+        }
+    }               
+
+    return false;
+}
+
 bool IsBehindTargetTrigger::IsActive()
 {
     Unit* target = AI_VALUE(Unit*, "current target");

--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -701,6 +701,13 @@ namespace ai
 		virtual bool IsActive() override;
 	};
 
+    class DpsAssistTrigger : public Trigger
+	{
+	public:
+        DpsAssistTrigger(PlayerbotAI* ai) : Trigger(ai, "dps assist", 2) {}
+		virtual bool IsActive() override;
+	};
+
     class IsBehindTargetTrigger : public Trigger
     {
     public:

--- a/playerbot/strategy/triggers/PullTriggers.cpp
+++ b/playerbot/strategy/triggers/PullTriggers.cpp
@@ -30,9 +30,10 @@ bool PullEndTrigger::IsActive()
             else
             {
                 float distanceToPullTarget = target->GetDistance(ai->GetBot());
+                // sometimes creatures can reach slightly more than normal attack distance
+                float creatureMeleeRange = ATTACK_DISTANCE + BASE_MELEERANGE_OFFSET + 1;
 
-
-                if (distanceToPullTarget <= ATTACK_DISTANCE || target->IsNonMeleeSpellCasted(true) || (ai->IsRanged(bot) && distanceToPullTarget <= ai->GetRange("spell")))
+                if (distanceToPullTarget <= creatureMeleeRange || (target->IsNonMeleeSpellCasted(true) && target->IsInCombat()) || (secondsSincePullStarted >= 10 && target->GetTarget() != bot) || (ai->IsRanged(bot) && distanceToPullTarget <= ai->GetRange("spell")))
                 {
                     if (ai->HasStrategy("pull back", BotState::BOT_STATE_COMBAT))
                     {

--- a/playerbot/strategy/triggers/RangeTriggers.h
+++ b/playerbot/strategy/triggers/RangeTriggers.h
@@ -434,7 +434,8 @@ namespace ai
 
         virtual bool IsActive() override
         {
-            if (WaitForAttackStrategy::ShouldWait(ai))
+            // we can't let them run away from the targets we need to cc at the start
+            if (WaitForAttackStrategy::ShouldWait(ai) && !AI_VALUE(Unit*, "rti cc target"))
             {
                 // Do not move if stay strategy is set
                 if (!ai->HasStrategy("stay", ai->GetState()))

--- a/playerbot/strategy/triggers/TriggerContext.h
+++ b/playerbot/strategy/triggers/TriggerContext.h
@@ -91,7 +91,7 @@ namespace ai
 
             creators["pull start"] = [](PlayerbotAI* ai) { return new PullStartTrigger(ai); };
             creators["pull end"] = [](PlayerbotAI* ai) { return new PullEndTrigger(ai); };
-
+            creators["dps assist"] = [](PlayerbotAI* ai) { return new DpsAssistTrigger(ai); };
             creators["tank assist"] = [](PlayerbotAI* ai) { return new TankAssistTrigger(ai); };
             creators["lose aggro"] = [](PlayerbotAI* ai) { return new LoseAggroTrigger(ai); };
             creators["has aggro"] = [](PlayerbotAI* ai) { return new HasAggroTrigger(ai); };

--- a/playerbot/strategy/values/AoeValues.cpp
+++ b/playerbot/strategy/values/AoeValues.cpp
@@ -13,7 +13,7 @@ std::list<ObjectGuid> AoeCountValue::FindMaxDensity(Player* bot, float range)
     std::map<ObjectGuid, std::list<ObjectGuid> > groups;
     if (bot)
     {
-        std::list<ObjectGuid> units = *bot->GetPlayerbotAI()->GetAiObjectContext()->GetValue<std::list<ObjectGuid>>("attackers");
+        std::list<ObjectGuid> units = *bot->GetPlayerbotAI()->GetAiObjectContext()->GetValue<std::list<ObjectGuid>>("possible attack targets");
         
         for (std::list<ObjectGuid>::iterator i = units.begin(); i != units.end(); ++i)
         {

--- a/playerbot/strategy/values/AttackersValue.cpp
+++ b/playerbot/strategy/values/AttackersValue.cpp
@@ -208,7 +208,7 @@ void AttackersValue::AddTargetsOf(Player* player, std::set<Unit*>& targets, std:
             const std::string ignoreValidate = std::to_string(true);
             const std::string range = std::to_string((int32)GetRange());
             const std::vector<std::string> qualifiers = { range, ignoreValidate };
-            const std::list<ObjectGuid> possibleTargets = PAI_VALUE2(std::list<ObjectGuid>, "possible targets", Qualified::MultiQualify(qualifiers, ":"));
+            const std::list<ObjectGuid> possibleTargets = PAI_VALUE2(std::list<ObjectGuid>, "possible targets no los", Qualified::MultiQualify(qualifiers, ":"));
             for (const ObjectGuid& guid : possibleTargets)
             {
                 if (Unit* unit = ai->GetUnit(guid))

--- a/playerbot/strategy/values/CcTargetValue.cpp
+++ b/playerbot/strategy/values/CcTargetValue.cpp
@@ -13,7 +13,7 @@ public:
     FindTargetForCcStrategy(PlayerbotAI* ai, std::string spell) : FindTargetStrategy(ai)
     {
         this->spell = spell;
-        maxDistance = 0;
+        maxDistance = sPlayerbotAIConfig.sightDistance;
     }
 
 public:
@@ -23,8 +23,7 @@ public:
 
         AiObjectContext* context = ai->GetAiObjectContext();
 
-        if (!ai->CanCastSpell(spell, creature, true, nullptr, false, true))
-            return;
+
 
         if (AI_VALUE(Unit*,"rti cc target") && AI_VALUE(Unit*,"rti cc target")->GetObjectGuid() == creature->GetObjectGuid())
         {

--- a/playerbot/strategy/values/CcTargetValue.cpp
+++ b/playerbot/strategy/values/CcTargetValue.cpp
@@ -26,7 +26,7 @@ public:
         if (!ai->CanCastSpell(spell, creature, true, nullptr, false, true))
             return;
 
-        if (AI_VALUE(Unit*,"rti cc target") == creature)
+        if (AI_VALUE(Unit*,"rti cc target") && AI_VALUE(Unit*,"rti cc target")->GetObjectGuid() == creature->GetObjectGuid())
         {
             result = creature;
             return;
@@ -56,7 +56,9 @@ public:
 
         if (creature->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE) && !(spell == "fear" || spell == "banish"))
             return;
-
+        /*
+        // Here we try to cc stuff that is not marked. This is not suggested because randomly cc'ing things with no
+        // reason can lead to bad outcomes (cc'ing the mob that isn't marked for you, rebanishing the only mob left nonstop)
         if (!creature->IsPlayer())
         {
             int tankCount, dpsCount;
@@ -68,26 +70,32 @@ public:
             }
         }
 
-        Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
-        for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
+        // This only makese sense if we don't have a target of our own to cc. 
+        // Since we use this function in a search of attackers, first result may not be our rti cc target
+        if (!context->GetValue<Unit*>("rti cc target")->Get())
         {
-            Player *member = sObjectMgr.GetPlayer(itr->guid);
-            if(!member || !sServerFacade.IsAlive(member) || member == bot || bot->GetMapId() != member->GetMapId())
-                continue;
+            Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
+            for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
+            {
+                Player *member = sObjectMgr.GetPlayer(itr->guid);
+                if(!member || !sServerFacade.IsAlive(member) || member == bot || bot->GetMapId() != member->GetMapId())
+                    continue;
 
-            if (!ai->IsTank(member))
-                continue;
+                if (!ai->IsTank(member))
+                    continue;
 
-            float distance = sServerFacade.GetDistance2d(member, creature);
-            if (distance < minDistance)
-                minDistance = distance;
-        }
+                float distance = sServerFacade.GetDistance2d(member, creature);
+                if (distance < minDistance)
+                    minDistance = distance;
+            }
 
-        if ((!result && !creature->IsPlayer()) || minDistance > maxDistance)
-        {
-            result = creature;
-            maxDistance = minDistance;
-        }
+            if ((!result && !creature->IsPlayer()) || minDistance > maxDistance)
+            {
+                result = creature;
+                maxDistance = minDistance;
+            }
+        */
+
     }
 
 private:

--- a/playerbot/strategy/values/CcTargetValue.cpp
+++ b/playerbot/strategy/values/CcTargetValue.cpp
@@ -23,8 +23,6 @@ public:
 
         AiObjectContext* context = ai->GetAiObjectContext();
 
-
-
         if (AI_VALUE(Unit*,"rti cc target") && AI_VALUE(Unit*,"rti cc target")->GetObjectGuid() == creature->GetObjectGuid())
         {
             result = creature;
@@ -54,6 +52,9 @@ public:
         }
 
         if (creature->HasAuraType(SPELL_AURA_PERIODIC_DAMAGE) && !(spell == "fear" || spell == "banish"))
+            return;
+
+        if (!ai->CanCastSpell(spell, creature, true, nullptr, false, true))
             return;
         /*
         // Here we try to cc stuff that is not marked. This is not suggested because randomly cc'ing things with no

--- a/playerbot/strategy/values/FreeMoveValues.cpp
+++ b/playerbot/strategy/values/FreeMoveValues.cpp
@@ -57,6 +57,9 @@ float FreeMoveRangeValue::Calculate()
     if (ai->HasStrategy("stay", ai->GetState()))
         return INTERACTION_DISTANCE;
 
+    if (AI_VALUE(Unit*, "rti cc target"))
+        return ai->GetRange("spell");
+
     Unit* followTarget = AI_VALUE(Unit*, "follow target");
 
     if (!followTarget || followTarget == bot)

--- a/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
@@ -8,6 +8,7 @@
 #include "Grids/GridNotifiersImpl.h"
 #include "Grids/CellImpl.h"
 #include "AttackersValue.h"
+#include "RtiTargetValue.h"
 #include "EnemyPlayerValue.h"
 
 using namespace ai;
@@ -163,6 +164,46 @@ bool PossibleAttackTargetsValue::HasUnBreakableCC(Unit* target, Player* player)
     return false;
 }
 
+bool PossibleAttackTargetsValue::IsCcTarget(Unit* attacker, Player* player)
+{
+    PlayerbotAI* ai = player->GetPlayerbotAI();
+    if (ai)
+    {
+        Group* group = ai->GetBot()->GetGroup();
+        if (group)
+        {
+            Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
+            for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
+            {
+                Player *player = sObjectMgr.GetPlayer(itr->guid);
+                if (!player || !sServerFacade.IsAlive(player) || !ai->IsSafe(player))
+                    continue;
+
+                if (player->GetPlayerbotAI())
+                {
+                    if (PAI_VALUE(Unit*,"rti cc target") == attacker)
+                        return true;
+
+                    std::string rti = PAI_VALUE(std::string,"rti cc");
+                    int index = RtiTargetValue::GetRtiIndex(rti);
+                    if (index != -1)
+                    {
+                        uint64 guid = group->GetTargetIcon(index);
+                        if (guid && attacker->GetObjectGuid() == ObjectGuid(guid))
+                            return true;
+                    }
+                }
+            }
+
+            uint64 guid = group->GetTargetIcon(4);
+            if (guid && attacker->GetObjectGuid() == ObjectGuid(guid))
+                return true;
+        }
+    }
+
+    return false;
+}
+
 bool PossibleAttackTargetsValue::IsImmuneToDamage(Unit* target, Player* player)
 {
     // Charmed
@@ -313,8 +354,8 @@ bool PossibleAttackTargetsValue::IsPossibleTarget(Unit* target, Player* player, 
             return false;
         }
 
-        // If the target is CC'ed
-        if(!ignoreCC && !HasIgnoreCCRti(target, player) && (HasBreakableCC(target, player) || HasUnBreakableCC(target, player)))
+        // If the target is CC'ed or is a CC target (don't place a dot before we recast cc...)
+        if(!ignoreCC && !HasIgnoreCCRti(target, player) && (HasBreakableCC(target, player) || HasUnBreakableCC(target, player)) || IsCcTarget(target, player))
         {
             return false;
         }

--- a/playerbot/strategy/values/PossibleAttackTargetsValue.h
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.h
@@ -33,6 +33,7 @@ namespace ai
         static bool IsImmuneToDamage(Unit* target, Player* player);
         static bool HasIgnoreCCRti(Unit* target, Player* player);
         static bool IsTapped(Unit* target, Player* player);
+        static bool IsCcTarget(Unit* attacker, Player* player);
     };
 
     class PossibleAddsValue : public BoolCalculatedValue

--- a/playerbot/strategy/values/PossibleTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleTargetsValue.cpp
@@ -50,8 +50,8 @@ bool PossibleTargetsValue::AcceptUnit(Unit* unit)
 
 void PossibleTargetsValue::FindPossibleTargets(Player* player, std::list<Unit*>& targets, float range)
 {
-    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(player, range);
-    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    MaNGOS::AnyUnitInObjectRangeCheck u_check(player, range);
+    MaNGOS::UnitListSearcher<MaNGOS::AnyUnitInObjectRangeCheck> searcher(targets, u_check);
     Cell::VisitAllObjects(player, searcher, range);
 }
 

--- a/playerbot/strategy/values/PossibleTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleTargetsValue.cpp
@@ -85,7 +85,8 @@ bool PossibleTargetsValue::IsAttackable(Unit* target, Player* player)
     return !target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_ATTACKABLE_1) &&
            !target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNTARGETABLE) &&
            (inVehicle || !target->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNINTERACTIBLE)) &&
-           !target->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION);
+           !target->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION) &&
+           player->CanAttack(target);
 }
 
 bool PossibleTargetsValue::IsValid(Unit* target, Player* player, bool ignoreLos)

--- a/playerbot/strategy/values/RtiTargetValue.h
+++ b/playerbot/strategy/values/RtiTargetValue.h
@@ -44,7 +44,7 @@ namespace ai
             if (!guid)
                 return NULL;
 
-            std::list<ObjectGuid> attackers = context->GetValue<std::list<ObjectGuid>>("possible targets")->Get();
+            std::list<ObjectGuid> attackers = context->GetValue<std::list<ObjectGuid>>("possible targets no los")->Get();
             if (std::find(attackers.begin(), attackers.end(), guid) == attackers.end()) return NULL;
 
             Unit* unit = ai->GetUnit(ObjectGuid(guid));

--- a/playerbot/strategy/values/TargetValue.cpp
+++ b/playerbot/strategy/values/TargetValue.cpp
@@ -12,7 +12,7 @@ using namespace ai;
 
 Unit* TargetValue::FindTarget(FindTargetStrategy* strategy)
 {
-    std::list<ObjectGuid> attackers = ai->GetAiObjectContext()->GetValue<std::list<ObjectGuid>>("possible attack targets")->Get();
+    std::list<ObjectGuid> attackers = ai->GetAiObjectContext()->GetValue<std::list<ObjectGuid>>("attackers")->Get();
     for (std::list<ObjectGuid>::iterator i = attackers.begin(); i != attackers.end(); ++i)
     {
         Unit* unit = ai->GetUnit(*i);

--- a/playerbot/strategy/warlock/WarlockTriggers.cpp
+++ b/playerbot/strategy/warlock/WarlockTriggers.cpp
@@ -20,7 +20,7 @@ bool SpellstoneTrigger::IsActive()
 
 bool InfernoTrigger::IsActive()
 {
-	return AI_VALUE(uint8, "attackers count") > 1 && bot->HasSpell(1122) && bot->HasItemCount(5565, 1) && !urand(0, 2);
+	return AI_VALUE(uint8, "possible attack targets count") > 1 && bot->HasSpell(1122) && bot->HasItemCount(5565, 1) && !urand(0, 2);
 }
 
 bool CorruptionTrigger::IsActive()
@@ -82,7 +82,7 @@ bool SeedOfCorruptionOnAttackerTrigger::IsActive()
 {
     if (DebuffOnAttackerTrigger::IsActive())
     {
-        return AI_VALUE(uint8, "attackers count") >= 3;
+        return AI_VALUE(uint8, "possible attack targets count") >= 3;
     }
 
     return false;


### PR DESCRIPTION
- Only cc marked targets. While it was nice that bots could cc unprompted, they picked things at random, would not do it consistently, and in all likelihood would cc things that would just get AoE'd. Now with this change and other targeting changes, they are MUCH more responsive to CCing things and Re-ccing when it gets popped.

- Change how the bots determine who to CC so it's correctly matching (previously matches were faulty so bots would just cc whoever is near and would even layer multiple cc on same target)

- Allow them to cc even while waiting to attack since 99% of cc has no aggro, since we want them to wait to attack (generate threat), but we definitely want them to cc as soon as possible.

- Units with CC marks are considered CC'd for attacking purposes so we don't try to attack them before they're cc'd, but we still consider them things to be cc'd and re cc'd

- Prevent pets from attacking until we are done waiting so we don't have pets breaking cc while master is still not attacking, but ccing.

- Lastly, need to change Seed of Corruption and Inferno on warlock because they were checking for attackers count. Since cc'd mobs are attackers we don't want them to think they can aoe breakable cc'd mobs, especially the ones they would have just cc'd. 

- Also in general, we exclude cc'd targets from counting towards the aoe count by checking for possible attack targets  instead, which is now excluding cc'd units or units with marks for cc from the count.

- Shooting is now considered "low threat", so bots will not wand while waiting for attacking (since wanding IS attacking and they're supposed to be waiting to attack), that way they can prioritize the cc much quicker. But they should still shoot in a low threat context (high aggro, no mana).

Bug fix: Fix CC marking check logic (previously when we query bots for their rti cc by doing "rti cc ?", the game would think we want to set their rti cc to ? which is invalid so they wouldn't cc their targets. This also fixes a bug with the addon UI selection). Now, you can correctly set bot cc targets using the Addon and you don't need to be targeting something to change it, if you want each bot to have its own mark instead of just using Moon.

Bug Fix: To account for better cc usage, we need to make sure that when a tank pulls, they have a way to determine if their target's cc'd. The way I did it is: if the target's target isn't the tank anymore by a certain point. At the moment, the pulling code assumes the target will reach the tank, but if they're cc'd or attacking someone else, that won't happen so we need to consider pull ended earlier in this event. Also the pulling code distance check was faulty as it is possible for enemies to melee beyond the melee distance of 5.0f, so we expand the distance a little bit to account for this and leeway.

Also there was a condition in the PullEnd logic that the pull would end early if the target was casting a non-melee spell. That makes sense as it follows the same logic as if the target is cc'd (it won't reach you so we have to end early or else we'll be stuck until max pull time). Problem was, this wasn't checking if the target was in combat or not. So if mobs were casting some kind of channeling spell, like in Shadow Labs, even if it is just a visual thing, the bots wouldn't want to pull since as soon as it got there, it considered the pull ended and ran back. So I fixed that too.

