### PR TITLE
[Feature] Add swiftmend

### DIFF
--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -30,7 +30,7 @@ namespace ai
     class CastSwiftmendAction : public CastHealingSpellAction 
 	{
 	public:
-		CastRegrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "swiftmend") {}
+        CastSwiftmendAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "swiftmend") {}
 	};
 
     class CastHealingTouchAction : public CastHealingSpellAction 

--- a/playerbot/strategy/druid/DruidActions.h
+++ b/playerbot/strategy/druid/DruidActions.h
@@ -27,6 +27,12 @@ namespace ai
 		CastRegrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "regrowth") {}
 	};
 
+    class CastSwiftmendAction : public CastHealingSpellAction 
+	{
+	public:
+		CastRegrowthAction(PlayerbotAI* ai) : CastHealingSpellAction(ai, "swiftmend") {}
+	};
+
     class CastHealingTouchAction : public CastHealingSpellAction 
 	{
     public:
@@ -43,6 +49,12 @@ namespace ai
     {
     public:
         CastRegrowthOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "regrowth") {}
+    };
+
+    class CastSwiftmendOnPartyAction : public HealPartyMemberAction
+    {
+    public:
+        CastSwiftmendOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "swiftmend") {}
     };
 
     class CastHealingTouchOnPartyAction : public HealPartyMemberAction

--- a/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -300,9 +300,11 @@ namespace ai
                 creators["mark of the wild on party"] = [](PlayerbotAI* ai) { return new CastMarkOfTheWildOnPartyAction(ai); };
                 creators["gift of the wild on party"] = [](PlayerbotAI* ai) { return new CastGiftOfTheWildOnPartyAction(ai); };
                 creators["regrowth"] = [](PlayerbotAI* ai) { return new CastRegrowthAction(ai); };
+                creators["swiftmend"] = [](PlayerbotAI* ai) { return new CastSwiftmendAction(ai); };
                 creators["rejuvenation"] = [](PlayerbotAI* ai) { return new CastRejuvenationAction(ai); };
                 creators["healing touch"] = [](PlayerbotAI* ai) { return new CastHealingTouchAction(ai); };
                 creators["regrowth on party"] = [](PlayerbotAI* ai) { return new CastRegrowthOnPartyAction(ai); };
+                creators["swiftmend on party"] = [](PlayerbotAI* ai) { return new CastSwiftmendOnPartyAction(ai); };
                 creators["rejuvenation on party"] = [](PlayerbotAI* ai) { return new CastRejuvenationOnPartyAction(ai); };
                 creators["healing touch on party"] = [](PlayerbotAI* ai) { return new CastHealingTouchOnPartyAction(ai); };
                 creators["rebirth"] = [](PlayerbotAI* ai) { return new CastRebirthAction(ai); };

--- a/playerbot/strategy/druid/RestorationDruidStrategy.cpp
+++ b/playerbot/strategy/druid/RestorationDruidStrategy.cpp
@@ -11,6 +11,9 @@ public:
     BalanceDruidStrategyActionNodeFactory()
     {
         creators["innervate"] = &innervate;
+        creators["tranquility"] = &tranquility;
+        creators["swiftmend"] = &swiftmend;
+        creators["swiftmend on party"] = &swiftmend_on_party;
     }
 
 private:
@@ -21,6 +24,27 @@ private:
             /*A*/ NextAction::array(0, new NextAction("mana potion"), NULL),
             /*C*/ NULL);
     }
+
+    static ActionNode* swiftmend(PlayerbotAI* ai)
+    {
+        return new ActionNode("swiftmend",
+            /*P*/ NextAction::array(0, new NextAction("restoration caster form"), NULL),
+            /*A*/ NextAction::array(0, new NextAction("healing touch"), NULL),
+            /*C*/ NULL);
+    }
+
+    static ActionNode* swiftmend_on_party(PlayerbotAI* ai)
+    {
+        return new ActionNode("swiftmend on party",
+            /*P*/ NextAction::array(0, new NextAction("restoration caster form"), NULL),
+            /*A*/ NextAction::array(0, new NextAction("healing touch on party"), NULL),
+            /*C*/ NULL);
+    }
+#ifdef MANGOSBOT_TWO
+    ACTION_NODE_P(tranquility, "tranquility", "restoration caster form");
+#else
+    ACTION_NODE_P(tranquility, "tranquility", "caster form");
+#endif
 };
 
 #ifdef MANGOSBOT_ZERO // Vanilla
@@ -36,12 +60,12 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
     triggers.push_back(new TriggerNode(
         "critical health",
         NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member critical health",
         NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch on party", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "low health",
@@ -75,6 +99,16 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
 void RestorationDruidStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
 {
     DruidStrategy::InitNonCombatTriggers(triggers);
+
+    triggers.push_back(new TriggerNode(
+        "critical health",
+        NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "party member critical health",
+        NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "low health",
@@ -432,12 +466,12 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
     triggers.push_back(new TriggerNode(
         "critical health",
         NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member critical health",
         NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch on party", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "lifebloom",
@@ -476,7 +510,21 @@ void RestorationDruidStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& tr
 {
     DruidStrategy::InitNonCombatTriggers(triggers);
 
-        triggers.push_back(new TriggerNode(
+    triggers.push_back(new TriggerNode(
+        "critical health",
+        NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "party member critical health",
+        NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "lifebloom",
+        NextAction::array(0, new NextAction("lifebloom", ACTION_MEDIUM_HEAL + 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "low health",
         NextAction::array(0, new NextAction("regrowth", ACTION_MEDIUM_HEAL), NULL)));
 
@@ -836,12 +884,12 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
     triggers.push_back(new TriggerNode(
         "critical health",
         NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member critical health",
         NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
-                             new NextAction("healing touch on party", ACTION_CRITICAL_HEAL), NULL)));
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
 
     triggers.push_back(new TriggerNode(
         "clearcasting",
@@ -879,6 +927,20 @@ void RestorationDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& trigg
 void RestorationDruidStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
 {
     DruidStrategy::InitNonCombatTriggers(triggers);
+
+    triggers.push_back(new TriggerNode(
+        "critical health",
+        NextAction::array(0, new NextAction("regrowth", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "party member critical health",
+        NextAction::array(0, new NextAction("regrowth on party", ACTION_CRITICAL_HEAL + 1),
+                             new NextAction("swiftmend on party", ACTION_CRITICAL_HEAL), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "clearcasting",
+        NextAction::array(0, new NextAction("lifebloom", ACTION_CRITICAL_HEAL - 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "low health",


### PR DESCRIPTION
Add swiftmend as an action. For now, it is just used when target hp is critical by resto druids. Alternate of swiftmend is healing touch, which keeps it similar to what it was before (regrowth + healing touch on critical hp) if swiftmend is on cooldown (15 second cd).

Hopefully this should keep resto druids in tree form more often since swiftmend is allowed in TBC but healing touch isn't. And regrowth+swiftmend is a better emergency heal than regrowth+healing touch if target is low hp (outside of Nature's Swiftness + healing touch).

This change should be added after the better casting form requirements: https://github.com/cmangos/playerbots/pull/351