### PR TITLE
Proper druid castingform requirements

### DIFF
--- a/playerbot/strategy/druid/BalanceDruidStrategy.cpp
+++ b/playerbot/strategy/druid/BalanceDruidStrategy.cpp
@@ -20,7 +20,7 @@ private:
     static ActionNode* innervate(PlayerbotAI* ai)
     {
         return new ActionNode("innervate",
-            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+            /*P*/ NextAction::array(0, new NextAction("balance caster form"), NULL),
             /*A*/ NextAction::array(0, new NextAction("mana potion"), NULL),
             /*C*/ NULL);
     }

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -58,7 +58,7 @@ namespace ai
 
 		virtual NextAction** getPrerequisites() 
 		{
-			return NextAction::merge( NextAction::array(0, new NextAction("caster form"), NULL), ResurrectPartyMemberAction::getPrerequisites());
+			return NextAction::merge( NextAction::array(0, new NextAction("restoration caster form"), NULL), ResurrectPartyMemberAction::getPrerequisites());
 		}
 	};
 
@@ -313,7 +313,7 @@ namespace ai
 	class CastCasterFormAction : public CastBuffSpellAction
 	{
 	public:
-		CastCasterFormAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "caster form") {}
+		CastCasterFormAction(PlayerbotAI* ai, std::string spell = "caster form") : CastBuffSpellAction(ai, spell) {}
 
 		virtual bool isUseful()
 		{
@@ -323,6 +323,39 @@ namespace ai
 		virtual bool isPossible() { return true; }
 
 		virtual bool Execute(Event& event);
+	};
+
+    class CastBalanceCasterFormAction : public CastCasterFormAction
+	{
+	public:
+		CastBalanceCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "balance caster form") {}
+
+		virtual bool isUseful() override
+		{
+			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", "tree of life", NULL);
+		}
+	};
+
+    class CastRestorationCasterFormAction : public CastCasterFormAction
+	{
+	public:
+		CastRestorationCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "restoration caster form") {}
+
+		virtual bool isUseful() override
+		{
+			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", "moonkin form", NULL);
+		}
+	};
+
+    class CastBalanceOrRestorationCasterFormAction : public CastCasterFormAction
+	{
+	public:
+		CastBalanceOrRestorationCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "balance or restoration caster form") {}
+
+		virtual bool isUseful() override
+		{
+			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", NULL);
+		}
 	};
 
     class CastFeralChargeCatAction : public CastReachTargetSpellAction

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -315,7 +315,7 @@ namespace ai
 	public:
 		CastCasterFormAction(PlayerbotAI* ai, std::string spell = "caster form") : CastBuffSpellAction(ai, spell) {}
 
-		virtual bool isUseful()
+		virtual bool isUseful() override
 		{
 			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", "moonkin form", "tree of life", NULL);
 		}
@@ -330,7 +330,7 @@ namespace ai
 	public:
 		CastBalanceCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "balance caster form") {}
 
-		virtual bool isUseful() override
+		bool isUseful() override
 		{
 			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", "tree of life", NULL);
 		}
@@ -341,7 +341,7 @@ namespace ai
 	public:
 		CastRestorationCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "restoration caster form") {}
 
-		virtual bool isUseful() override
+		bool isUseful() override
 		{
 			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", "moonkin form", NULL);
 		}
@@ -352,7 +352,7 @@ namespace ai
 	public:
 		CastBalanceOrRestorationCasterFormAction(PlayerbotAI* ai) : CastCasterFormAction(ai, "balance or restoration caster form") {}
 
-		virtual bool isUseful() override
+		bool isUseful() override
 		{
 			return ai->HasAnyAuraOf(GetTarget(), "dire bear form", "bear form", "cat form", "travel form", "aquatic form", "flight form", "swift flight form", NULL);
 		}

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -260,6 +260,9 @@ namespace ai
                 creators["travel form"] = [](PlayerbotAI* ai) { return new CastTravelFormAction(ai); };
                 creators["aquatic form"] = [](PlayerbotAI* ai) { return new CastAquaticFormAction(ai); };
                 creators["caster form"] = [](PlayerbotAI* ai) { return new CastCasterFormAction(ai); };
+                creators["balance caster form"] = [](PlayerbotAI* ai) { return new CastBalanceCasterFormAction(ai); };
+                creators["restoration caster form"] = [](PlayerbotAI* ai) { return new CastRestorationCasterFormAction(ai); };
+                creators["balance or restoration caster form"] = [](PlayerbotAI* ai) { return new CastBalanceOrRestorationCasterFormAction(ai); };
                 creators["mangle (bear)"] = [](PlayerbotAI* ai) { return new CastMangleBearAction(ai); };
                 creators["maul"] = [](PlayerbotAI* ai) { return new CastMaulAction(ai); };
                 creators["bash"] = [](PlayerbotAI* ai) { return new CastBashAction(ai); };

--- a/playerbot/strategy/druid/DruidStrategy.cpp
+++ b/playerbot/strategy/druid/DruidStrategy.cpp
@@ -79,9 +79,11 @@ private:
 
     ACTION_NODE_P(rebirth, "rebirth", "restoration caster form");
 
-#ifdef MANGOSBOT_TWO
     ACTION_NODE_P(regrowth, "regrowth", "restoration caster form");
+
     ACTION_NODE_P(regrowth_on_party, "regrowth on party", "restoration caster form");
+
+#ifdef MANGOSBOT_TWO
     ACTION_NODE_P(healing_touch, "healing touch", "restoration caster form");
     ACTION_NODE_P(healing_touch_on_party, "healing touch on party", "restoration caster form");
     ACTION_NODE_P(thorns, "thorns", "restoration caster form");
@@ -90,8 +92,6 @@ private:
     ACTION_NODE_P(mark_of_the_wild_on_party, "mark of the wild on party", "restoration caster form");
     ACTION_NODE_P(gift_of_the_wild_on_party, "gift of the wild on party", "restoration caster form");
 #else
-    ACTION_NODE_P(regrowth, "regrowth", "caster form");
-    ACTION_NODE_P(regrowth_on_party, "regrowth on party", "caster form");
     ACTION_NODE_P(healing_touch, "healing touch", "caster form");
     ACTION_NODE_P(healing_touch_on_party, "healing touch on party", "caster form");
     ACTION_NODE_P(thorns, "thorns", "caster form");

--- a/playerbot/strategy/druid/DruidStrategy.cpp
+++ b/playerbot/strategy/druid/DruidStrategy.cpp
@@ -35,7 +35,11 @@ private:
     static ActionNode* abolish_poison(PlayerbotAI* ai)
     {
         return new ActionNode("abolish poison",
-            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+#ifdef MANGOSBOT_TWO
+            /*P*/ NextAction::array(0, new NextAction("balance or restoration caster form"), NULL),
+#else
+            /*P*/ NextAction::array(0, new NextAction("restoration caster form"), NULL),
+#endif
             /*A*/ NextAction::array(0, new NextAction("cure poison"), NULL),
             /*C*/ NULL);
     }
@@ -43,7 +47,11 @@ private:
     static ActionNode* abolish_poison_on_party(PlayerbotAI* ai)
     {
         return new ActionNode("abolish poison on party",
-            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+#ifdef MANGOSBOT_TWO
+            /*P*/ NextAction::array(0, new NextAction("balance or restoration caster form"), NULL),
+#else
+            /*P*/ NextAction::array(0, new NextAction("restoration caster form"), NULL),
+#endif
             /*A*/ NextAction::array(0, new NextAction("cure poison on party"), NULL),
             /*C*/ NULL);
     }
@@ -56,35 +64,46 @@ private:
             /*C*/ NULL);
     }
 
+#ifdef MANGOSBOT_TWO
+    ACTION_NODE_P(remove_curse, "remove curse", "balance or restoration caster form");
+    ACTION_NODE_P(remove_curse_on_party, "remove curse on party", "balance or restoration caster form");
+#elif MANGOSBOT_ONE
+    ACTION_NODE_P(remove_curse, "remove curse", "balance caster form");
+    ACTION_NODE_P(remove_curse_on_party, "remove curse on party", "balance caster form");
+#else
     ACTION_NODE_P(remove_curse, "remove curse", "caster form");
-
     ACTION_NODE_P(remove_curse_on_party, "remove curse on party", "caster form");
+#endif
 
-    ACTION_NODE_P(hibernate_on_cc, "hibernate on cc", "caster form");
+    ACTION_NODE_P(hibernate_on_cc, "hibernate on cc", "balance caster form");
 
-    ACTION_NODE_P(rebirth, "rebirth", "caster form");
+    ACTION_NODE_P(rebirth, "rebirth", "restoration caster form");
 
+#ifdef MANGOSBOT_TWO
+    ACTION_NODE_P(regrowth, "regrowth", "restoration caster form");
+    ACTION_NODE_P(regrowth_on_party, "regrowth on party", "restoration caster form");
+    ACTION_NODE_P(healing_touch, "healing touch", "restoration caster form");
+    ACTION_NODE_P(healing_touch_on_party, "healing touch on party", "restoration caster form");
+    ACTION_NODE_P(thorns, "thorns", "restoration caster form");
+    ACTION_NODE_P(thorns_on_party, "thorns on party", "restoration caster form");
+    ACTION_NODE_P(mark_of_the_wild, "mark of the wild", "restoration caster form");
+    ACTION_NODE_P(mark_of_the_wild_on_party, "mark of the wild on party", "restoration caster form");
+    ACTION_NODE_P(gift_of_the_wild_on_party, "gift of the wild on party", "restoration caster form");
+#else
     ACTION_NODE_P(regrowth, "regrowth", "caster form");
-
     ACTION_NODE_P(regrowth_on_party, "regrowth on party", "caster form");
-
     ACTION_NODE_P(healing_touch, "healing touch", "caster form");
-
     ACTION_NODE_P(healing_touch_on_party, "healing touch on party", "caster form");
-
-    ACTION_NODE_P(rejuvenation, "rejuvenation", "caster form");
-
-    ACTION_NODE_P(rejuvenation_on_party, "rejuvenation on party", "caster form");
-
     ACTION_NODE_P(thorns, "thorns", "caster form");
-
     ACTION_NODE_P(thorns_on_party, "thorns on party", "caster form");
-
     ACTION_NODE_P(mark_of_the_wild, "mark of the wild", "caster form");
-
     ACTION_NODE_P(mark_of_the_wild_on_party, "mark of the wild on party", "caster form");
-
     ACTION_NODE_P(gift_of_the_wild_on_party, "gift of the wild on party", "caster form");
+#endif
+
+    ACTION_NODE_P(rejuvenation, "rejuvenation", "restoration caster form");
+
+    ACTION_NODE_P(rejuvenation_on_party, "rejuvenation on party", "restoration caster form");
 
     ACTION_NODE_P(cat_form, "cat form", "caster form");
 

--- a/playerbot/strategy/druid/RestorationDruidStrategy.cpp
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.cpp
@@ -5,10 +5,10 @@
 
 using namespace ai;
 
-class BalanceDruidStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+class RestorationDruidStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
 {
 public:
-    BalanceDruidStrategyActionNodeFactory()
+    RestorationDruidStrategyActionNodeFactory()
     {
         creators["innervate"] = &innervate;
     }
@@ -17,7 +17,7 @@ private:
     static ActionNode* innervate(PlayerbotAI* ai)
     {
         return new ActionNode("innervate",
-            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+            /*P*/ NextAction::array(0, new NextAction("restoration caster form"), NULL),
             /*A*/ NextAction::array(0, new NextAction("mana potion"), NULL),
             /*C*/ NULL);
     }

--- a/playerbot/strategy/druid/RestorationDruidStrategy.cpp
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.cpp
@@ -29,6 +29,11 @@ private:
 #endif
 };
 
+RestorationDruidStrategy::RestorationDruidStrategy(PlayerbotAI* ai) : DruidStrategy(ai)
+{
+    actionNodeFactories.Add(std::make_unique<RestorationDruidStrategyActionNodeFactory>());
+}
+
 #ifdef MANGOSBOT_ZERO // Vanilla
 
 void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/druid/RestorationDruidStrategy.cpp
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.cpp
@@ -11,6 +11,7 @@ public:
     RestorationDruidStrategyActionNodeFactory()
     {
         creators["innervate"] = &innervate;
+        creators["tranquility"] = &tranquility;
     }
 
 private:
@@ -21,6 +22,11 @@ private:
             /*A*/ NextAction::array(0, new NextAction("mana potion"), NULL),
             /*C*/ NULL);
     }
+#ifdef MANGOSBOT_TWO
+    ACTION_NODE_P(tranquility, "tranquility", "restoration caster form");
+#else
+    ACTION_NODE_P(tranquility, "tranquility", "caster form");
+#endif
 };
 
 #ifdef MANGOSBOT_ZERO // Vanilla

--- a/playerbot/strategy/druid/RestorationDruidStrategy.h
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.h
@@ -14,7 +14,7 @@ namespace ai
     class RestorationDruidStrategy : public DruidStrategy
     {
     public:
-        RestorationDruidStrategy(PlayerbotAI* ai) : DruidStrategy(ai) {}
+        RestorationDruidStrategy(PlayerbotAI* ai);
 
     protected:
         virtual void InitCombatTriggers(std::list<TriggerNode*>& triggers) override;


### PR DESCRIPTION
Certain spells, depending on expansion, can be cast in moonkin and tree form. But by default, a lot of actions had the prerequisite of doing "caster form" action, which checks if you're in any druid form and shapeshifts you out back to humanoid form. Since that may or may not be necessary, I've added "restoration caster form", "balance caster form" and "balance or restoration caster form" actions which check if you are in a valid form to cast the spell depending on the one used, (restoration caster form ignores checking tree form for shifting out to humanoid form). This should be useful for TBC and Wotlk where Moonkin form allows Remove curse but currently we were requiring druids to shapeshift out in all expansions, or abolish poison which is allowed in Tree form, among others. This also changes requiring humanoid form for innervate, since Tree form and Moonkin form allows casting innervate.

The chief benefit of this is that druids should spend less mana shifting in and out of form. Balance druids in particular shouldn't need to keep shifting in and out of form as they want to use moonkin form to deal damage but think they have to be in humanoid form to remove curse. This is also less global cooldowns wasted which means more spell casts they can do.