### PR TITLE
Fix thorns on party trigger

### DIFF
--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -23,15 +23,15 @@ namespace ai
         GiftOfTheWildOnPartyTrigger(PlayerbotAI* ai) : GreaterBuffOnPartyTrigger(ai, "gift of the wild", "mark of the wild", 4) {}
     };
 
-    class ThornsOnPartyTrigger : public BuffOnPartyTrigger
+    class ThornsOnPartyTrigger : public BuffOnTankTrigger
     {
     public:
-        ThornsOnPartyTrigger(PlayerbotAI* ai) : BuffOnPartyTrigger(ai, "thorns", 4) {}
+        ThornsOnPartyTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "thorns", 2) {}
 
         virtual bool IsActive() override
         {
             Unit* target = GetTarget();
-            if (target && BuffOnPartyTrigger::IsActive() && (!target->IsPlayer() || !ai->IsRanged((Player*)target)))
+            if (target && BuffOnTankTrigger::IsActive() && (!target->IsPlayer() || !ai->IsRanged((Player*)target)))
             {
                 // Don't apply thorns if fire shield (conflict) is on the target
                 return !ai->HasAura("fire shield", target);

--- a/playerbot/strategy/druid/DruidTriggers.h
+++ b/playerbot/strategy/druid/DruidTriggers.h
@@ -26,7 +26,7 @@ namespace ai
     class ThornsOnPartyTrigger : public BuffOnTankTrigger
     {
     public:
-        ThornsOnPartyTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "thorns", 2) {}
+        ThornsOnPartyTrigger(PlayerbotAI* ai) : BuffOnTankTrigger(ai, "thorns", 4) {}
 
         virtual bool IsActive() override
         {


### PR DESCRIPTION
Fix thorns on party trigger to prioritize searching for tanks first instead of healers first.

It made no sense to use a "friendly units" search which would return healers first if we will then exclude those with ranged strategies (which is all the healers). The GetTarget() would keep returning the same priest unit in a 10 man raid over and over again. Then in the trigger because this healer has a ranged strategy, it would say the trigger is not active. Then 4 seconds would pass and it would repeat the same process again with the same result. This would mean that none of the members, particularly the tanks, would get thorns casted on them.

Since the original intent of the trigger is to find units that would be in melee (hence those who would trigger the thorns effect), and since the majority of thorns damage will come from those who should take melee damage (the tanks), I made it a BuffOnTankTrigger instead and now the druid will cast it on the tanks in a raid, instead of nobody.

Druids will cast thorns on themselves but this is a separate trigger.