### PR TITLE
Add reflection spell check to spell usefulness

### DIFF
--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -144,11 +144,19 @@ bool CastSpellAction::isUseful()
     if (ai->IsInVehicle() && !ai->IsInVehicle(false, false, true))
         return false;
 
+    const SpellEntry* pSpellInfo = sServerFacade.LookupSpellInfo(spellId);
+    if (!pSpellInfo)
+        return false;
+
     if(!AI_VALUE2(bool, "spell cast useful", spellName))
         return false;
 
     Unit* spellTarget = GetTarget();
     if (!spellTarget)
+        return false;
+
+    // If target is more likely than not to reflect and our spell is reflectable, don't cast
+    if (spellTarget->GetReflectChance(GetSpellSchoolMask(pSpellInfo)) > 50.0f && IsReflectableSpell(pSpellInfo))
         return false;
 
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -155,11 +155,11 @@ bool CastSpellAction::isUseful()
     if (!spellTarget)
         return false;
 
-    // If target is more likely than not to reflect and our spell is reflectable, don't cast
-    if (spellTarget->GetReflectChance(GetSpellSchoolMask(pSpellInfo)) > 50.0f && IsReflectableSpell(pSpellInfo))
+    if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
 
-    if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
+    // If target is more likely than not to reflect and our spell is reflectable, don't cast
+    if (spellTarget->GetReflectChance(GetSpellSchoolMask(pSpellInfo)) > 50.0f && IsReflectableSpell(pSpellInfo))
         return false;
 
     return true;


### PR DESCRIPTION
Add a check to see if the spell we want to cast could likely be reflected to the IsUseful check for CastSpellAction.

This should make it so that bots will not cast a spell if it is likely to be reflected back at them. Has to be greater than 50% chance and our spell is reflectable, although most reflection shields in PvE are 100%.

Note that this will not cause bots to cancel casting a spell they've already started casting if the reflection shield went up mid cast because they've already determined the cast to be useful.