### PR TITLE
Chain heal is 40 yards + use better function for health percent

### DIFF
--- a/playerbot/strategy/values/AoeHealValues.cpp
+++ b/playerbot/strategy/values/AoeHealValues.cpp
@@ -25,13 +25,13 @@ uint8 AoeHealValue::Calculate()
 	for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
 	{
 		Player *player = sObjectMgr.GetPlayer(itr->guid);
-		if( !player || !sServerFacade.IsAlive(player) || sServerFacade.GetDistance2d(bot, player) > 30.0f)
+		if( !player || !sServerFacade.IsAlive(player) || sServerFacade.GetDistance2d(bot, player) > (bot->getClass() == CLASS_SHAMAN ? 40.0f : 30.0f))
 			continue;
 
         if (bot->getClass() == CLASS_PRIEST && !bot->IsInGroup(player, true))
             continue;
 
-	    float percent = (static_cast<float> (player->GetHealth()) / player->GetMaxHealth()) * 100;
+	    float percent = player->GetHealthPercent();
 	    if (percent <= range)
 	    	count++;
 	}


### PR DESCRIPTION
Chain heal is a 40 yard spell + use better function for health percent