### PR TITLE
[Feature] Proper prince malchezaar fight strategy

### DIFF
--- a/playerbot/strategy/actions/ActionContext.h
+++ b/playerbot/strategy/actions/ActionContext.h
@@ -407,6 +407,7 @@ namespace ai
             creators["enable prince malchezaar fight strategy"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarEnableFightStrategyAction(ai); };
             creators["disable prince malchezaar fight strategy"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarDisableFightStrategyAction(ai); };
             creators["move away from netherspite infernal"] = [](PlayerbotAI* ai) { return new NetherspiteInfernalMoveAwayAction(ai); };
+            creators["move away from prince malchezaar"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarMoveAwayAction(ai); };
 
             creators["enable four horseman fight strategy"] = [](PlayerbotAI* ai) { return new FourHorsemanEnableFightStrategyAction(ai); };
             creators["disable four horseman fight strategy"] = [](PlayerbotAI* ai) { return new FourHorsemanDisableFightStrategyAction(ai); };

--- a/playerbot/strategy/actions/DungeonActions.cpp
+++ b/playerbot/strategy/actions/DungeonActions.cpp
@@ -2,6 +2,7 @@
 #include "playerbot/strategy/values/PositionValue.h"
 #include "playerbot/strategy/AiObjectContext.h"
 #include "playerbot/PlayerbotAI.h"
+#include "playerbot/ServerFacade.h"
 #include "Grids/GridNotifiers.h"
 #include "Grids/GridNotifiersImpl.h"
 #include "Grids/CellImpl.h"
@@ -129,6 +130,7 @@ bool MoveAwayFromCreature::CreatureSearchHelperFunction(Event& event, uint32 cre
     MaNGOS::AllCreaturesOfEntryInRangeCheck u_check(bot, creatureID, range);
     MaNGOS::UnitListSearcher<MaNGOS::AllCreaturesOfEntryInRangeCheck> searcher(units, u_check);
     Cell::VisitAllObjects(bot, searcher, range);
+
     for (Unit* unit : units)
     {
         Creature* creature = (Creature*)unit;
@@ -161,12 +163,47 @@ bool MoveAwayFromCreature::CreatureSearchHelperFunction(Event& event, uint32 cre
     creatures.erase(it);
 
     // Generate the initial angle directly behind the bot looking at the closest creature
-    const WorldPosition botPosition(bot);
-    const WorldPosition creaturePosition(closestCreature);
-    float angleLeft = creaturePosition.getAngleTo(botPosition);
+    WorldPosition botPosition(bot);
+    WorldPosition targetPosition(closestCreature);
+    float angleLeft = targetPosition.getAngleTo(botPosition);
     float angleRight = angleLeft;
 
-    const uint8 attempts = 60;
+    Group* group = bot->GetGroup();
+    bool shouldRunToHeal = group && healersSafe && !ai->IsHeal(bot, true);
+    if (shouldRunToHeal)
+    {
+        std::list<WorldPosition> points;
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->getSource();
+            if (!member || !sServerFacade.IsAlive(member))
+                continue;
+
+            if (ai->IsHeal(member, true))
+            {
+                WorldPosition healPosition(member);
+                points.push_back(healPosition);
+            }
+        }
+        // Use a minimal move from where we are to a safe spot.
+        if (!points.empty())
+        {
+            points.sort([botPosition](WorldPosition i, WorldPosition j) { return botPosition.fDist(i) < botPosition.fDist(j); });
+            WorldPosition* validPoint = &points.front();
+            if (IsValidPoint(points.front(), creatures, hazards))
+            {
+                if (MoveTo(bot->GetMapId(), validPoint->getX(), validPoint->getY(), validPoint->getZ(), false, IsReaction(), false, false))
+                {
+                    if (IsReaction())
+                        WaitForReach(validPoint->distance(botPosition));
+                    return true;
+                }
+            }
+
+        }
+    }
+
+    const uint8 attempts = 20;
     const uint8 halfAtempts = (uint8)(attempts * 0.5f);
     float angleIncrement = (float)((M_PI) / halfAtempts);
 
@@ -178,9 +215,9 @@ bool MoveAwayFromCreature::CreatureSearchHelperFunction(Event& event, uint32 cre
         WorldPosition* validPoint = nullptr;
 
         // Calculate a point to the left and right
-        WorldPosition pointLeft = creaturePosition + WorldPosition(0, distance * cos(angleLeft), distance * sin(angleLeft), 1.0f);
+        WorldPosition pointLeft = targetPosition + WorldPosition(0, distance * cos(angleLeft), distance * sin(angleLeft), 1.0f);
         pointLeft.setZ(pointLeft.getHeight());
-        WorldPosition pointRight = creaturePosition + WorldPosition(0, distance * cos(angleRight), distance * sin(angleRight), 1.0f);
+        WorldPosition pointRight = targetPosition + WorldPosition(0, distance * cos(angleRight), distance * sin(angleRight), 1.0f);
         pointRight.setZ(pointRight.getHeight());
 
         if (IsValidPoint(pointLeft, creatures, hazards))

--- a/playerbot/strategy/actions/DungeonActions.cpp
+++ b/playerbot/strategy/actions/DungeonActions.cpp
@@ -148,7 +148,7 @@ bool MoveAwayFromCreature::CreatureSearchHelperFunction(Event& event, uint32 cre
         }
     }
 
-    if (creatures.empty())
+    if (creatures.empty() || closestCreatureDistance >= range)
     {
         return false;
     }

--- a/playerbot/strategy/actions/DungeonActions.h
+++ b/playerbot/strategy/actions/DungeonActions.h
@@ -30,7 +30,7 @@ namespace ai
     class MoveAwayFromCreature : public MovementAction
     {
     public:
-        MoveAwayFromCreature(PlayerbotAI* ai, std::string name, uint32 creatureID, float range, bool ignoreVictim = false) : MovementAction(ai, name), creatureID(creatureID), range(range), ignoreVictim(ignoreVictim) {}
+        MoveAwayFromCreature(PlayerbotAI* ai, std::string name, uint32 creatureID, float range, bool ignoreVictim = false, bool healersSafe = false) : MovementAction(ai, name), creatureID(creatureID), range(range), ignoreVictim(ignoreVictim), healersSafe(healersSafe) {}
         bool Execute(Event& event) override;
         bool isPossible() override;
 
@@ -55,6 +55,7 @@ namespace ai
         uint32 creatureID;
         float range;
         bool ignoreVictim;
+        bool healersSafe;
     };
 
     class MoveAwayFromSpecificCreatures : public MoveAwayFromCreature

--- a/playerbot/strategy/actions/KarazhanDungeonActions.h
+++ b/playerbot/strategy/actions/KarazhanDungeonActions.h
@@ -101,6 +101,13 @@ namespace ai
     class NetherspiteInfernalMoveAwayAction : public MoveAwayFromCreature
     {
     public:
-        NetherspiteInfernalMoveAwayAction(PlayerbotAI* ai) : MoveAwayFromCreature(ai, "move away from netherspite infernal", 17646, 21.0f) {}
+        NetherspiteInfernalMoveAwayAction(PlayerbotAI* ai) : MoveAwayFromCreature(ai, "move away from netherspite infernal", 17646, 22.0f, false, true) {}
     };
+
+    class PrinceMalchezaarMoveAwayAction : public MoveAwayFromCreature
+    {
+    public:
+        PrinceMalchezaarMoveAwayAction(PlayerbotAI* ai) : MoveAwayFromCreature(ai, "move away from prince malchezaar", 15690, 32.0f, false, true) {}
+    };
+    
 }

--- a/playerbot/strategy/generic/KarazhanDungeonStrategies.cpp
+++ b/playerbot/strategy/generic/KarazhanDungeonStrategies.cpp
@@ -62,6 +62,10 @@ void PrinceMalchezaarFightStrategy::InitCombatTriggers(std::list<TriggerNode*>& 
 	triggers.push_back(new TriggerNode(
 		"netherspite infernal too close",
 		NextAction::array(0, new NextAction("move away from netherspite infernal", 100.0f), NULL)));
+		
+	triggers.push_back(new TriggerNode(
+		"prince malchezaar too close",
+		NextAction::array(0, new NextAction("move away from prince malchezaar", 100.0f), NULL)));
 }
 
 void PrinceMalchezaarFightStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/triggers/DungeonTriggers.h
+++ b/playerbot/strategy/triggers/DungeonTriggers.h
@@ -131,8 +131,8 @@ namespace ai
     class CloseToCreatureTrigger : public Trigger
     {
     public:
-        CloseToCreatureTrigger(PlayerbotAI* ai, std::string name, uint32 creatureID, float range, bool ignoreVictim = false)
-        : Trigger(ai, name, 1)
+        CloseToCreatureTrigger(PlayerbotAI* ai, std::string name, uint32 creatureID, float range, bool ignoreVictim = false, uint32 timeInterval = 1)
+        : Trigger(ai, name, timeInterval)
         , creatureID(creatureID)
         , range(range)
         , ignoreVictim(ignoreVictim) {}

--- a/playerbot/strategy/triggers/KarazhanDungeonTriggers.cpp
+++ b/playerbot/strategy/triggers/KarazhanDungeonTriggers.cpp
@@ -25,6 +25,9 @@ bool NetherspiteBeamsCheatNeedRefreshTrigger::IsActive()
 
 bool PrinceMalchezaarTooCloseTrigger::IsActive()
 {
+    PullStrategy* strategy = PullStrategy::Get(ai);
+    if (strategy && strategy->HasPullStarted())
+        return false;
     Unit* target = AI_VALUE(Unit*, "tank target");
     if (!target) target = AI_VALUE(Unit*, "current target");
     if (bot->HasAura(30843) || (EnfeeblePart() && target && target->GetVictim() != bot) || MeleeWaitCheck(target)) 

--- a/playerbot/strategy/triggers/KarazhanDungeonTriggers.cpp
+++ b/playerbot/strategy/triggers/KarazhanDungeonTriggers.cpp
@@ -22,3 +22,50 @@ bool NetherspiteBeamsCheatNeedRefreshTrigger::IsActive()
     //Checking that is Netherspite target
     return AI_VALUE2(bool, "has aggro", "current target");
 }
+
+bool PrinceMalchezaarTooCloseTrigger::IsActive()
+{
+    Unit* target = AI_VALUE(Unit*, "tank target");
+    if (!target) target = AI_VALUE(Unit*, "current target");
+    if (bot->HasAura(30843) || (EnfeeblePart() && target && target->GetVictim() != bot) || MeleeWaitCheck(target)) 
+        return true;
+    if (ai->IsRanged(bot, true))
+        return CloseToCreatureTrigger::IsActive();
+    return false;
+}
+
+bool PrinceMalchezaarTooCloseTrigger::MeleeWaitCheck(Unit* target)
+{
+    // Check if we should be someone staying out of Shadow Nova blast
+    if (target && target->GetHealthPercent() > 30.0f && target->IsCreature())
+    {
+        if (ai->IsMelee(bot, true) && target->GetVictim() != bot && target->GetDistance(bot) > 8.0f)
+        {
+            if (Spell const* genericSpell = target->GetCurrentSpell(CURRENT_GENERIC_SPELL))
+            {
+                if (genericSpell->m_spellInfo->Id == 30852 && genericSpell->getState() != SPELL_STATE_FINISHED)
+                    return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool PrinceMalchezaarTooCloseTrigger::EnfeeblePart()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return AI_VALUE(Unit*, "master target");
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->getSource();
+        if (!member || !sServerFacade.IsAlive(member))
+            continue;
+
+        if (member->HasAura(30843))
+            return true;
+    }
+    return false;
+}

--- a/playerbot/strategy/triggers/KarazhanDungeonTriggers.h
+++ b/playerbot/strategy/triggers/KarazhanDungeonTriggers.h
@@ -82,7 +82,7 @@ namespace ai
 	class NetherspiteInfernalTooCloseTrigger : public CloseToCreatureTrigger
 	{
 	public:
-		NetherspiteInfernalTooCloseTrigger(PlayerbotAI* ai) : CloseToCreatureTrigger(ai, "netherspite infernal too close", 17646, 20.0f) {}
+		NetherspiteInfernalTooCloseTrigger(PlayerbotAI* ai) : CloseToCreatureTrigger(ai, "netherspite infernal too close", 17646, 21.0f) {}
 	};
 
 	class PrinceMalchezaarTooCloseTrigger : public CloseToCreatureTrigger

--- a/playerbot/strategy/triggers/KarazhanDungeonTriggers.h
+++ b/playerbot/strategy/triggers/KarazhanDungeonTriggers.h
@@ -84,4 +84,16 @@ namespace ai
 	public:
 		NetherspiteInfernalTooCloseTrigger(PlayerbotAI* ai) : CloseToCreatureTrigger(ai, "netherspite infernal too close", 17646, 20.0f) {}
 	};
+
+	class PrinceMalchezaarTooCloseTrigger : public CloseToCreatureTrigger
+	{
+	public:
+		PrinceMalchezaarTooCloseTrigger(PlayerbotAI* ai) : CloseToCreatureTrigger(ai, "prince malchezaar too close", 15690, ai->HasStrategy("ranged", BotState::BOT_STATE_COMBAT) ? 30.0f : 32.0f, false, ai->HasStrategy("ranged", BotState::BOT_STATE_COMBAT) ? 2 : 1)  {}
+
+		bool IsActive() override;
+
+		bool MeleeWaitCheck(Unit* target);
+
+		bool EnfeeblePart();
+	};
 }

--- a/playerbot/strategy/triggers/TriggerContext.h
+++ b/playerbot/strategy/triggers/TriggerContext.h
@@ -343,6 +343,7 @@ namespace ai
             creators["start prince malchezaar fight"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarStartFightTrigger(ai); };
             creators["end prince malchezaar fight"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarEndFightTrigger(ai); };
             creators["netherspite infernal too close"] = [](PlayerbotAI* ai) { return new NetherspiteInfernalTooCloseTrigger(ai); };
+            creators["prince malchezaar too close"] = [](PlayerbotAI* ai) { return new PrinceMalchezaarTooCloseTrigger(ai); };
 
             creators["start four horseman fight"] = [](PlayerbotAI* ai) { return new FourHorsemanStartFightTrigger(ai); };
             creators["end four horseman fight"] = [](PlayerbotAI* ai) { return new FourHorsemanEndFightTrigger(ai); };


### PR DESCRIPTION
- Add support for MoveAwayFromCreature to run to healers
- Keep bots out of Shadow Nova (until Phase 3)
- Keep range bots away from the boss
- Tweak netherspite infernal move range to lessen stutter (TODO: fix why bots stutter when they are near to their move point if it is close to trigger range)

I was able to get a deathless 9 man kill with unoptimized but flasked 115 Ilvl group without player intervention.