### PR TITLE
Fix Shield slam not being used over Devastate

### DIFF
--- a/playerbot/strategy/warrior/WarriorActions.h
+++ b/playerbot/strategy/warrior/WarriorActions.h
@@ -83,7 +83,7 @@ namespace ai
     MELEE_ACTION(CastShieldSlamAction, "shield slam");
     MELEE_ACTION(CastConcussionBlowAction, "concussion blow");
     // protection talents 2.4.3
-    MELEE_ACTION(CastDevastateAction, "devastate");
+    // MELEE_ACTION(CastDevastateAction, "devastate");
     // protection talents 3.3.5
     MELEE_DEBUFF_ACTION_R(CastShockwaveAction, "shockwave", 8.0f);
     SNARE_ACTION(CastShockwaveSnareAction, "shockwave");
@@ -141,6 +141,30 @@ namespace ai
                 return true;
 
             return !ai->HasAura("sunder armor", target, true);
+        }
+    };
+
+    class CastDevastateAction : public CastMeleeSpellAction
+    {
+    public:
+        CastDevastateAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "devastate") {}
+
+        virtual bool isUseful() override
+        {
+            Unit* target = GetTarget();
+            if (!target)
+                return false;
+
+            const bool isTank = ai->IsTank(bot);
+
+            uint32 shieldSlam = AI_VALUE2(uint32, "spell id", "shield slam");
+
+            if (shieldSlam)
+            {
+                return !bot->IsSpellReady(shieldSlam);
+            }
+
+            return true;
         }
     };
 


### PR DESCRIPTION
Fix Shield slam not being used over Devastate by adding a Useful check for devastate action.

Because Devastate casts Sunder Armor, it would appear that bots were checking the Sunder Armor action for if it was useful. However, because the resulting ability cast is "devastate", it would go to the devastate action even if the sunder action wasn't useful. And the devastate action was just a basic castmeleespellaction with no useful check so it'd fire off regardless of the sunderaction outcome. This would then result in the bots using devastate even if shield slam was ready to use. So we'll use similar conditions to check if devastate is useful, that way if both sunder and then devastate weren't useful, the rage and free global will be there to use shield slam.

I tested myself, prior to this change in a 1 hour run of Karazhan the warrior used no shield slams. After the change, they are using shield slams.

Before:
<img width="1447" height="895" alt="image" src="https://github.com/user-attachments/assets/8bd02389-4b1e-4954-af8a-5a020e06a1a4" />


After:
<img width="890" height="590" alt="image" src="https://github.com/user-attachments/assets/85f10ffd-7d32-4538-add7-3ec826edfc81" />
