### PR TITLE
[Feature] Remove redundant reactDelay

### DIFF
--- a/playerbot/PlayerbotAI.cpp
+++ b/playerbot/PlayerbotAI.cpp
@@ -1989,7 +1989,7 @@ int32 PlayerbotAI::CalculateGlobalCooldown(uint32 spellid)
         globalCooldown = spellEntry->StartRecoveryTime;
     }
 
-    return globalCooldown > 0 ? globalCooldown : sPlayerbotAIConfig.reactDelay;
+    return globalCooldown;
 }
 
 void PlayerbotAI::HandleMasterIncomingPacket(const WorldPacket& packet)


### PR DESCRIPTION
When figuring out the global cooldown for spells, if the spell had a GCD of 0, it would return the reactDelay. But this is redundant because after we obtained this value, we would then add reactDelay again to figure out the Action's duration for the purpose of delaying other actions. So this resulted in bots adding reactDelay twice for abilities which are off the GCD or have no GCD such as racials and trinkets, which over time could propagate as less actions being taken overall. Therefore, I've removed this part of the return value.

As the default reactDelay value in the config is 100 ms, this would mean abilities with no GCD would be considered to have a minimum of 200 ms delay between them when technically it should be 0 ms.

While technically a player can stack multiple things off the GCD (such as making a macro to use trinket + cooldowns and such), meaning that having any reactDelay is unnecessary to begin with in this case, I will leave that as a separate subject matter, as there are further ramifications if bots can stack multiple spells simultaneously.