### PR TITLE
[Feature] Make CanCastSpell fail for damaging spells if target is immune

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -4176,15 +4176,30 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, uint8 effectMask, b
             }
         }
 
+        bool immune = target->IsImmuneToSpell(spellInfo, false, effectMask, bot);
         if (!damage)
         {
-            bool immune = target->IsImmuneToSpell(spellInfo, false, effectMask, bot);
             if (!immune)
             {
                 for (int32 i = EFFECT_INDEX_0; i <= EFFECT_INDEX_2; i++)
                     immune = target->IsImmuneToSpellEffect(spellInfo, SpellEffectIndex(i), false);
             }
 
+            if (immune)
+            {
+                if (checkResult)
+                {
+                    *checkResult = SPELL_FAILED_IMMUNE;
+                }
+
+                return false;
+            }
+        }
+        else
+        {
+            if (!immune)
+                immune = target->IsImmuneToDamage(GetSpellSchoolMask(spellInfo));
+                
             if (immune)
             {
                 if (checkResult)


### PR DESCRIPTION
Casting a spell should not be possible if the target would be immune to it, even if it is a damaging spell.

We were already immune checking if the spell didn't have SPELL_AURA_PERIODIC_DAMAGE or SPELL_EFFECT_SCHOOL_DAMAGE (hence, damage = false). But for these two types of spell which are pretty common we should check for immunity, so the bots don't think that they can cast spells that targets are immune to.

When selecting targets, we check for targets that are not immune to damage (usually, immune to everything) because at this moment we don't know what spell to cast since we have no target. Then we may have a target which is not immune to everything but may be immune to certain things like bleed or nature or frost. Then when we find that target we make some checks against that target with our spells to see if it is useful and possible to do a CastSpellAction, but we fail to check immunity for the damage spells.

Therefore we should check if the target is immune to the spell, regardless of what type of spell it is, and for good measure we should also check if it's immune to the damage of that spell, if the spell is damaging (for instance, the target may not be immune to rend but is immune to the damage of it).

This should fix many problems with certain specs/classes spamming abilities that the targets are immune to, one notable example is hunters spamming serpent sting on a nature immune target.

I personally tested this with a frost mage and the result is that they default to using a wand on a target that is frost immune, instead of casting frostbolt. So perhaps there is room to create ActionNodes for using alternate types of spells if target is immune. Otherwise you could just tell them to go fire/arcane mage and they'll do normal abilities.