### PR TITLE
[Feature] Ret Seal and Judge Crusader

### DIFF
--- a/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
+++ b/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
@@ -242,6 +242,7 @@ namespace ai
                 creators["seal"] = [](PlayerbotAI* ai) { return new SealTrigger(ai); };
                 creators["art of war"] = [](PlayerbotAI* ai) { return new ArtOfWarTrigger(ai); };
                 creators["blessing"] = [](PlayerbotAI* ai) { return new BlessingTrigger(ai); };
+                creators["target no judgement"] = [](PlayerbotAI* ai) { return new TargetNoJudgementTrigger(ai); };
                 creators["greater blessing"] = [](PlayerbotAI* ai) { return new GreaterBlessingTrigger(ai); };
                 creators["blessing of might"] = [](PlayerbotAI* ai) { return new BlessingOfMightTrigger(ai); };
                 creators["blessing of wisdom"] = [](PlayerbotAI* ai) { return new BlessingOfWisdomTrigger(ai); };

--- a/playerbot/strategy/paladin/PaladinTriggers.h
+++ b/playerbot/strategy/paladin/PaladinTriggers.h
@@ -196,10 +196,16 @@ namespace ai
         bool IsActive() override 
         {
             Unit* target = bot->GetTarget();
-            return !target->HasAura(21183) && !target->HasAura(20188) && 
-                !target->HasAura(20300) && !target->HasAura(20301) &&
-                !target->HasAura(20302) && !target->HasAura(20303) &&
-                !target->HasAura(27159);
+            if (target)
+            {
+                return !target->HasAura(21183) && !target->HasAura(20188) &&
+                    !target->HasAura(20300) && !target->HasAura(20301) &&
+                    !target->HasAura(20302) && !target->HasAura(20303) &&
+                    !target->HasAura(27159);
+            }
+
+            return false;
+
         }
     };
 

--- a/playerbot/strategy/paladin/PaladinTriggers.h
+++ b/playerbot/strategy/paladin/PaladinTriggers.h
@@ -189,6 +189,20 @@ namespace ai
         bool IsActive() override { return (bot->GetMap()->IsDungeon() || bot->GetMap()->IsBattleGround()) && GreaterBuffOnPartyTrigger::IsActive(); }
     };
 
+    class TargetNoJudgementTrigger : public DebuffOnAttackerTrigger
+    {
+    public:
+        TargetNoJudgementTrigger(PlayerbotAI* ai) : DebuffOnAttackerTrigger(ai, "judgement of the crusader") {}
+        bool IsActive() override 
+        {
+            Unit* target = bot->GetTarget();
+            return !target->HasAura(21183) && !target->HasAura(20188) && 
+                !target->HasAura(20300) && !target->HasAura(20301) &&
+                !target->HasAura(20302) && !target->HasAura(20303) &&
+                !target->HasAura(27159);
+        }
+    };
+
     class BlessingTrigger : public BuffTrigger
     {
     public:

--- a/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
@@ -90,7 +90,7 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
 
     triggers.push_back(new TriggerNode(
         "target no judgement",
-        NextAction::array(0, new NextAction("seal of the crusader"), ACTION_NORMAL + 8), NULL)));
+        NextAction::array(0, new NextAction("seal of the crusader", ACTION_NORMAL + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
         "seal",
@@ -589,7 +589,7 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
 
     triggers.push_back(new TriggerNode(
         "target no judgement",
-        NextAction::array(0, new NextAction("seal of the crusader"), ACTION_NORMAL + 8), NULL)));
+        NextAction::array(0, new NextAction("seal of the crusader", ACTION_NORMAL + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
         "seal",

--- a/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
@@ -90,7 +90,7 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
 
     triggers.push_back(new TriggerNode(
         "target no judgement",
-        NextAction::array(0, new NextAction("seal of the crusader", ACTION_NORMAL + 8), NULL)));
+        NextAction::array(0, new NextAction("seal of the crusader", ACTION_HIGH + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
         "seal",
@@ -589,7 +589,7 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
 
     triggers.push_back(new TriggerNode(
         "target no judgement",
-        NextAction::array(0, new NextAction("seal of the crusader", ACTION_NORMAL + 8), NULL)));
+        NextAction::array(0, new NextAction("seal of the crusader", ACTION_HIGH + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
         "seal",

--- a/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
+++ b/playerbot/strategy/paladin/RetributionPaladinStrategy.cpp
@@ -89,6 +89,10 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
         NextAction::array(0, new NextAction("exorcism", ACTION_NORMAL + 4), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "target no judgement",
+        NextAction::array(0, new NextAction("seal of the crusader"), ACTION_NORMAL + 8), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "seal",
         NextAction::array(0, new NextAction("seal of command", ACTION_NORMAL + 3), NULL)));
 
@@ -582,6 +586,10 @@ void RetributionPaladinStrategy::InitCombatTriggers(std::list<TriggerNode*>& tri
     triggers.push_back(new TriggerNode(
         "exorcism",
         NextAction::array(0, new NextAction("exorcism", ACTION_NORMAL + 4), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "target no judgement",
+        NextAction::array(0, new NextAction("seal of the crusader"), ACTION_NORMAL + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
         "seal",


### PR DESCRIPTION
Adds a trigger that detects if the target in combat does not have judgement of the crusader.

Uses this trigger to make ret paladin cast seal of the crusader. Since seal trigger (the one they normally use for dps/tanking) is only active if a seal is not up, they won't change it for command or blood until after they judge.

Therefore, ret paladin bots now judge crusader in vanilla/tbc.