### PR TITLE
Change preprocessor for canstoreitem and canbankitem to ifndef MANGOSBOT_ZERO to compile

### DIFF
--- a/playerbot/strategy/actions/BankAction.cpp
+++ b/playerbot/strategy/actions/BankAction.cpp
@@ -105,7 +105,7 @@ bool BankAction::Withdraw(Player* requester, const uint32 itemid)
     ResetBankActionItemCaches(ai, itemId, itemQualifier);
 
     ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
     uint8 bagSlot;
     InventoryResult msg = bot->CanStoreItem(NULL_BAG, NULL_SLOT, dest, pItem, bagSlot, false);
 #else
@@ -143,7 +143,7 @@ bool BankAction::Deposit(Player* requester, Item* pItem)
     ResetBankActionItemCaches(ai, itemId, itemQualifier);
 
     ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
     uint8 bagSlot;
     InventoryResult msg = bot->CanBankItem(NULL_BAG, NULL_SLOT, dest, pItem, false, bagSlot);
 #else
@@ -274,7 +274,7 @@ bool BankAction::AutoDeposit()
             continue;
 
         ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
         uint8 bagSlot;
         InventoryResult msg = bot->CanBankItem(NULL_BAG, NULL_SLOT, dest, item, false, bagSlot);
 #else
@@ -316,7 +316,7 @@ bool BankAction::AutoWithdraw()
             return false;        
 
         ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
         uint8 bagSlot;
         InventoryResult msg = bot->CanStoreItem(NULL_BAG, NULL_SLOT, dest, pItem, bagSlot, false);
 #else

--- a/playerbot/strategy/actions/GiveItemAction.cpp
+++ b/playerbot/strategy/actions/GiveItemAction.cpp
@@ -34,7 +34,7 @@ bool GiveItemAction::Execute(Event& event)
             continue;
 
         ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
         uint8 bagSlot;
         InventoryResult msg = receiver->CanStoreItem(NULL_BAG, NULL_SLOT, dest, item, bagSlot, false);
 #else

--- a/playerbot/strategy/actions/GuildShareItemAction.cpp
+++ b/playerbot/strategy/actions/GuildShareItemAction.cpp
@@ -41,7 +41,7 @@ bool GuildShareItemAction::Execute(Event& event)
         if (giveCount == stackCount)
         {
             ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
             uint8 bagSlot;
             InventoryResult msg = receiver->CanStoreItem(NULL_BAG, NULL_SLOT, dest, item, bagSlot, false);
 #else

--- a/playerbot/strategy/tests/CommandSetup.cpp
+++ b/playerbot/strategy/tests/CommandSetup.cpp
@@ -104,7 +104,7 @@ TestResult CommandSetupGiveItem::Execute(const std::string& params, Player* bot,
         if (isBank)
         {
             ItemPosCountVec dest;
-#ifdef MANGOSBOT_TWO
+#ifndef MANGOSBOT_ZERO
             uint8 bagSlot;
             InventoryResult msg = bot->CanBankItem(NULL_BAG, NULL_SLOT, dest, pItem, false, bagSlot);
 #else


### PR DESCRIPTION
Latest TBC Cmangos commits caused compile failure for TBC playerbots due to a change in function parameters, but seeing as how these changes were pulled from Wotlk, I decided to change the preprocessor directive for Wotlk version to include TBC as well, that way it compiles successfully (which it has).

The Classic Cmangos version of these functions is still unchanged so we keep that one as is.