### PR TITLE
[Feature] EnemyTooCloseForSpellTrigger IsActive() false when stay is set or if flee range is less than/equal to 5.0

### DIFF
--- a/playerbot/strategy/triggers/RangeTriggers.h
+++ b/playerbot/strategy/triggers/RangeTriggers.h
@@ -20,17 +20,23 @@ namespace ai
             {
                 if (ai->HasStrategy("follow", BotState::BOT_STATE_COMBAT) ||
                     ai->HasStrategy("guard", BotState::BOT_STATE_COMBAT) ||
+                    ai->HasStrategy("stay", BotState::BOT_STATE_COMBAT) ||
                     ai->HasStrategy("wander", BotState::BOT_STATE_COMBAT))
                     if(bot->getClass() != CLASS_HUNTER || sServerFacade.GetDistance2d(bot, target) > 5.0f)
                         return false;                   
 
                 const bool canMove = !PossibleAttackTargetsValue::HasBreakableCC(target, bot) && !PossibleAttackTargetsValue::HasUnBreakableCC(target, bot);
 
-                // Don't move if the target is targeting you and you can't add distance between you and the target
+                // Don't move if the target is targeting you and you can't add distance between you and the target (how fast bot runs)
                 if (target->GetTarget() == bot && canMove && target->GetSpeedInMotion() > (bot->GetSpeedInMotion() * 0.65))
                 {
                     return false;
                 }
+
+                // Don't move if our flee range (how far bot runs) is too low to escape attack distance
+                // This is good if you don't want a bot to run away from an enemy that can't be cc or tanked
+                if (ai->GetRange("flee") <= ATTACK_DISTANCE)
+                    return false;
 
                 float const combatReach = bot->GetCombinedCombatReach(target, false);
                 float const minDistance = ai->GetRange("spell") + combatReach;


### PR DESCRIPTION
To preface why I am adding this feature:

If a bot has "ranged" strategy they have this trigger "enemy too close for spell"; If target is within their casting range, they will think it is too close to start casting, which makes them do the action "flee" in order to keep away from the enemy. 

When fleeing the bots ignore doing a lot of things in order to prioritize the movement. In most cases this is a good strategy to have since being far from an enemy makes it such that you need more threat to pass the tank than normal, as well as avoiding things that would affect those who use the "close" strategy.

Sometimes you want ranged strategy users to ignore this behavior. While giving them "guard" strategy can prevent this behavior (and stay should too), there are times where you can't set these strategies or as a general rule you don't care if they reposition or not.

Now to explain the feature:

If the flee range of a bot is set less than or equal to 5.0, since this distance is too short to sufficiently keep the bot out of range of the enemy, this trigger will not be active, so they won't try to reposition for casting. This is similar to the existing behavior that if the enemy is too fast for the bot to outrun, the trigger won't be active.

_**Since the default flee distance is larger than 5.0, this change will not impact bots with the default flee value. You have to expressly set the value to be at or under 5.0 to get this behavior.**_

This feature useful in three situations:

A) You are in a very tightly confined space (hallway or just too many enemies around nearby) and you don't want this trigger to be active to begin with.

B) You are in a situation where an enemy can approach them within their casting range and you don't want them to run away, but for whatever reason you can't have them in guard or stay mode.

C) As a general rule, you want your casters/healers to be in ranged strategy, reposition before attacking ("wait for attack keep safe distance"), but otherwise not move after the initial reposition if the enemy is close, and you don't want to babysit their guard/stay strategy setting.

Finally, this commit also adds the check that if "stay" strategy is set in combat, this trigger shouldn't be active, much like how it is if "guard" is set. Since "stay" (no moving) is more strict than "guard" (move within an area), that should also be checked to prevent repositioning.

