### PR TITLE
Make balance druid prioritize starfire in vanilla/tbc

### DIFF
--- a/playerbot/strategy/druid/BalanceDruidStrategy.cpp
+++ b/playerbot/strategy/druid/BalanceDruidStrategy.cpp
@@ -481,7 +481,7 @@ void BalanceDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("moonfire", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "often",
+        "very often",
         NextAction::array(0, new NextAction("starfire", ACTION_NORMAL), NULL)));
 }
 

--- a/playerbot/strategy/druid/BalanceDruidStrategy.cpp
+++ b/playerbot/strategy/druid/BalanceDruidStrategy.cpp
@@ -39,7 +39,7 @@ BalanceDruidStrategy::BalanceDruidStrategy(PlayerbotAI* ai) : DruidStrategy(ai)
 
 NextAction** BalanceDruidStrategy::GetDefaultCombatActions()
 {
-    return NextAction::array(0, new NextAction("wrath", ACTION_IDLE), NULL);
+    return NextAction::array(0, new NextAction("starfire", ACTION_IDLE), NULL);
 }
 
 void BalanceDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -448,7 +448,7 @@ void BalanceDruidCureRaidStrategy::InitNonCombatTriggers(std::list<TriggerNode*>
 
 NextAction** BalanceDruidStrategy::GetDefaultCombatActions()
 {
-    return NextAction::array(0, new NextAction("wrath", ACTION_IDLE), NULL);
+    return NextAction::array(0, new NextAction("starfire", ACTION_IDLE), NULL);
 }
 
 void BalanceDruidStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)


### PR DESCRIPTION
Starfire should be the default cast balance druids use in vanilla and tbc, not wrath. Keep wrath as the alternate action in case starfire can't be cast.