### PR TITLE
[Feature] Add misdirection for pull and fix pet attack to account for this

### DIFF
--- a/playerbot/strategy/actions/AttackAction.cpp
+++ b/playerbot/strategy/actions/AttackAction.cpp
@@ -115,10 +115,10 @@ bool AttackAction::Attack(Player* requester, Unit* target)
 
         WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
         bool isWaitingForAttack = false;
+        Pet* pet = bot->GetPet();
         if (strategy)
         {
             isWaitingForAttack = strategy->ShouldWait(ai);
-            Pet* pet = bot->GetPet();
             if (pet)
             {
                 UnitAI* creatureAI = ((Creature*)pet)->AI();
@@ -129,61 +129,38 @@ bool AttackAction::Attack(Player* requester, Unit* target)
                     {
                         // Reset the pet state if no master
                         if (creatureAI->GetReactState() == REACT_PASSIVE && !ai->GetMaster())
-                        {
                             creatureAI->SetReactState(REACT_DEFENSIVE);
-                        }
                         else 
-                        {
-                            // If we're done waiting to attack and there's mobs to cc, we can't use defensive/aggressive
-                            // because non passive pets will ignore our cc
-                            // Therefore, we'll keep passive so we can only attack the current target specifically
-                            // In other words, pet only attacks what owner can attack
-                            Unit* ccTarget = AI_VALUE(Unit*, "rti cc target");
-                            if (!ccTarget || (ccTarget && target->GetObjectGuid() != ccTarget->GetObjectGuid()))
-                            {
-                                constexpr uint32 PET_IMP = 416;
-                                constexpr uint32 PHASE_SHIFT = 4511;
-                                if (!(bot->getClass() == CLASS_WARLOCK &&
-                                    pet->AI() && pet->AI()->HasReactState(REACT_PASSIVE) &&
-                                    pet->GetEntry() == PET_IMP && pet->HasAura(PHASE_SHIFT)))
-                                {
-                                    // Send pet action packet
-                                    const ObjectGuid& petGuid = pet->GetObjectGuid();
-                                    const ObjectGuid& targetGuid = target->GetObjectGuid();
-                                    const uint8 flag = ACT_COMMAND;
-                                    const uint32 spellId = COMMAND_ATTACK;
-                                    const uint32 command = (flag << 24) | spellId;
-
-                                    WorldPacket data(CMSG_PET_ACTION);
-                                    data << petGuid;
-                                    data << command;
-                                    data << targetGuid;
-                                    bot->GetSession()->HandlePetAction(data);
-                                }
-                            }
-                        }
+                            PetAttack(requester, target);
                     }
                     else
                     {
-                        strategy->SetPetReactState(creatureAI->GetReactState() != REACT_PASSIVE ? creatureAI->GetReactState() : REACT_PASSIVE);
-                        creatureAI->SetReactState(REACT_PASSIVE);
+                        if (!isWaitingForAttack)
+                            PetAttack(requester, target);
+                        else
+                        {
+                            strategy->SetPetReactState(creatureAI->GetReactState() != REACT_PASSIVE ? creatureAI->GetReactState() : REACT_PASSIVE);
+                            creatureAI->SetReactState(REACT_PASSIVE);
 
-                        // Send pet action packet
-                        const ObjectGuid& petGuid = pet->GetObjectGuid();
-                        const uint8 flag = ACT_REACTION;
-                        const uint32 spellId = REACT_PASSIVE;
-                        const uint32 data = (flag << 24) | spellId;
+                            // Send pet action packet
+                            const ObjectGuid& petGuid = pet->GetObjectGuid();
+                            const uint8 flag = ACT_REACTION;
+                            const uint32 spellId = REACT_PASSIVE;
+                            const uint32 data = (flag << 24) | spellId;
 
-                        WorldPacket packet(CMSG_PET_ACTION);
-                        packet << petGuid;
-                        packet << data;
-                        packet << uint64(0);
-                        bot->GetSession()->HandlePetAction(packet);
-                        bot->PetSpellInitialize();
+                            WorldPacket packet(CMSG_PET_ACTION);
+                            packet << petGuid;
+                            packet << data;
+                            packet << uint64(0);
+                            bot->GetSession()->HandlePetAction(packet);
+                            bot->PetSpellInitialize();
+                        }
                     }
                 }
             }
         }
+        else
+            PetAttack(requester, target);
 
         if (ai->CanMove() && !sServerFacade.IsInFront(bot, target, sPlayerbotAIConfig.sightDistance, CAST_ANGLE_IN_FRONT))
         {
@@ -235,6 +212,43 @@ bool AttackAction::Attack(Player* requester, Unit* target)
     }
 
     return false;
+}
+
+bool AttackAction::PetAttack(Player* requester, Unit* target)
+{
+    // If we're done waiting to attack and there's mobs to cc, we can't use defensive/aggressive
+    // because non passive pets will ignore our cc
+    // Therefore, we'll keep passive so we can only attack the current target specifically
+    // In other words, pet only attacks what owner can attack
+    Pet* pet = bot->GetPet();
+    Unit* ccTarget = AI_VALUE(Unit*, "rti cc target");
+    if (pet && (!ccTarget || (ccTarget && target->GetObjectGuid() != ccTarget->GetObjectGuid())))
+    {
+        constexpr uint32 PET_IMP = 416;
+        constexpr uint32 PHASE_SHIFT = 4511;
+        if (!(bot->getClass() == CLASS_WARLOCK &&
+            pet->AI() && pet->AI()->HasReactState(REACT_PASSIVE) &&
+            pet->GetEntry() == PET_IMP && pet->HasAura(PHASE_SHIFT)))
+        {
+            // Send pet action packet
+            const ObjectGuid& petGuid = pet->GetObjectGuid();
+            const ObjectGuid& targetGuid = target->GetObjectGuid();
+            const uint8 flag = ACT_COMMAND;
+            const uint32 spellId = COMMAND_ATTACK;
+            const uint32 command = (flag << 24) | spellId;
+
+            WorldPacket data(CMSG_PET_ACTION);
+            data << petGuid;
+            data << command;
+            data << targetGuid;
+            bot->GetSession()->HandlePetAction(data);
+        }
+
+        return true;
+    }
+
+    return false;
+    
 }
 
 bool AttackAction::IsTargetValid(Player* requester, Unit* target)

--- a/playerbot/strategy/actions/AttackAction.h
+++ b/playerbot/strategy/actions/AttackAction.h
@@ -16,6 +16,7 @@ namespace ai
 
     protected:
         bool Attack(Player* requester, Unit* target);
+        bool PetAttack(Player* requester, Unit* target);
         bool IsTargetValid(Player* requester, Unit* target);
 
 #ifdef GenerateBotHelp

--- a/playerbot/strategy/hunter/HunterActions.h
+++ b/playerbot/strategy/hunter/HunterActions.h
@@ -70,6 +70,12 @@ public:
     BEGIN_RANGED_SPELL_ACTION(CastScorpidStingAction, "scorpid sting")
     END_SPELL_ACTION()
 
+    class MisdirectionOnPartyTankAction : public BuffOnTankAction
+    {
+    public:
+        MisdirectionOnPartyTankAction(PlayerbotAI* ai) : BuffOnTankAction(ai, "misdirection") {}
+    };
+
     class CastAspectOfTheMonkeyAction : public CastBuffSpellAction
     {
     public:

--- a/playerbot/strategy/hunter/HunterAiObjectContext.cpp
+++ b/playerbot/strategy/hunter/HunterAiObjectContext.cpp
@@ -19,7 +19,13 @@ namespace ai
             {
                 creators["aoe"] = [](PlayerbotAI* ai) { return new AoePlaceholderStrategy(ai); };
                 creators["buff"] = [](PlayerbotAI* ai) { return new BuffPlaceholderStrategy(ai); };
-                creators["pull"] = [](PlayerbotAI* ai) { return new PullStrategy(ai, "serpent sting"); };
+                creators["pull"] = [](PlayerbotAI* ai) {
+#ifndef MANGOSBOT_ZERO
+                    return new PullStrategy(ai, "steady shot", "misdirection on party tank");      
+#else 
+                    return new PullStrategy(ai, "serpent sting");
+#endif
+                };
                 creators["cc"] = [](PlayerbotAI* ai) { return new CcPlaceholderStrategy(ai); };
                 creators["boost"] = [](PlayerbotAI* ai) { return new BoostPlaceholderStrategy(ai); };
                 creators["pet"] = [](PlayerbotAI* ai) { return new HunterPetStrategy(ai); };
@@ -264,6 +270,7 @@ namespace ai
                 creators["viper sting"] = [](PlayerbotAI* ai) { return new CastViperStingAction(ai); };
                 creators["scorpid sting"] = [](PlayerbotAI* ai) { return new CastScorpidStingAction(ai); };
                 creators["hunter's mark"] = [](PlayerbotAI* ai) { return new CastHuntersMarkAction(ai); };
+                creators["misdirection on party tank"] = [](PlayerbotAI* ai) { return new MisdirectionOnPartyTankAction(ai); };
                 creators["mend pet"] = [](PlayerbotAI* ai) { return new CastMendPetAction(ai); };
                 creators["revive pet"] = [](PlayerbotAI* ai) { return new CastRevivePetAction(ai); };
                 creators["call pet"] = [](PlayerbotAI* ai) { return new CastCallPetAction(ai); };

--- a/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -600,21 +600,20 @@ bool DpsAssistTrigger::IsActive()
     WaitForAttackStrategy* strategy = WaitForAttackStrategy::Get(ai);
     bool isWaitingForAttack = false;
     if (strategy)
+        isWaitingForAttack = strategy->ShouldWait(ai); 
+        
+    Pet* pet = bot->GetPet();
+    if (pet)
     {
-        isWaitingForAttack = strategy->ShouldWait(ai);
-        Pet* pet = bot->GetPet();
-        if (pet)
+        UnitAI* creatureAI = ((Creature*)pet)->AI();
+        if (creatureAI)
         {
-            UnitAI* creatureAI = ((Creature*)pet)->AI();
-            if (creatureAI)
-            {
-                if (creatureAI->GetReactState() == REACT_PASSIVE && !isWaitingForAttack)
-                    return true;
-            }
+            if (isWaitingForAttack)
+                return false;
         }
-    }               
+    }
 
-    return false;
+    return true;
 }
 
 bool IsBehindTargetTrigger::IsActive()


### PR DESCRIPTION
Add usage for the spell Misdirection for hunters. This will be used as part of the Hunter's pull strategy in TBC+.

Also adjust some changes made to pet attacking code from the CC rework to account for this, as hunter will need to have wait for attack disabled to do the pull, but the pet wasn't going in to attack.