### PR TITLE
[Feature] Improve hunter use of steady shot

### DIFF
--- a/playerbot/strategy/hunter/HunterActions.cpp
+++ b/playerbot/strategy/hunter/HunterActions.cpp
@@ -111,9 +111,7 @@ bool CastSteadyShotAction::Execute(Event& event)
         const Item* equippedWeapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
         if (equippedWeapon)
         {
-            const ItemPrototype* itemPrototype = equippedWeapon->GetProto();
-            weaponDelay = itemPrototype->Delay + sPlayerbotAIConfig.globalCoolDown;
-            SetDuration(weaponDelay);
+            SetDuration(GetDuration() + sPlayerbotAIConfig.globalCoolDown);
         }
 
         return true;


### PR DESCRIPTION
Improve hunter use of steady shot by changing how the delay works. Now instead of using the weapon's delay, there will be a short delay added to each cast to properly allow enough time between casts to get auto shots/multi shots off, but not too long of a delay as to create dead time especially for slower weapons.

In essence this is similar to the human player use of hunter macro and results in a dps increase for hunters.