### PR TITLE
Fix frost mage aoe priority

### DIFF
--- a/playerbot/strategy/mage/FrostMageStrategy.cpp
+++ b/playerbot/strategy/mage/FrostMageStrategy.cpp
@@ -113,7 +113,7 @@ void FrostMageAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("blizzard", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "ranged high aoe",
+        "frost spells locked",
         NextAction::array(0, new NextAction("flamestrike", ACTION_HIGH), NULL)));
 }
 
@@ -463,7 +463,7 @@ void FrostMageAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("blizzard", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "ranged high aoe",
+        "frost spells locked",
         NextAction::array(0, new NextAction("flamestrike", ACTION_HIGH), NULL)));
 }
 
@@ -829,7 +829,7 @@ void FrostMageAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("blizzard", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "ranged high aoe",
+        "frost spells locked",
         NextAction::array(0, new NextAction("flamestrike", ACTION_HIGH), NULL)));
 }
 

--- a/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -183,6 +183,7 @@ namespace ai
                 creators["summon water elemental"] = [](PlayerbotAI* ai) { return new WaterElementalBoostTrigger(ai); };
                 creators["ice lance"] = [](PlayerbotAI* ai) { return new IceLanceTrigger(ai); };
                 creators["fire spells locked"] = [](PlayerbotAI* ai) { return new FireSpellsLocked(ai); };
+                creators["frost spells locked"] = [](PlayerbotAI* ai) { return new FrostSpellsLocked(ai); };
                 creators["cold snap"] = [](PlayerbotAI* ai) { return new ColdSnapTrigger(ai); };
                 creators["ice barrier"] = [](PlayerbotAI* ai) { return new IceBarrierTrigger(ai); };
                 creators["hot streak"] = [](PlayerbotAI* ai) { return new HotStreakTrigger(ai); };

--- a/playerbot/strategy/mage/MageTriggers.h
+++ b/playerbot/strategy/mage/MageTriggers.h
@@ -179,6 +179,17 @@ namespace ai
         }
     };
 
+    class FrostSpellsLocked : public Trigger
+    {
+    public:
+        FrostSpellsLocked(PlayerbotAI* ai) : Trigger(ai, "frost spells locked", 2) {}
+
+        virtual bool IsActive() override
+        {
+            return !bot->IsSpellReady(116);      //frostbolt
+        }
+    };
+
     class IceLanceTrigger : public Trigger
     {
     public:


### PR DESCRIPTION
Fix frost mage aoe priority to use blizzard more by changing the trigger for flamestrike to be when you are not allowed to use frost spells because of spell locking.

We create a trigger for frost spell lockout which is similar to the current trigger for fire spell lockout and apply that in a similar manner to how the fire mage aoe works.

At the moment, Frost mages are using flamestrike about half the time when they aoe, which is a problem especially when you'd want them to be using blizzard for the aoe slow, but Fire mages will and should use Flamestrike more than Blizzard. But there should still be times when a mage uses other types of AoE so we shouldn't rule out usage totally.

<img width="2056" height="648" alt="image" src="https://github.com/user-attachments/assets/13db1cfe-cbe3-4815-95ed-767e9c6363df" />
