### PR TITLE
[Bugfix] Correct immunity mask

### DIFF
--- a/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
@@ -173,7 +173,7 @@ bool PossibleAttackTargetsValue::IsImmuneToDamage(Unit* target, Player* player)
 
     // Immune to damage
     // Before we check auras, check school derived immunity
-    if (target->IsImmuneToDamage(SPELL_SCHOOL_MASK_ALL))
+    if (target->m_spellImmune[IMMUNITY_SCHOOL] == SPELL_SCHOOL_MASK_ALL || target->m_spellImmune[IMMUNITY_DAMAGE] == SPELL_SCHOOL_MASK_ALL)
         return true;
 
     PlayerbotAI* ai = player->GetPlayerbotAI();

--- a/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
+++ b/playerbot/strategy/values/PossibleAttackTargetsValue.cpp
@@ -172,9 +172,13 @@ bool PossibleAttackTargetsValue::IsImmuneToDamage(Unit* target, Player* player)
     }
 
     // Immune to damage
-    // Before we check auras, check school derived immunity
-    if (target->m_spellImmune[IMMUNITY_SCHOOL] == SPELL_SCHOOL_MASK_ALL || target->m_spellImmune[IMMUNITY_DAMAGE] == SPELL_SCHOOL_MASK_ALL)
-        return true;
+    // Before we check auras, check school derived immunity for creatures
+    if (target->IsCreature())
+    {
+        if(((Creature*)target)->GetCreatureInfo()->SchoolImmuneMask == SPELL_SCHOOL_MASK_ALL)
+            return true;
+    }
+
 
     PlayerbotAI* ai = player->GetPlayerbotAI();
     if (!ai)


### PR DESCRIPTION
When I had added the additional immunity mask check that is derived from the unit, I had mistakenly used a function which would check if the unit had an immunity that was in the included list.

This meant that if a creature was immune to nature, because this is included in the SPELL_SCHOOL_MASK_ALL, the bot would think the creature is immune to damage, and would not attack the creature at all, causing them to be frozen in combat unless they had a unit with no immunities to fight.

So instead, I am changing this check to be if the SchoolImmuneMask is SPELL_SCHOOL_MASK_ALL so if the target is immune to nature, the bot will still consider it an attack target. The bots should now only not attack the unit if it is immune to everything, and only immune to everything.

Now as for checking if it would be immune to the spells the bots would use, that is for a separate discussion and a separate function.