### PR TITLE
[Feature] Skip healing party members who can't receive healing due to debuff

### DIFF
--- a/playerbot/strategy/values/PartyMemberToHeal.cpp
+++ b/playerbot/strategy/values/PartyMemberToHeal.cpp
@@ -89,6 +89,10 @@ Unit* PartyMemberToHeal::Calculate()
                 continue;
             }
 
+            // do not heal if they will not receive healing due to debuff
+            if (player->GetMaxNegativeAuraModifier(SPELL_AURA_MOD_HEALING_PCT) <= -100)
+                continue;
+
             uint32 incomingDamage = 0;
             if (ai->HasStrategy("preheal", BotState::BOT_STATE_COMBAT))
                 incomingDamage = getIncomingdamage(player);


### PR DESCRIPTION
Skip healing party members that would be healed for 0 hp because of -healing % taken debuff.