### PR TITLE
[Feature] Add thunder clap as a threat move

### DIFF
--- a/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
+++ b/playerbot/strategy/warrior/ProtectionWarriorStrategy.cpp
@@ -629,12 +629,18 @@ void ProtectionWarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
     WarriorAoeStrategy::InitCombatTriggers(triggers);
 
     triggers.push_back(new TriggerNode(
-        "melee medium aoe",
-        NextAction::array(0, new NextAction("challenging shout", ACTION_HIGH + 1), NULL)));
+        "melee light aoe",
+        NextAction::array(0, new NextAction("thunder clap threat", ACTION_HIGH + 7), NULL)));
 
     triggers.push_back(new TriggerNode(
         "melee medium aoe",
+        NextAction::array(0, new NextAction("challenging shout", ACTION_HIGH + 1), NULL)));
+
+    /*
+    triggers.push_back(new TriggerNode(
+        "melee medium aoe",
         NextAction::array(0, new NextAction("battle shout taunt", ACTION_HIGH), NULL)));
+    */
 }
 
 void ProtectionWarriorAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)
@@ -1019,10 +1025,14 @@ void ProtectionWarriorAoeStrategy::InitCombatTriggers(std::list<TriggerNode*>& t
     triggers.push_back(new TriggerNode(
         "melee medium aoe",
         NextAction::array(0, new NextAction("challenging shout", ACTION_HIGH + 1), NULL)));
-
+    
     triggers.push_back(new TriggerNode(
+        "melee light aoe",
+        NextAction::array(0, new NextAction("thunder clap threat", ACTION_HIGH + 7), NULL)));
+
+    /*triggers.push_back(new TriggerNode(
         "melee medium aoe",
-        NextAction::array(0, new NextAction("battle shout taunt", ACTION_HIGH), NULL)));
+        NextAction::array(0, new NextAction("battle shout taunt", ACTION_HIGH), NULL)));*/
 }
 
 void ProtectionWarriorAoeStrategy::InitNonCombatTriggers(std::list<TriggerNode*>& triggers)

--- a/playerbot/strategy/warrior/WarriorActions.h
+++ b/playerbot/strategy/warrior/WarriorActions.h
@@ -22,6 +22,7 @@ namespace ai
     MELEE_DEBUFF_ACTION(CastRendAction, "rend");
     MELEE_DEBUFF_ENEMY_ACTION(CastRendOnAttackerAction, "rend");
     MELEE_DEBUFF_ACTION_R(CastThunderClapAction, "thunder clap", 8.0f);
+    SPELL_ACTION(CastThunderClapThreatAction, "thunder clap");
     SNARE_ACTION(CastThunderClapSnareAction, "thunder clap");
     SNARE_ACTION(CastHamstringAction, "hamstring");
     MELEE_ACTION(CastOverpowerAction, "overpower");

--- a/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
@@ -210,6 +210,7 @@ namespace ai
                 creators["battle shout"] = [](PlayerbotAI* ai) { return new CastBattleShoutAction(ai); };
                 creators["battle shout taunt"] = [](PlayerbotAI* ai) { return new CastBattleShoutTauntAction(ai); };
                 creators["thunder clap"] = [](PlayerbotAI* ai) { return new CastThunderClapAction(ai); };
+                creators["thunder clap threat"] = [](PlayerbotAI* ai) { return new CastThunderClapThreatAction(ai); };
                 creators["taunt"] = [](PlayerbotAI* ai) { return new CastTauntAction(ai); };
                 creators["revenge"] = [](PlayerbotAI* ai) { return new CastRevengeAction(ai); };
                 creators["slam"] = [](PlayerbotAI* ai) { return new CastSlamAction(ai); };


### PR DESCRIPTION
Add thunder clap as a threat move so prot warriors will use aoe more often if applicable. Currently they're only using it for the debuff application.