### PR TITLE
[Feature] TBC shaman to use flame shock more

### DIFF
--- a/playerbot/strategy/shaman/EnhancementShamanStrategy.cpp
+++ b/playerbot/strategy/shaman/EnhancementShamanStrategy.cpp
@@ -492,7 +492,11 @@ void EnhancementShamanStrategy::InitCombatTriggers(std::list<TriggerNode*>& trig
 
     triggers.push_back(new TriggerNode(
         "stormstrike",
-        NextAction::array(0, new NextAction("stormstrike", ACTION_NORMAL + 1), NULL)));
+        NextAction::array(0, new NextAction("stormstrike", ACTION_NORMAL + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "flame shock",
+        NextAction::array(0, new NextAction("flame shock", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "shock",

--- a/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
+++ b/playerbot/strategy/shaman/ShamanAiObjectContext.cpp
@@ -270,6 +270,7 @@ namespace ai
                 creators["party member cleanse spirit curse"] = [](PlayerbotAI* ai) { return new PartyMemberCleanseSpiritCurseTrigger(ai); };
                 creators["party member cleanse spirit disease"] = [](PlayerbotAI* ai) { return new PartyMemberCleanseSpiritDiseaseTrigger(ai); };
                 creators["shock"] = [](PlayerbotAI* ai) { return new ShockTrigger(ai); };
+                creators["flame shock"] = [](PlayerbotAI* ai) { return new FlameShockTrigger(ai); };
                 creators["frost shock snare"] = [](PlayerbotAI* ai) { return new FrostShockSnareTrigger(ai); };
                 creators["heroism"] = [](PlayerbotAI* ai) { return new HeroismTrigger(ai); };
                 creators["bloodlust"] = [](PlayerbotAI* ai) { return new BloodlustTrigger(ai); };

--- a/playerbot/strategy/shaman/ShamanTriggers.cpp
+++ b/playerbot/strategy/shaman/ShamanTriggers.cpp
@@ -35,3 +35,8 @@ bool ShockTrigger::IsActive()
 {
     return SpellTrigger::IsActive() && !ai->HasAnyAuraOf(GetTarget(), "frost shock", "earth shock", "flame shock", NULL) && !HasMaxDebuffs();
 }
+
+bool FlameShockTrigger::IsActive()
+{
+    return SpellTrigger::IsActive() && !ai->HasAnyAuraOf(GetTarget(), "flame shock", NULL) && !HasMaxDebuffs();
+}

--- a/playerbot/strategy/shaman/ShamanTriggers.h
+++ b/playerbot/strategy/shaman/ShamanTriggers.h
@@ -450,6 +450,13 @@ namespace ai
         virtual bool IsActive() override;
     };
 
+    class FlameShockTrigger : public DebuffTrigger 
+    {
+    public:
+        FlameShockTrigger(PlayerbotAI* ai) : DebuffTrigger(ai, "flame shock") {}
+        virtual bool IsActive() override;
+    };
+
     class FrostShockSnareTrigger : public SnareTargetTrigger
     {
     public:


### PR DESCRIPTION
Have TBC shamans use flame shock for dps more often, they should still use earth shock to interrupt.