### PR TITLE
[Feature] Bots stop attacking targets that either have a large thorns-like damage shield or a reflect shield

### DIFF
--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -166,7 +166,6 @@ bool AttackAction::Attack(Player* requester, Unit* target)
                             bot->AttackStop();
                             return false;
                         }
-                            
 
                         i = vDamageShields.begin();
                     }

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -162,7 +162,11 @@ bool AttackAction::Attack(Player* requester, Unit* target)
 
                         // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't attack
                         if (damage >= bot->GetMaxHealth() * 0.10f)
+                        {
+                            bot->AttackStop();
                             return false;
+                        }
+                            
 
                         i = vDamageShields.begin();
                     }

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -148,6 +148,30 @@ bool AttackAction::Attack(Player* requester, Unit* target)
         // Don't attack target if it is waiting for attack or in stealth
         if (!ai->HasStrategy("stealthed", BotState::BOT_STATE_COMBAT) && !isWaitingForAttack)
         {
+            // Don't attack a target that has a high damage shield in melee
+            if (!ai->IsRanged(bot) || (sServerFacade.GetDistance2d(bot, target) < 5.0f))
+            {
+                std::set<Aura*> alreadyDone;
+                Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+                for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+                {
+                    if (alreadyDone.find(*i) == alreadyDone.end())
+                    {
+                        alreadyDone.insert(*i);
+                        uint32 damage = (*i)->GetModifier()->m_amount;
+
+                        // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't attack
+                        if (damage >= bot->GetMaxHealth() * 0.10f)
+                            return false;
+
+                        i = vDamageShields.begin();
+                    }
+                    else
+                        ++i;
+                }
+            }
+
+
             ai->PlayAttackEmote(1);
             result = bot->Attack(target, !ai->IsRanged(bot) || (sServerFacade.GetDistance2d(bot, target) < 5.0f));
         }

--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -171,7 +171,6 @@ bool AttackAction::Attack(Player* requester, Unit* target)
                 }
             }
 
-
             ai->PlayAttackEmote(1);
             result = bot->Attack(target, !ai->IsRanged(bot) || (sServerFacade.GetDistance2d(bot, target) < 5.0f));
         }

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -15,14 +15,24 @@ bool MeleeAction::isUseful()
 
     if (target)
     {
-        Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+        // victim's damage shield
+        std::set<Aura*> alreadyDone;
+        Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
         for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
         {
-            uint32 damage = (*i)->GetModifier()->m_amount;
+            if (alreadyDone.find(*i) == alreadyDone.end())
+            {
+                alreadyDone.insert(*i);
+                uint32 damage = (*i)->GetModifier()->m_amount;
 
-            // If the damage shield does 25% of our max hp on each hit we do, we shouldn't melee
-            if (damage >= bot->GetMaxHealth() * 0.25f)
-                return false;
+                // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
+                if (damage >= bot->GetMaxHealth() * 0.25f)
+                    return false;
+
+                i = vDamageShields.begin();
+            }
+            else
+                ++i;
         }
     }
 

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -24,9 +24,12 @@ bool MeleeAction::isUseful()
                 alreadyDone.insert(*i);
                 uint32 damage = (*i)->GetModifier()->m_amount;
 
-                // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
+                // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't melee
                 if (damage >= bot->GetMaxHealth() * 0.10f)
+                {
+                    bot->AttackStop();
                     return false;
+                }
 
                 i = vDamageShields.begin();
             }

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -24,8 +24,8 @@ bool MeleeAction::isUseful()
                 alreadyDone.insert(*i);
                 uint32 damage = (*i)->GetModifier()->m_amount;
 
-                // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
-                if (damage >= bot->GetMaxHealth() * 0.25f)
+                // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
+                if (damage >= bot->GetMaxHealth() * 0.10f)
                     return false;
 
                 i = vDamageShields.begin();

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -11,6 +11,21 @@ bool MeleeAction::isUseful()
     if (ai->IsInVehicle() && !ai->IsInVehicle(false, false, true))
         return false;
 
+    Unit* target = GetTarget();
+
+    if (target)
+    {
+        Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+        for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+        {
+            uint32 damage = (*i)->GetModifier()->m_amount;
+
+            // If the damage shield does 25% of our max hp on each hit we do, we shouldn't melee
+            if (damage >= bot->GetMaxHealth() * 0.25f)
+                return false;
+        }
+    }
+
     return true;
 }
 

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -17,7 +17,7 @@ bool MeleeAction::isUseful()
     {
         // victim's damage shield
         std::set<Aura*> alreadyDone;
-        Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+        Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
         for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
         {
             if (alreadyDone.find(*i) == alreadyDone.end())

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -15,6 +15,7 @@ bool MeleeAction::isUseful()
 
     if (target)
     {
+        // If the target has a damage shield, melee action not useful and we should actually stop attacking
         std::set<Aura*> alreadyDone;
         Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
         for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)

--- a/playerbot/strategy/actions/GenericActions.cpp
+++ b/playerbot/strategy/actions/GenericActions.cpp
@@ -15,7 +15,6 @@ bool MeleeAction::isUseful()
 
     if (target)
     {
-        // victim's damage shield
         std::set<Aura*> alreadyDone;
         Unit::AuraList const& vDamageShields = target->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
         for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -158,14 +158,24 @@ bool CastSpellAction::isUseful()
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
 
+    // victim's damage shield
+    std::set<Aura*> alreadyDone;
     Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
     for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
     {
-        uint32 damage = (*i)->GetModifier()->m_amount;
+        if (alreadyDone.find(*i) == alreadyDone.end())
+        {
+            alreadyDone.insert(*i);
+            uint32 damage = (*i)->GetModifier()->m_amount;
 
-        // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
-        if (damage >= bot->GetMaxHealth() * 0.25f && range == ATTACK_DISTANCE)
-            return false;
+            // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
+            if (damage >= bot->GetMaxHealth() * 0.25f && range == ATTACK_DISTANCE)
+                return false;
+
+            i = vDamageShields.begin();
+        }
+        else
+            ++i;
     }
 
     return true;

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -158,23 +158,27 @@ bool CastSpellAction::isUseful()
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
 
-    std::set<Aura*> alreadyDone;
-    Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
-    for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+    // check if the damage we'd take from damage shields is too harmful, only for melee spells
+    if (range == ATTACK_DISTANCE)
     {
-        if (alreadyDone.find(*i) == alreadyDone.end())
+        std::set<Aura*> alreadyDone;
+        Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+        for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
         {
-            alreadyDone.insert(*i);
-            uint32 damage = (*i)->GetModifier()->m_amount;
+            if (alreadyDone.find(*i) == alreadyDone.end())
+            {
+                alreadyDone.insert(*i);
+                uint32 damage = (*i)->GetModifier()->m_amount;
 
-            // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
-            if (damage >= bot->GetMaxHealth() * 0.25f && range == ATTACK_DISTANCE)
-                return false;
+                // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
+                if (damage >= bot->GetMaxHealth() * 0.25f)
+                    return false;
 
-            i = vDamageShields.begin();
+                i = vDamageShields.begin();
+            }
+            else
+                ++i;
         }
-        else
-            ++i;
     }
 
     return true;

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -170,8 +170,8 @@ bool CastSpellAction::isUseful()
                 alreadyDone.insert(*i);
                 uint32 damage = (*i)->GetModifier()->m_amount;
 
-                // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
-                if (damage >= bot->GetMaxHealth() * 0.25f)
+                // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
+                if (damage >= bot->GetMaxHealth() * 0.10f)
                     return false;
 
                 i = vDamageShields.begin();

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -144,6 +144,10 @@ bool CastSpellAction::isUseful()
     if (ai->IsInVehicle() && !ai->IsInVehicle(false, false, true))
         return false;
 
+    const SpellEntry* pSpellInfo = sServerFacade.LookupSpellInfo(spellId);
+    if (!pSpellInfo)
+        return false;
+
     if(!AI_VALUE2(bool, "spell cast useful", spellName))
         return false;
 
@@ -153,6 +157,16 @@ bool CastSpellAction::isUseful()
 
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
+
+    Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+    for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+    {
+        uint32 damage = (*i)->GetModifier()->m_amount;
+
+        // If the damage shield does 25% of our max hp on each hit we do, we shouldn't cast a melee spell
+        if (damage >= bot->GetMaxHealth() * 0.25f && range == ATTACK_DISTANCE)
+            return false;
+    }
 
     return true;
 }

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -172,7 +172,11 @@ bool CastSpellAction::isUseful()
 
                 // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
                 if (damage >= bot->GetMaxHealth() * 0.10f)
+                {
+                    bot->AttackStop();
                     return false;
+                }
+                    
 
                 i = vDamageShields.begin();
             }

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -144,10 +144,6 @@ bool CastSpellAction::isUseful()
     if (ai->IsInVehicle() && !ai->IsInVehicle(false, false, true))
         return false;
 
-    const SpellEntry* pSpellInfo = sServerFacade.LookupSpellInfo(spellId);
-    if (!pSpellInfo)
-        return false;
-
     if(!AI_VALUE2(bool, "spell cast useful", spellName))
         return false;
 
@@ -158,31 +154,38 @@ bool CastSpellAction::isUseful()
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
 
-    // check if the damage we'd take from damage shields is too harmful, only for melee spells
-    if (range == ATTACK_DISTANCE)
+    const SpellEntry* pSpellInfo = sServerFacade.LookupSpellInfo(spellId);
+    if (pSpellInfo)
     {
-        std::set<Aura*> alreadyDone;
-        Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
-        for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
+        // check if the damage we'd take from damage shields is too harmful, only for melee spells
+        if (range == ATTACK_DISTANCE)
         {
-            if (alreadyDone.find(*i) == alreadyDone.end())
+            std::set<Aura*> alreadyDone;
+            Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
+            for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)
             {
-                alreadyDone.insert(*i);
-                uint32 damage = (*i)->GetModifier()->m_amount;
-
-                // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
-                if (damage >= bot->GetMaxHealth() * 0.10f)
+                if (alreadyDone.find(*i) == alreadyDone.end())
                 {
-                    bot->AttackStop();
-                    return false;
-                }
-                    
+                    alreadyDone.insert(*i);
+                    uint32 damage = (*i)->GetModifier()->m_amount;
 
-                i = vDamageShields.begin();
+                    // If the damage shield does at least 10% of our max hp on each hit we do, we shouldn't cast a melee spell
+                    if (damage >= bot->GetMaxHealth() * 0.10f)
+                    {
+                        bot->AttackStop();
+                        return false;
+                    }
+
+                    i = vDamageShields.begin();
+                }
+                else
+                    ++i;
             }
-            else
-                ++i;
         }
+
+        // If target is more likely than not to reflect and our spell is reflectable, don't cast
+        if (spellTarget->GetReflectChance(GetSpellSchoolMask(pSpellInfo)) > 50.0f && IsReflectableSpell(pSpellInfo))
+            return false;
     }
 
     return true;

--- a/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -158,7 +158,6 @@ bool CastSpellAction::isUseful()
     if (!spellTarget->IsInWorld() || spellTarget->GetMapId() != bot->GetMapId())
         return false;
 
-    // victim's damage shield
     std::set<Aura*> alreadyDone;
     Unit::AuraList const& vDamageShields = spellTarget->GetAurasByType(SPELL_AURA_DAMAGE_SHIELD);
     for (Unit::AuraList::const_iterator i = vDamageShields.begin(); i != vDamageShields.end();)


### PR DESCRIPTION
Add support for bots to stop attacking a target if:

- The bot is in melee, or is about to attack in melee, or is doing a melee spell and the target has a damage shield that would cause the bot to take at least 10% of hp in damage (in other words, if the bot attacked 10 times they would die from the recoil damage so it's probably something significant to avoid)

- The bot is casting a spell and the target is likely to reflect our spell back at us (> 50% chance) and the spell we want to cast is not reflectable.

For the latter, they seem to respond very well and attack quickly afterwards when the reflection goes away.

The former is not as consistent because it depends on when those spell or melee actions are sent, as casters will constantly check on each cast if it's useful while melee users will auto attack. So melee users will still attack when the shield goes up for a bit because they're just auto attacking melee, but if they were to stop and bandage and the damage shield is still up, they won't go to attack again until it's worn off because they'd re-engage and at that moment check for the shield. Or if they were to do a sinister strike or sunder action, there they would check the damage shield and stop attacking. So really it all depends on when they check the shield. Perhaps there could be a separate trigger for this but I found this code to achieve the ultimate result of trying to not get them killed by their own attacks.

Keep in mind for both of these, if the bots were preparing an action with a castbar, and the reflection/damage shield is placed, they won't cancel their cast or action as these checks wouldn't happen until the next action.