### PR TITLE
Change High Aoe trigger to 5 mobs instead of 6

### DIFF
--- a/playerbot/strategy/triggers/GenericTriggers.h
+++ b/playerbot/strategy/triggers/GenericTriggers.h
@@ -306,7 +306,7 @@ namespace ai
     class RangedHighAoeTrigger : public AoeTrigger
     {
     public:
-        RangedHighAoeTrigger(PlayerbotAI* ai) : AoeTrigger(ai, 6) {}
+        RangedHighAoeTrigger(PlayerbotAI* ai) : AoeTrigger(ai, 5) {}
     };
 
     class RangedVeryHighAoeTrigger : public AoeTrigger


### PR DESCRIPTION
Change High Aoe trigger to 5 mobs instead of 6. Since bots will ignore immune, cc, and cc marked enemies for the count this will be more accurate of when to use mass aoe such as blizzard or rain of fire.

"Large packs" also tend to be 5 at a minimum. 4/3 is expected to use Cc. Very rare to encounter packs of 6 which would be a 5 pack but maybe some of the mobs have pets of their own.