### PR TITLE
[Feature] Add random cc if rti cc is none and we have cc on

### DIFF
--- a/playerbot/strategy/triggers/RtiTriggers.h
+++ b/playerbot/strategy/triggers/RtiTriggers.h
@@ -42,4 +42,32 @@ namespace ai
             return true;
         }
     };
+
+    class NoRtiCCTrigger : public Trigger
+    {
+    public:
+        NoRtiCCTrigger(PlayerbotAI* ai) : Trigger(ai, "no rti cc target") {}
+
+        virtual bool IsActive() override
+		{
+            if (AI_VALUE(Unit*, "rti cc target"))
+            {
+                return false;
+            }
+            else
+            {
+                // Check for the default rti cc if the bot is setup to ignore rti cc targets
+                std::string rti = AI_VALUE(std::string, "rti cc");
+                int index = RtiTargetValue::GetRtiIndex(rti);
+                if (index == -1)
+                {
+                    // If we have cc enabled, but no mark set, then we're open to ccing stuff at random
+                    if (ai->HasStrategy("cc", BotState::BOT_STATE_COMBAT))
+                        return true;
+                }
+
+                return false;
+            }
+        }
+    };
 }

--- a/playerbot/strategy/triggers/TriggerContext.h
+++ b/playerbot/strategy/triggers/TriggerContext.h
@@ -173,6 +173,7 @@ namespace ai
             creators["far from rpg target"] = [](PlayerbotAI* ai) { return new FarFromRpgTargetTrigger(ai); };
             creators["near rpg target"] = [](PlayerbotAI* ai) { return new NearRpgTargetTrigger(ai); };
             creators["no rti target"] = [](PlayerbotAI* ai) { return new NoRtiTrigger(ai); };
+            creators["no rti cc target"] = [](PlayerbotAI* ai) { return new NoRtiCCTrigger(ai); };
 
             creators["give food"] = [](PlayerbotAI* ai) { return new GiveFoodTrigger(ai); };
             creators["give water"] = [](PlayerbotAI* ai) { return new GiveWaterTrigger(ai); };

--- a/playerbot/strategy/values/CcTargetValue.cpp
+++ b/playerbot/strategy/values/CcTargetValue.cpp
@@ -4,6 +4,7 @@
 #include "playerbot/PlayerbotAIConfig.h"
 #include "playerbot/ServerFacade.h"
 #include "playerbot/strategy/Action.h"
+#include "playerbot/strategy/values/RtiTargetValue.h"
 
 using namespace ai;
 
@@ -56,23 +57,11 @@ public:
 
         if (!ai->CanCastSpell(spell, creature, true, nullptr, false, true))
             return;
-        /*
-        // Here we try to cc stuff that is not marked. This is not suggested because randomly cc'ing things with no
-        // reason can lead to bad outcomes (cc'ing the mob that isn't marked for you, rebanishing the only mob left nonstop)
-        if (!creature->IsPlayer())
-        {
-            int tankCount, dpsCount;
-            GetPlayerCount(creature, &tankCount, &dpsCount);
-            if (!tankCount || !dpsCount)
-            {
-                result = creature;
-                return;
-            }
-        }
 
-        // This only makese sense if we don't have a target of our own to cc. 
-        // Since we use this function in a search of attackers, first result may not be our rti cc target
-        if (!context->GetValue<Unit*>("rti cc target")->Get())
+        // If we have rti cc none but have cc strategy, then we'll cc something we're able to
+        std::string rti = AI_VALUE(std::string, "rti cc");
+        int index = RtiTargetValue::GetRtiIndex(rti);
+        if (index == -1 && ai->HasStrategy("cc", BotState::BOT_STATE_COMBAT))
         {
             Group::MemberSlotList const& groupSlot = group->GetMemberSlots();
             for (Group::member_citerator itr = groupSlot.begin(); itr != groupSlot.end(); itr++)
@@ -94,8 +83,7 @@ public:
                 result = creature;
                 maxDistance = minDistance;
             }
-        */
-
+        }
     }
 
 private:


### PR DESCRIPTION
Add random cc if rti cc is none and we have cc on

This restores the "old" cc behavior if the bots didn't immediately find their cc target. Results may vary.

In order to enable this, they have to have no mark for cc but also have cc strategy on. So this is not enabled by default as their default rti cc is moon.

This is useful if you want the bots to just cc something, don't care what, or if you can't or won't mark stuff for them to cc.

I've also added a "no rti cc target" trigger if you want to make specific actions that ONLY happen if these conditions are met, separate from ordinary cc trigger. But they will do the random cc'ing with the regular trigger should the conditions be met.