### PR TITLE
[Bugfix+Feature] Fix kill command

### DIFF
--- a/playerbot/strategy/hunter/HunterActions.h
+++ b/playerbot/strategy/hunter/HunterActions.h
@@ -167,11 +167,15 @@ public:
         CastRapidFireAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "rapid fire") {}
     };
 
+#ifdef MANGOSBOT_TWO
     class CastKillCommandAction : public CastBuffSpellAction
     {
     public:
         CastKillCommandAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "kill command") {}
     };
+#else
+    SPELL_ACTION(CastKillCommandAction, "kill command");
+#endif
 
     class CastBlackArrow : public CastRangedDebuffSpellAction
     {

--- a/playerbot/strategy/hunter/HunterAiObjectContext.cpp
+++ b/playerbot/strategy/hunter/HunterAiObjectContext.cpp
@@ -232,6 +232,7 @@ namespace ai
                 creators["mongoose bite"] = [](PlayerbotAI* ai) { return new MongooseBiteCastTrigger(ai); };
                 creators["viper sting"] = [](PlayerbotAI* ai) { return new ViperStingTrigger(ai); };
                 creators["aimed shot"] = [](PlayerbotAI* ai) { return new AimedShotTrigger(ai); };
+                creators["arcane shot"] = [](PlayerbotAI* ai) { return new ArcaneShotTrigger(ai); };
                 creators["bestial wrath"] = [](PlayerbotAI* ai) { return new BestialWrathBoostTrigger(ai); };
                 creators["silencing shot interrupt"] = [](PlayerbotAI* ai) { return new SilencingShotInterruptTrigger(ai); };
                 creators["silencing shot on enemy healer"] = [](PlayerbotAI* ai) { return new SilencingShotInterruptHealerTrigger(ai); };

--- a/playerbot/strategy/hunter/HunterStrategy.cpp
+++ b/playerbot/strategy/hunter/HunterStrategy.cpp
@@ -547,8 +547,8 @@ void HunterStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("hunter's mark", ACTION_NORMAL + 6), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "aimed shot",
-        NextAction::array(0, new NextAction("aimed shot", ACTION_NORMAL + 2), NULL)));
+        "arcane shot",
+        NextAction::array(0, new NextAction("arcane shot", ACTION_NORMAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
         "kill command",

--- a/playerbot/strategy/hunter/HunterStrategy.cpp
+++ b/playerbot/strategy/hunter/HunterStrategy.cpp
@@ -547,6 +547,10 @@ void HunterStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("hunter's mark", ACTION_NORMAL + 6), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "aimed shot",
+        NextAction::array(0, new NextAction("aimed shot", ACTION_NORMAL + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "kill command",
         NextAction::array(0, new NextAction("kill command", ACTION_NORMAL + 6), NULL)));
 

--- a/playerbot/strategy/hunter/HunterStrategy.cpp
+++ b/playerbot/strategy/hunter/HunterStrategy.cpp
@@ -1013,6 +1013,10 @@ void HunterStrategy::InitCombatTriggers(std::list<TriggerNode*>& triggers)
         NextAction::array(0, new NextAction("hunter's mark", ACTION_NORMAL + 6), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "kill command",
+        NextAction::array(0, new NextAction("kill command", ACTION_NORMAL + 6), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "aimed shot",
         NextAction::array(0, new NextAction("aimed shot", ACTION_NORMAL + 2), NULL)));
 

--- a/playerbot/strategy/hunter/HunterTriggers.h
+++ b/playerbot/strategy/hunter/HunterTriggers.h
@@ -295,7 +295,11 @@ private:
     CAN_CAST_TRIGGER(ExplosiveShotCanCastTrigger, "explosive shot");
     CAN_CAST_TRIGGER(MultishotCanCastTrigger, "multi-shot");
     CAN_CAST_TRIGGER(SteadyShotCanCastTrigger, "steady shot");
+#ifdef MANGOSBOT_TWO
     BOOST_TRIGGER(KillCommandBoostTrigger, "kill command");
+#else
+    CAN_CAST_TRIGGER(KillCommandBoostTrigger, "kill command");
+#endif
     SNARE_TRIGGER(IntimidationSnareTrigger, "intimidation");
     CAN_CAST_TRIGGER(CounterattackCanCastTrigger, "counterattack");
     SNARE_TRIGGER(WybernStingSnareTrigger, "wyvern sting");

--- a/playerbot/strategy/hunter/HunterTriggers.h
+++ b/playerbot/strategy/hunter/HunterTriggers.h
@@ -295,6 +295,7 @@ private:
     CAN_CAST_TRIGGER(ExplosiveShotCanCastTrigger, "explosive shot");
     CAN_CAST_TRIGGER(MultishotCanCastTrigger, "multi-shot");
     CAN_CAST_TRIGGER(SteadyShotCanCastTrigger, "steady shot");
+    CAN_CAST_TRIGGER(ArcaneShotTrigger, "arcane shot");
 #ifdef MANGOSBOT_TWO
     BOOST_TRIGGER(KillCommandBoostTrigger, "kill command");
 #else


### PR DESCRIPTION
Fix kill command. While there was a trigger/action setup in TBC combat triggers, they match how the ability works in Wotlk (a buff) rather than a on-crit reactive, which is how it works in TBC. With preprocessor it is now using proper trigger and action for the expansions.

I also added the trigger/action for Wotlk combat triggers as well, since we had the trigger and action defined properly for the Wotlk version but weren't actually using it in the combat triggers.

In addition I added a trigger for using arcane shot, and I added a trigger/action combo for arcane shot in TBC combat triggers. Vanilla and Wotlk had an aimed shot trigger/action set up in combat, but since you don't use aimed shot in tbc raiding, I assume it was left out. The alternate action for aimed shot is arcane shot, and you definitely use arcane shot in TBC. So this meant that arcane shot was left out of usage in TBC. It technically acts as a purge since it can dispel magic effects but I set it up to be a basic ability like multi-shot etc.

I have tested and now hunters will use kill command, it will show in the pet damage logs on addons:
<img width="882" height="598" alt="image" src="https://github.com/user-attachments/assets/089bdb1f-9a79-49a5-a9e7-09a562b807cb" />

Have yet to see hunter use arcane shot though.
