### PR TITLE
Fix warstomp useful in pve

### DIFF
--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -307,6 +307,21 @@ bool CastFrozenDeathboltAction::isPossible()
     return CastVehicleSpellAction::isPossible();
 }
 
+bool CastWarStompAction::isUseful()
+{
+    // only close the gap if we have pvp on
+    if (!ai->HasStrategy("pvp", BotState::BOT_STATE_COMBAT) &&
+        !ai->HasStrategy("duel", BotState::BOT_STATE_COMBAT))
+    {
+        Unit* target = AI_VALUE(Unit*, "current target");
+        if (target)
+            return AI_VALUE2(float, "distance", "current target") <= 8.0f;
+        return false;
+    }
+
+    return true;
+}
+
 bool CastDevourHumanoidAction::isPossible()
 {
     Unit* target = GetTarget();

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -309,7 +309,7 @@ bool CastFrozenDeathboltAction::isPossible()
 
 bool CastWarStompAction::isUseful()
 {
-    // only close the gap if we have pvp on
+    // ignore distance check in pvp or duel
     if (!ai->HasStrategy("pvp", BotState::BOT_STATE_COMBAT) &&
         !ai->HasStrategy("duel", BotState::BOT_STATE_COMBAT))
     {

--- a/playerbot/strategy/actions/GenericSpellActions.h
+++ b/playerbot/strategy/actions/GenericSpellActions.h
@@ -391,6 +391,8 @@ namespace ai
     {
     public:
         CastWarStompAction(PlayerbotAI* ai) : CastSpellAction(ai, "war stomp") {}
+        bool isUseful() override;
+
     };
 
     //cc breakers


### PR DESCRIPTION
Prevent bots from deliberately running into melee distance to warstomp target if it's not within range already and they're not in pvp.

This should prevent ranged (healers casters hunters) from going into melee distance to warstomp. Instead, they should only warstomp if the target is actually within 8 yards already in pve, which is what we check for in the trigger.