### PR TITLE
Install the bundled AhBot config template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,16 @@ if (NOT CONF_INSTALL_DIR)
 endif()
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/aiplayerbot.conf.dist DESTINATION ${CONF_INSTALL_DIR})
 
+# The bundled AhBot replaces the core AuctionHouseBot whenever BUILD_AHBOT is
+# off, which is the default for a playerbots build. Its config template was
+# never installed, so AhBotConfig::Initialize() could not find ahbot.conf and
+# AhBot disabled itself on startup. Guarded so it cannot collide with the
+# core's own ahbot.conf.dist when the AuctionHouseBot module is selected.
+if (NOT BUILD_AHBOT)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ahbot/ahbot.conf.dist.in ${CMAKE_CURRENT_BINARY_DIR}/ahbot.conf.dist)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ahbot.conf.dist DESTINATION ${CONF_INSTALL_DIR})
+endif()
+
 set_target_properties(${LIBRARY_NAME} PROPERTIES PROJECT_LABEL "PlayerBots")
 
 # Generate PCH


### PR DESCRIPTION
## Problem

The bundled AhBot is compiled into the playerbots library and driven from `World.cpp` (`auctionbot.Init()` / `Update()`) under `#ifdef ENABLE_PLAYERBOTS` + `#ifndef BUILD_AHBOT`, which is the default for a playerbots build. It is therefore the active auction bot.

`AhBotConfig::Initialize()` reads `SYSCONFDIR"ahbot.conf"`, but nothing installs a template for it:

- this module's `CMakeLists.txt` installs `aiplayerbot.conf.dist` but never references `ahbot/ahbot.conf.dist.in`;
- the core installs its own `ahbot.conf.dist` only inside `if (BUILD_AHBOT)`, and that file belongs to the separate AuctionHouseBot module and contains no `AhBot.*` keys.

So the one config the bundled AhBot needs is installed exactly when the bundled AhBot is not the one running.

## Effect

`AhBot::Init()` bails with `AhBot is Disabled. Unable to open configuration file ahbot.conf`, and the 182-line template with its 116 `AhBot.*` tuning keys never reaches the operator.

## Change

Install it the same way `aiplayerbot.conf.dist` is installed, guarded on `NOT BUILD_AHBOT` so it cannot collide with the core's file.

## Local verification (cmake 3.28, mangos-classic)

- `BUILD_PLAYERBOTS=ON`, `BUILD_AHBOT=OFF`: configure succeeds and `cmake_install.cmake` gains an install rule for `ahbot.conf.dist`; the configured file in the build tree contains all 116 `AhBot.*` keys.
- `BUILD_AHBOT=ON`: the playerbots module emits no `ahbot.conf.dist` rule (only the core's own), confirming the guard prevents a collision.
- same configure with the unpatched CMakeLists: the rule is absent, i.e. the bug.
