### PR TITLE
Skip AhBot updates until its config is loaded

### DIFF
--- a/ahbot/AhBot.cpp
+++ b/ahbot/AhBot.cpp
@@ -91,6 +91,9 @@ void activateAhbotThread()
 
 void AhBot::Update()
 {
+    if (!sAhBotConfig.enabled)
+        return;
+
     if (sWorld.IsShutdowning())
         return;
 


### PR DESCRIPTION
## Problem

`World.cpp` drives the bundled AhBot on a fixed 20s timer (`m_timers[WUPDATE_AHBOT].SetInterval(20 * IN_MILLISECONDS)`), calling `AhBot::Update()` every tick. `Update()` never checks whether `Init()` succeeded, so on the broken path — `AhBotConfig::Initialize()` bails with `AhBot is Disabled. Unable to open configuration file ahbot.conf` — the bot is still ticked.

## Effect

With no config, `sAhBotConfig` members stay at their zero values, including `updateInterval = 0`, so `Update()` passes its `now < nextAICheckTime` gate every time and spawns a detached `AhbotThread` every 20s, running a full "auction check" against an empty config (the guard in `ForceUpdate` on `sAhBotConfig.enabled` mostly short-circuits it, but the thread spin and the un-init tick happen regardless).

## Change

Add the same guard `ForceUpdate()` and `HandleCommand()` already use, at the top of `AhBot::Update()`:

```cpp
if (!sAhBotConfig.enabled)
    return;
```

`sAhBotConfig::Initialize()` only leaves `enabled` true when the config file actually loaded (it defaults to `AhBot.Enabled = true` once the source opens), so this is exactly "did Init succeed". Complements #369: that PR makes the default install correct, this one stops the degraded-but-ticking state when it's still absent.

## Local verification (cmake 3.28, mangos-classic)

- `AhBot.cpp` compiles cleanly in-tree with this change (mangos-classic, `BUILD_PLAYERBOTS=ON`, `BUILD_AHBOT=OFF` configure; single-object rebuild of `playerbots.dir/ahbot/AhBot.cpp.o` passed).
- Behaviour: with `AhBot.Enabled=false` or a missing `ahbot.conf`, `Update()` now returns before the timer gate; a successful `Init()` is unaffected since `enabled` is set in `Initialize()`.
