### PR TITLE
[Feature] Clarify buy action if bot doesn't have enough money

### DIFF
--- a/playerbot/strategy/actions/BuyAction.cpp
+++ b/playerbot/strategy/actions/BuyAction.cpp
@@ -230,6 +230,19 @@ bool BuyAction::Execute(Event& event)
                 const ItemPrototype* proto = sObjectMgr.GetItemPrototype(itemId);
                 if (!proto)
                     continue;
+                
+                if (!ai->HasCheat(BotCheatMask::gold))
+                {
+                    uint32 price = uint32(floor(proto->BuyPrice * bot->GetReputationPriceDiscount(pCreature)));
+                    uint32 botMoney = bot->GetMoney();
+                    if (price > botMoney)
+                    {
+                        std::ostringstream out;
+                        out << "I don't have enough to buy " << ChatHelper::formatItem(proto);
+                        ai->TellPlayer(requester, out.str(), PlayerbotSecurityLevel::PLAYERBOT_SECURITY_ALLOW_ALL, false);
+                        continue;
+                    }
+                }
 
                 result |= BuyItem(requester, pCreature->GetVendorItems(), vendorguid, proto, bought);
                 if (!result)


### PR DESCRIPTION
Clarify buy action if bot doesn't have enough money, rather than saying that nobody has the item when in fact they do.

We factor in cost when attempting to purchase the item when we call BuyItemFromVendor. But this core function only returns bool, and always false, so after using it, we just attempt to check if the count of the item is different from what it was before (meaning we did buy it) to verify if the buy action worked. If not, we currently assume the item can't be bought because nobody sells it. Since it is possible for a bot to not have enough money to buy this, and as we can (and for some types of items, already do) check before buying, we should reflect this to better reflect the situation.